### PR TITLE
Updating commandline tools to not log config file details every command

### DIFF
--- a/cmd/armada-load-tester/cmd/root.go
+++ b/cmd/armada-load-tester/cmd/root.go
@@ -18,7 +18,18 @@ func init() {
 var rootCmd = &cobra.Command{
 	Use:   "armada-load-tester command",
 	Short: "Command line utility to submit many jobs to armada",
-	Long:  ``,
+	Long: `
+Command line utility to submit many jobs to armada
+
+Persistent config can be saved in a config file so it doesn't have to be specified every command.
+
+Example structure:
+armadaUrl: localhost:50051
+username: user1
+password: password123
+
+The location of this file can be passed in using --config argument or picked from $HOME/.armadactl.yaml.
+`,
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/cmd/armadactl/cmd/root.go
+++ b/cmd/armadactl/cmd/root.go
@@ -16,9 +16,20 @@ func init() {
 }
 
 var rootCmd = &cobra.Command{
-	Use:   "armadaclt command",
+	Use:   "armadactl",
 	Short: "Command line utility to manage armada",
-	Long:  ``,
+	Long: `
+Command line utility to manage armada
+
+Persistent config can be saved in a config file so it doesn't have to be specified every command.
+
+Example structure:
+armadaUrl: localhost:50051
+username: user1
+password: password123
+
+The location of this file can be passed in using --config argument or picked from $HOME/.armadactl.yaml.
+`,
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/internal/client/command_line.go
+++ b/internal/client/command_line.go
@@ -41,14 +41,12 @@ func LoadCommandlineArgsFromConfigFile(cfgFile string) {
 	// If a config file is found, read it in.
 	err := viper.ReadInConfig()
 
-	if err == nil {
-		fmt.Println("Using config file:", viper.ConfigFileUsed())
-	} else {
+	if err != nil {
 		switch err.(type) {
 		case viper.ConfigFileNotFoundError:
-			fmt.Println("No config file:", err)
+			// Do nothing
 		default:
-			fmt.Println("Can't read config:", err)
+			fmt.Printf("Can't read config file %s because %s\n", viper.ConfigFileUsed(), err)
 			os.Exit(1)
 		}
 	}

--- a/internal/client/command_line.go
+++ b/internal/client/command_line.go
@@ -44,7 +44,8 @@ func LoadCommandlineArgsFromConfigFile(cfgFile string) {
 	if err != nil {
 		switch err.(type) {
 		case viper.ConfigFileNotFoundError:
-			// Do nothing
+			// This only occurs when looking for the default .armadactl file and it is not present
+			// This is not an error as users don't have to specify it, so do nothing
 		default:
 			fmt.Printf("Can't read config file %s because %s\n", viper.ConfigFileUsed(), err)
 			os.Exit(1)


### PR DESCRIPTION
This is very verbose and makes users think they have done something wrong when this file has not been specified

It is better to not repeatedly log about the config file location on every command