### PR TITLE
Add a log CommandLineFormatter

### DIFF
--- a/cmd/armada-load-tester/cmd/root.go
+++ b/cmd/armada-load-tester/cmd/root.go
@@ -1,9 +1,9 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/G-Research/armada/internal/client"
@@ -36,7 +36,7 @@ The location of this file can be passed in using --config argument or picked fro
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
+		log.Error(err)
 		os.Exit(1)
 	}
 }

--- a/cmd/armada-load-tester/main.go
+++ b/cmd/armada-load-tester/main.go
@@ -6,6 +6,6 @@ import (
 )
 
 func main() {
-	common.ConfigureLogging()
+	common.ConfigureCommandLineLogging()
 	cmd.Execute()
 }

--- a/cmd/armadactl/cmd/analyze.go
+++ b/cmd/armadactl/cmd/analyze.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"reflect"
 
 	log "github.com/sirupsen/logrus"
@@ -50,16 +49,16 @@ var analyzeCmd = &cobra.Command{
 				if jobInfo.Status != service.Succeeded {
 					jobEvents := events[id]
 
-					fmt.Println()
+					log.Println()
 					for _, e := range jobEvents {
 						data, err := json.Marshal(e)
 						if err != nil {
-							fmt.Print(e)
+							log.Error(e)
 						} else {
-							fmt.Printf("%s %s\n", reflect.TypeOf(*e), string(data))
+							log.Info("%s %s\n", reflect.TypeOf(*e), string(data))
 						}
 					}
-					fmt.Println()
+					log.Println()
 				}
 			}
 

--- a/cmd/armadactl/cmd/root.go
+++ b/cmd/armadactl/cmd/root.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
 	log "github.com/sirupsen/logrus"

--- a/cmd/armadactl/cmd/root.go
+++ b/cmd/armadactl/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/G-Research/armada/internal/client"
@@ -36,7 +37,7 @@ The location of this file can be passed in using --config argument or picked fro
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
+		log.Error(err)
 		os.Exit(1)
 	}
 }

--- a/cmd/armadactl/cmd/watch.go
+++ b/cmd/armadactl/cmd/watch.go
@@ -43,15 +43,15 @@ var watchCmd = &cobra.Command{
 				if raw {
 					data, err := json.Marshal(e)
 					if err != nil {
-						fmt.Print(e)
+						log.Error(e)
 					} else {
-						fmt.Printf("%s %s\n", reflect.TypeOf(e), string(data))
+						log.Infof("%s %s\n", reflect.TypeOf(e), string(data))
 					}
 				} else {
-					fmt.Printf("%s | ", e.GetCreated().Format(time.Stamp))
-					fmt.Print(service.CreateSummaryOfCurrentState(state))
-					fmt.Printf(" | event: %s, job id: %s", reflect.TypeOf(e), e.GetJobId())
-					fmt.Println()
+					summary := fmt.Sprintf("%s | ", e.GetCreated().Format(time.Stamp))
+					summary += service.CreateSummaryOfCurrentState(state)
+					summary += fmt.Sprintf(" | event: %s, job id: %s", reflect.TypeOf(e), e.GetJobId())
+					log.Info(summary)
 				}
 				return false
 			})

--- a/cmd/armadactl/main.go
+++ b/cmd/armadactl/main.go
@@ -6,7 +6,6 @@ import (
 )
 
 func main() {
-
-	common.ConfigureLogging()
+	common.ConfigureCommandLineLogging()
 	cmd.Execute()
 }

--- a/internal/client/command_line.go
+++ b/internal/client/command_line.go
@@ -1,10 +1,10 @@
 package client
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/mitchellh/go-homedir"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -28,7 +28,7 @@ func LoadCommandlineArgsFromConfigFile(cfgFile string) {
 		// Find home directory.
 		home, err := homedir.Dir()
 		if err != nil {
-			fmt.Println(err)
+			log.Error(err)
 			os.Exit(1)
 		}
 
@@ -47,7 +47,7 @@ func LoadCommandlineArgsFromConfigFile(cfgFile string) {
 			// This only occurs when looking for the default .armadactl file and it is not present
 			// This is not an error as users don't have to specify it, so do nothing
 		default:
-			fmt.Printf("Can't read config file %s because %s\n", viper.ConfigFileUsed(), err)
+			log.Errorf("Can't read config file %s because %s\n", viper.ConfigFileUsed(), err)
 			os.Exit(1)
 		}
 	}

--- a/internal/common/logging/formatter.go
+++ b/internal/common/logging/formatter.go
@@ -1,0 +1,14 @@
+package logging
+
+import (
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type CommandLineFormatter struct {
+}
+
+func (f *CommandLineFormatter) Format(entry *log.Entry) ([]byte, error) {
+	return []byte(fmt.Sprintf("%s\n", entry.Message)), nil
+}

--- a/internal/common/logging/formatter_test.go
+++ b/internal/common/logging/formatter_test.go
@@ -1,0 +1,24 @@
+package logging
+
+import (
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommandLineFormatter(t *testing.T) {
+	commandLineFormatter := new(CommandLineFormatter)
+
+	testMessage := "Test"
+	expectedOutput := testMessage + "\n"
+
+	event := log.Entry{
+		Message: testMessage,
+	}
+
+	output, err := commandLineFormatter.Format(&event)
+
+	assert.Nil(t, err)
+	assert.Equal(t, expectedOutput, string(output[:]))
+}

--- a/internal/common/startup.go
+++ b/internal/common/startup.go
@@ -13,6 +13,8 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"github.com/weaveworks/promrus"
+
+	"github.com/G-Research/armada/internal/common/logging"
 )
 
 func BindCommandlineArguments() {
@@ -50,6 +52,11 @@ func LoadConfig(config interface{}, defaultPath string, overrideConfig string) {
 		log.Error(err)
 		os.Exit(-1)
 	}
+}
+func ConfigureCommandLineLogging() {
+	commandLineFormatter := new(logging.CommandLineFormatter)
+	log.SetFormatter(commandLineFormatter)
+	log.SetOutput(os.Stdout)
 }
 
 func ConfigureLogging() {


### PR DESCRIPTION
This allows us to format log messages how you'd expect to see them on the command line

So we can use log.Info etc everywhere (rather than a mix of fmt/log)

We can then just swap the formatter for the commandline tools