### PR TITLE
Handling pod submission failure in Executor

### DIFF
--- a/internal/armada/api/event.pb.go
+++ b/internal/armada/api/event.pb.go
@@ -249,6 +249,90 @@ func (m *JobLeasedEvent) GetClusterId() string {
 	return ""
 }
 
+type JobLeaseReturnedEvent struct {
+	JobId     string    `protobuf:"bytes,1,opt,name=JobId,proto3" json:"JobId,omitempty"`
+	JobSetId  string    `protobuf:"bytes,2,opt,name=JobSetId,proto3" json:"JobSetId,omitempty"`
+	Queue     string    `protobuf:"bytes,3,opt,name=Queue,proto3" json:"Queue,omitempty"`
+	Created   time.Time `protobuf:"bytes,4,opt,name=Created,proto3,stdtime" json:"Created"`
+	ClusterId string    `protobuf:"bytes,5,opt,name=ClusterId,proto3" json:"ClusterId,omitempty"`
+	Reason    string    `protobuf:"bytes,6,opt,name=Reason,proto3" json:"Reason,omitempty"`
+}
+
+func (m *JobLeaseReturnedEvent) Reset()         { *m = JobLeaseReturnedEvent{} }
+func (m *JobLeaseReturnedEvent) String() string { return proto.CompactTextString(m) }
+func (*JobLeaseReturnedEvent) ProtoMessage()    {}
+func (*JobLeaseReturnedEvent) Descriptor() ([]byte, []int) {
+	return fileDescriptor_f36d4f2a7aeb61e3, []int{3}
+}
+func (m *JobLeaseReturnedEvent) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *JobLeaseReturnedEvent) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_JobLeaseReturnedEvent.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalTo(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *JobLeaseReturnedEvent) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_JobLeaseReturnedEvent.Merge(m, src)
+}
+func (m *JobLeaseReturnedEvent) XXX_Size() int {
+	return m.Size()
+}
+func (m *JobLeaseReturnedEvent) XXX_DiscardUnknown() {
+	xxx_messageInfo_JobLeaseReturnedEvent.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_JobLeaseReturnedEvent proto.InternalMessageInfo
+
+func (m *JobLeaseReturnedEvent) GetJobId() string {
+	if m != nil {
+		return m.JobId
+	}
+	return ""
+}
+
+func (m *JobLeaseReturnedEvent) GetJobSetId() string {
+	if m != nil {
+		return m.JobSetId
+	}
+	return ""
+}
+
+func (m *JobLeaseReturnedEvent) GetQueue() string {
+	if m != nil {
+		return m.Queue
+	}
+	return ""
+}
+
+func (m *JobLeaseReturnedEvent) GetCreated() time.Time {
+	if m != nil {
+		return m.Created
+	}
+	return time.Time{}
+}
+
+func (m *JobLeaseReturnedEvent) GetClusterId() string {
+	if m != nil {
+		return m.ClusterId
+	}
+	return ""
+}
+
+func (m *JobLeaseReturnedEvent) GetReason() string {
+	if m != nil {
+		return m.Reason
+	}
+	return ""
+}
+
 type JobLeaseExpiredEvent struct {
 	JobId    string    `protobuf:"bytes,1,opt,name=JobId,proto3" json:"JobId,omitempty"`
 	JobSetId string    `protobuf:"bytes,2,opt,name=JobSetId,proto3" json:"JobSetId,omitempty"`
@@ -260,7 +344,7 @@ func (m *JobLeaseExpiredEvent) Reset()         { *m = JobLeaseExpiredEvent{} }
 func (m *JobLeaseExpiredEvent) String() string { return proto.CompactTextString(m) }
 func (*JobLeaseExpiredEvent) ProtoMessage()    {}
 func (*JobLeaseExpiredEvent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_f36d4f2a7aeb61e3, []int{3}
+	return fileDescriptor_f36d4f2a7aeb61e3, []int{4}
 }
 func (m *JobLeaseExpiredEvent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -329,7 +413,7 @@ func (m *JobPendingEvent) Reset()         { *m = JobPendingEvent{} }
 func (m *JobPendingEvent) String() string { return proto.CompactTextString(m) }
 func (*JobPendingEvent) ProtoMessage()    {}
 func (*JobPendingEvent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_f36d4f2a7aeb61e3, []int{4}
+	return fileDescriptor_f36d4f2a7aeb61e3, []int{5}
 }
 func (m *JobPendingEvent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -405,7 +489,7 @@ func (m *JobRunningEvent) Reset()         { *m = JobRunningEvent{} }
 func (m *JobRunningEvent) String() string { return proto.CompactTextString(m) }
 func (*JobRunningEvent) ProtoMessage()    {}
 func (*JobRunningEvent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_f36d4f2a7aeb61e3, []int{5}
+	return fileDescriptor_f36d4f2a7aeb61e3, []int{6}
 }
 func (m *JobRunningEvent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -482,7 +566,7 @@ func (m *JobUnableToScheduleEvent) Reset()         { *m = JobUnableToScheduleEve
 func (m *JobUnableToScheduleEvent) String() string { return proto.CompactTextString(m) }
 func (*JobUnableToScheduleEvent) ProtoMessage()    {}
 func (*JobUnableToScheduleEvent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_f36d4f2a7aeb61e3, []int{6}
+	return fileDescriptor_f36d4f2a7aeb61e3, []int{7}
 }
 func (m *JobUnableToScheduleEvent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -566,7 +650,7 @@ func (m *JobFailedEvent) Reset()         { *m = JobFailedEvent{} }
 func (m *JobFailedEvent) String() string { return proto.CompactTextString(m) }
 func (*JobFailedEvent) ProtoMessage()    {}
 func (*JobFailedEvent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_f36d4f2a7aeb61e3, []int{7}
+	return fileDescriptor_f36d4f2a7aeb61e3, []int{8}
 }
 func (m *JobFailedEvent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -649,7 +733,7 @@ func (m *JobSucceededEvent) Reset()         { *m = JobSucceededEvent{} }
 func (m *JobSucceededEvent) String() string { return proto.CompactTextString(m) }
 func (*JobSucceededEvent) ProtoMessage()    {}
 func (*JobSucceededEvent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_f36d4f2a7aeb61e3, []int{8}
+	return fileDescriptor_f36d4f2a7aeb61e3, []int{9}
 }
 func (m *JobSucceededEvent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -724,7 +808,7 @@ func (m *JobReprioritizedEvent) Reset()         { *m = JobReprioritizedEvent{} }
 func (m *JobReprioritizedEvent) String() string { return proto.CompactTextString(m) }
 func (*JobReprioritizedEvent) ProtoMessage()    {}
 func (*JobReprioritizedEvent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_f36d4f2a7aeb61e3, []int{9}
+	return fileDescriptor_f36d4f2a7aeb61e3, []int{10}
 }
 func (m *JobReprioritizedEvent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -792,7 +876,7 @@ func (m *JobCancellingEvent) Reset()         { *m = JobCancellingEvent{} }
 func (m *JobCancellingEvent) String() string { return proto.CompactTextString(m) }
 func (*JobCancellingEvent) ProtoMessage()    {}
 func (*JobCancellingEvent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_f36d4f2a7aeb61e3, []int{10}
+	return fileDescriptor_f36d4f2a7aeb61e3, []int{11}
 }
 func (m *JobCancellingEvent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -860,7 +944,7 @@ func (m *JobCancelledEvent) Reset()         { *m = JobCancelledEvent{} }
 func (m *JobCancelledEvent) String() string { return proto.CompactTextString(m) }
 func (*JobCancelledEvent) ProtoMessage()    {}
 func (*JobCancelledEvent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_f36d4f2a7aeb61e3, []int{11}
+	return fileDescriptor_f36d4f2a7aeb61e3, []int{12}
 }
 func (m *JobCancelledEvent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -929,7 +1013,7 @@ func (m *JobTerminatedEvent) Reset()         { *m = JobTerminatedEvent{} }
 func (m *JobTerminatedEvent) String() string { return proto.CompactTextString(m) }
 func (*JobTerminatedEvent) ProtoMessage()    {}
 func (*JobTerminatedEvent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_f36d4f2a7aeb61e3, []int{12}
+	return fileDescriptor_f36d4f2a7aeb61e3, []int{13}
 }
 func (m *JobTerminatedEvent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -998,6 +1082,7 @@ type EventMessage struct {
 	//	*EventMessage_Submitted
 	//	*EventMessage_Queued
 	//	*EventMessage_Leased
+	//	*EventMessage_LeaseReturned
 	//	*EventMessage_LeaseExpired
 	//	*EventMessage_Pending
 	//	*EventMessage_Running
@@ -1015,7 +1100,7 @@ func (m *EventMessage) Reset()         { *m = EventMessage{} }
 func (m *EventMessage) String() string { return proto.CompactTextString(m) }
 func (*EventMessage) ProtoMessage()    {}
 func (*EventMessage) Descriptor() ([]byte, []int) {
-	return fileDescriptor_f36d4f2a7aeb61e3, []int{13}
+	return fileDescriptor_f36d4f2a7aeb61e3, []int{14}
 }
 func (m *EventMessage) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1059,40 +1144,44 @@ type EventMessage_Queued struct {
 type EventMessage_Leased struct {
 	Leased *JobLeasedEvent `protobuf:"bytes,3,opt,name=leased,proto3,oneof"`
 }
+type EventMessage_LeaseReturned struct {
+	LeaseReturned *JobLeaseReturnedEvent `protobuf:"bytes,4,opt,name=leaseReturned,proto3,oneof"`
+}
 type EventMessage_LeaseExpired struct {
-	LeaseExpired *JobLeaseExpiredEvent `protobuf:"bytes,4,opt,name=leaseExpired,proto3,oneof"`
+	LeaseExpired *JobLeaseExpiredEvent `protobuf:"bytes,5,opt,name=leaseExpired,proto3,oneof"`
 }
 type EventMessage_Pending struct {
-	Pending *JobPendingEvent `protobuf:"bytes,5,opt,name=pending,proto3,oneof"`
+	Pending *JobPendingEvent `protobuf:"bytes,6,opt,name=pending,proto3,oneof"`
 }
 type EventMessage_Running struct {
-	Running *JobRunningEvent `protobuf:"bytes,6,opt,name=running,proto3,oneof"`
+	Running *JobRunningEvent `protobuf:"bytes,7,opt,name=running,proto3,oneof"`
 }
 type EventMessage_UnableToSchedule struct {
-	UnableToSchedule *JobUnableToScheduleEvent `protobuf:"bytes,7,opt,name=unableToSchedule,proto3,oneof"`
+	UnableToSchedule *JobUnableToScheduleEvent `protobuf:"bytes,8,opt,name=unableToSchedule,proto3,oneof"`
 }
 type EventMessage_Failed struct {
-	Failed *JobFailedEvent `protobuf:"bytes,8,opt,name=failed,proto3,oneof"`
+	Failed *JobFailedEvent `protobuf:"bytes,9,opt,name=failed,proto3,oneof"`
 }
 type EventMessage_Succeeded struct {
-	Succeeded *JobSucceededEvent `protobuf:"bytes,9,opt,name=succeeded,proto3,oneof"`
+	Succeeded *JobSucceededEvent `protobuf:"bytes,10,opt,name=succeeded,proto3,oneof"`
 }
 type EventMessage_Reprioritized struct {
-	Reprioritized *JobReprioritizedEvent `protobuf:"bytes,10,opt,name=reprioritized,proto3,oneof"`
+	Reprioritized *JobReprioritizedEvent `protobuf:"bytes,11,opt,name=reprioritized,proto3,oneof"`
 }
 type EventMessage_Cancelling struct {
-	Cancelling *JobCancellingEvent `protobuf:"bytes,11,opt,name=cancelling,proto3,oneof"`
+	Cancelling *JobCancellingEvent `protobuf:"bytes,12,opt,name=cancelling,proto3,oneof"`
 }
 type EventMessage_Cancelled struct {
-	Cancelled *JobCancelledEvent `protobuf:"bytes,12,opt,name=cancelled,proto3,oneof"`
+	Cancelled *JobCancelledEvent `protobuf:"bytes,13,opt,name=cancelled,proto3,oneof"`
 }
 type EventMessage_Terminated struct {
-	Terminated *JobTerminatedEvent `protobuf:"bytes,13,opt,name=terminated,proto3,oneof"`
+	Terminated *JobTerminatedEvent `protobuf:"bytes,14,opt,name=terminated,proto3,oneof"`
 }
 
 func (*EventMessage_Submitted) isEventMessage_Events()        {}
 func (*EventMessage_Queued) isEventMessage_Events()           {}
 func (*EventMessage_Leased) isEventMessage_Events()           {}
+func (*EventMessage_LeaseReturned) isEventMessage_Events()    {}
 func (*EventMessage_LeaseExpired) isEventMessage_Events()     {}
 func (*EventMessage_Pending) isEventMessage_Events()          {}
 func (*EventMessage_Running) isEventMessage_Events()          {}
@@ -1128,6 +1217,13 @@ func (m *EventMessage) GetQueued() *JobQueuedEvent {
 func (m *EventMessage) GetLeased() *JobLeasedEvent {
 	if x, ok := m.GetEvents().(*EventMessage_Leased); ok {
 		return x.Leased
+	}
+	return nil
+}
+
+func (m *EventMessage) GetLeaseReturned() *JobLeaseReturnedEvent {
+	if x, ok := m.GetEvents().(*EventMessage_LeaseReturned); ok {
+		return x.LeaseReturned
 	}
 	return nil
 }
@@ -1208,6 +1304,7 @@ func (*EventMessage) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) 
 		(*EventMessage_Submitted)(nil),
 		(*EventMessage_Queued)(nil),
 		(*EventMessage_Leased)(nil),
+		(*EventMessage_LeaseReturned)(nil),
 		(*EventMessage_LeaseExpired)(nil),
 		(*EventMessage_Pending)(nil),
 		(*EventMessage_Running)(nil),
@@ -1240,53 +1337,58 @@ func _EventMessage_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
 		if err := b.EncodeMessage(x.Leased); err != nil {
 			return err
 		}
-	case *EventMessage_LeaseExpired:
+	case *EventMessage_LeaseReturned:
 		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.LeaseReturned); err != nil {
+			return err
+		}
+	case *EventMessage_LeaseExpired:
+		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
 		if err := b.EncodeMessage(x.LeaseExpired); err != nil {
 			return err
 		}
 	case *EventMessage_Pending:
-		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
+		_ = b.EncodeVarint(6<<3 | proto.WireBytes)
 		if err := b.EncodeMessage(x.Pending); err != nil {
 			return err
 		}
 	case *EventMessage_Running:
-		_ = b.EncodeVarint(6<<3 | proto.WireBytes)
+		_ = b.EncodeVarint(7<<3 | proto.WireBytes)
 		if err := b.EncodeMessage(x.Running); err != nil {
 			return err
 		}
 	case *EventMessage_UnableToSchedule:
-		_ = b.EncodeVarint(7<<3 | proto.WireBytes)
+		_ = b.EncodeVarint(8<<3 | proto.WireBytes)
 		if err := b.EncodeMessage(x.UnableToSchedule); err != nil {
 			return err
 		}
 	case *EventMessage_Failed:
-		_ = b.EncodeVarint(8<<3 | proto.WireBytes)
+		_ = b.EncodeVarint(9<<3 | proto.WireBytes)
 		if err := b.EncodeMessage(x.Failed); err != nil {
 			return err
 		}
 	case *EventMessage_Succeeded:
-		_ = b.EncodeVarint(9<<3 | proto.WireBytes)
+		_ = b.EncodeVarint(10<<3 | proto.WireBytes)
 		if err := b.EncodeMessage(x.Succeeded); err != nil {
 			return err
 		}
 	case *EventMessage_Reprioritized:
-		_ = b.EncodeVarint(10<<3 | proto.WireBytes)
+		_ = b.EncodeVarint(11<<3 | proto.WireBytes)
 		if err := b.EncodeMessage(x.Reprioritized); err != nil {
 			return err
 		}
 	case *EventMessage_Cancelling:
-		_ = b.EncodeVarint(11<<3 | proto.WireBytes)
+		_ = b.EncodeVarint(12<<3 | proto.WireBytes)
 		if err := b.EncodeMessage(x.Cancelling); err != nil {
 			return err
 		}
 	case *EventMessage_Cancelled:
-		_ = b.EncodeVarint(12<<3 | proto.WireBytes)
+		_ = b.EncodeVarint(13<<3 | proto.WireBytes)
 		if err := b.EncodeMessage(x.Cancelled); err != nil {
 			return err
 		}
 	case *EventMessage_Terminated:
-		_ = b.EncodeVarint(13<<3 | proto.WireBytes)
+		_ = b.EncodeVarint(14<<3 | proto.WireBytes)
 		if err := b.EncodeMessage(x.Terminated); err != nil {
 			return err
 		}
@@ -1324,7 +1426,15 @@ func _EventMessage_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.B
 		err := b.DecodeMessage(msg)
 		m.Events = &EventMessage_Leased{msg}
 		return true, err
-	case 4: // events.leaseExpired
+	case 4: // events.leaseReturned
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(JobLeaseReturnedEvent)
+		err := b.DecodeMessage(msg)
+		m.Events = &EventMessage_LeaseReturned{msg}
+		return true, err
+	case 5: // events.leaseExpired
 		if wire != proto.WireBytes {
 			return true, proto.ErrInternalBadWireType
 		}
@@ -1332,7 +1442,7 @@ func _EventMessage_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.B
 		err := b.DecodeMessage(msg)
 		m.Events = &EventMessage_LeaseExpired{msg}
 		return true, err
-	case 5: // events.pending
+	case 6: // events.pending
 		if wire != proto.WireBytes {
 			return true, proto.ErrInternalBadWireType
 		}
@@ -1340,7 +1450,7 @@ func _EventMessage_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.B
 		err := b.DecodeMessage(msg)
 		m.Events = &EventMessage_Pending{msg}
 		return true, err
-	case 6: // events.running
+	case 7: // events.running
 		if wire != proto.WireBytes {
 			return true, proto.ErrInternalBadWireType
 		}
@@ -1348,7 +1458,7 @@ func _EventMessage_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.B
 		err := b.DecodeMessage(msg)
 		m.Events = &EventMessage_Running{msg}
 		return true, err
-	case 7: // events.unableToSchedule
+	case 8: // events.unableToSchedule
 		if wire != proto.WireBytes {
 			return true, proto.ErrInternalBadWireType
 		}
@@ -1356,7 +1466,7 @@ func _EventMessage_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.B
 		err := b.DecodeMessage(msg)
 		m.Events = &EventMessage_UnableToSchedule{msg}
 		return true, err
-	case 8: // events.failed
+	case 9: // events.failed
 		if wire != proto.WireBytes {
 			return true, proto.ErrInternalBadWireType
 		}
@@ -1364,7 +1474,7 @@ func _EventMessage_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.B
 		err := b.DecodeMessage(msg)
 		m.Events = &EventMessage_Failed{msg}
 		return true, err
-	case 9: // events.succeeded
+	case 10: // events.succeeded
 		if wire != proto.WireBytes {
 			return true, proto.ErrInternalBadWireType
 		}
@@ -1372,7 +1482,7 @@ func _EventMessage_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.B
 		err := b.DecodeMessage(msg)
 		m.Events = &EventMessage_Succeeded{msg}
 		return true, err
-	case 10: // events.reprioritized
+	case 11: // events.reprioritized
 		if wire != proto.WireBytes {
 			return true, proto.ErrInternalBadWireType
 		}
@@ -1380,7 +1490,7 @@ func _EventMessage_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.B
 		err := b.DecodeMessage(msg)
 		m.Events = &EventMessage_Reprioritized{msg}
 		return true, err
-	case 11: // events.cancelling
+	case 12: // events.cancelling
 		if wire != proto.WireBytes {
 			return true, proto.ErrInternalBadWireType
 		}
@@ -1388,7 +1498,7 @@ func _EventMessage_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.B
 		err := b.DecodeMessage(msg)
 		m.Events = &EventMessage_Cancelling{msg}
 		return true, err
-	case 12: // events.cancelled
+	case 13: // events.cancelled
 		if wire != proto.WireBytes {
 			return true, proto.ErrInternalBadWireType
 		}
@@ -1396,7 +1506,7 @@ func _EventMessage_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.B
 		err := b.DecodeMessage(msg)
 		m.Events = &EventMessage_Cancelled{msg}
 		return true, err
-	case 13: // events.terminated
+	case 14: // events.terminated
 		if wire != proto.WireBytes {
 			return true, proto.ErrInternalBadWireType
 		}
@@ -1425,6 +1535,11 @@ func _EventMessage_OneofSizer(msg proto.Message) (n int) {
 		n += s
 	case *EventMessage_Leased:
 		s := proto.Size(x.Leased)
+		n += 1 // tag and wire
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *EventMessage_LeaseReturned:
+		s := proto.Size(x.LeaseReturned)
 		n += 1 // tag and wire
 		n += proto.SizeVarint(uint64(s))
 		n += s
@@ -1494,7 +1609,7 @@ func (m *EventStreamMessage) Reset()         { *m = EventStreamMessage{} }
 func (m *EventStreamMessage) String() string { return proto.CompactTextString(m) }
 func (*EventStreamMessage) ProtoMessage()    {}
 func (*EventStreamMessage) Descriptor() ([]byte, []int) {
-	return fileDescriptor_f36d4f2a7aeb61e3, []int{14}
+	return fileDescriptor_f36d4f2a7aeb61e3, []int{15}
 }
 func (m *EventStreamMessage) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1547,7 +1662,7 @@ func (m *JobSetRequest) Reset()         { *m = JobSetRequest{} }
 func (m *JobSetRequest) String() string { return proto.CompactTextString(m) }
 func (*JobSetRequest) ProtoMessage()    {}
 func (*JobSetRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_f36d4f2a7aeb61e3, []int{15}
+	return fileDescriptor_f36d4f2a7aeb61e3, []int{16}
 }
 func (m *JobSetRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1601,6 +1716,7 @@ func init() {
 	proto.RegisterType((*JobSubmittedEvent)(nil), "api.JobSubmittedEvent")
 	proto.RegisterType((*JobQueuedEvent)(nil), "api.JobQueuedEvent")
 	proto.RegisterType((*JobLeasedEvent)(nil), "api.JobLeasedEvent")
+	proto.RegisterType((*JobLeaseReturnedEvent)(nil), "api.JobLeaseReturnedEvent")
 	proto.RegisterType((*JobLeaseExpiredEvent)(nil), "api.JobLeaseExpiredEvent")
 	proto.RegisterType((*JobPendingEvent)(nil), "api.JobPendingEvent")
 	proto.RegisterType((*JobRunningEvent)(nil), "api.JobRunningEvent")
@@ -1619,62 +1735,63 @@ func init() {
 func init() { proto.RegisterFile("internal/armada/api/event.proto", fileDescriptor_f36d4f2a7aeb61e3) }
 
 var fileDescriptor_f36d4f2a7aeb61e3 = []byte{
-	// 867 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xd4, 0x57, 0xcf, 0x6f, 0xe3, 0x44,
-	0x14, 0xb6, 0xdb, 0xcd, 0xaf, 0x97, 0x66, 0x97, 0x1d, 0x42, 0xd7, 0x04, 0x48, 0x2a, 0x8b, 0xc3,
-	0x4a, 0x68, 0x93, 0x55, 0x56, 0x42, 0xe2, 0x02, 0x28, 0x55, 0x97, 0xc4, 0x80, 0x44, 0xa7, 0x45,
-	0x1c, 0x38, 0x8d, 0xed, 0x69, 0x6a, 0xc9, 0xf6, 0xb8, 0xf6, 0x18, 0x01, 0x07, 0xfe, 0x86, 0x1e,
-	0x91, 0x40, 0xf0, 0x5f, 0x80, 0x40, 0xe2, 0xde, 0x13, 0xea, 0xb1, 0x27, 0x40, 0xed, 0x5f, 0xc1,
-	0x0d, 0xcd, 0x8c, 0x27, 0xb1, 0x93, 0x72, 0x4f, 0x6e, 0x19, 0xcf, 0xf7, 0xcd, 0x7c, 0xf3, 0x66,
-	0xde, 0xf7, 0x5e, 0x60, 0x10, 0xc4, 0x9c, 0xa6, 0x31, 0x09, 0x47, 0x24, 0x8d, 0x88, 0x4f, 0x46,
-	0x24, 0x09, 0x46, 0xf4, 0x2b, 0x1a, 0xf3, 0x61, 0x92, 0x32, 0xce, 0xd0, 0x2e, 0x49, 0x82, 0xde,
-	0x60, 0xce, 0xd8, 0x3c, 0xa4, 0x23, 0xf9, 0xc9, 0xcd, 0xcf, 0x46, 0x3c, 0x88, 0x68, 0xc6, 0x49,
-	0x94, 0x28, 0x54, 0xef, 0xde, 0x65, 0x2e, 0x72, 0x9a, 0xd3, 0x02, 0xf0, 0xc6, 0xea, 0x0a, 0x34,
-	0x4a, 0xf8, 0x37, 0xc5, 0xe4, 0xb3, 0x79, 0xc0, 0xcf, 0x73, 0x77, 0xe8, 0xb1, 0x68, 0x34, 0x67,
-	0x73, 0xb6, 0x44, 0x89, 0x91, 0x1c, 0xc8, 0x5f, 0x0a, 0x6e, 0xff, 0x61, 0xc2, 0x63, 0x87, 0xb9,
-	0x27, 0xb9, 0x1b, 0x05, 0x9c, 0x53, 0xff, 0x48, 0xc8, 0x45, 0x5d, 0xa8, 0x39, 0xcc, 0x9d, 0xf9,
-	0x96, 0x79, 0x60, 0x3e, 0x6d, 0x61, 0x35, 0x40, 0x3d, 0x68, 0x0a, 0x28, 0xe5, 0x33, 0xdf, 0xda,
-	0x91, 0x13, 0x8b, 0xb1, 0x60, 0x1c, 0x0b, 0x89, 0xd6, 0xae, 0x62, 0xc8, 0x01, 0x7a, 0x1f, 0x1a,
-	0x87, 0x29, 0x25, 0x9c, 0xfa, 0xd6, 0x83, 0x03, 0xf3, 0x69, 0x7b, 0xdc, 0x1b, 0x2a, 0xed, 0x43,
-	0xad, 0x6a, 0x78, 0xaa, 0x4f, 0x3f, 0x69, 0x5e, 0xfd, 0x35, 0x30, 0x2e, 0xff, 0x1e, 0x98, 0x58,
-	0x93, 0xd0, 0x01, 0xec, 0x3a, 0xcc, 0xb5, 0x6a, 0x92, 0xdb, 0x1c, 0x92, 0x24, 0x18, 0x3a, 0xcc,
-	0x9d, 0x3c, 0x10, 0x48, 0x2c, 0xa6, 0xec, 0xef, 0x4d, 0x78, 0xe8, 0x30, 0x57, 0x6e, 0xb7, 0x59,
-	0xe2, 0xed, 0x5f, 0x94, 0xb4, 0x4f, 0x28, 0xc9, 0x36, 0x2d, 0xae, 0x6f, 0x42, 0xeb, 0x30, 0xcc,
-	0x33, 0x4e, 0xd3, 0x99, 0x2f, 0xa3, 0xdb, 0xc2, 0xcb, 0x0f, 0xf6, 0x4f, 0x26, 0x74, 0xb5, 0xf0,
-	0xa3, 0xaf, 0x93, 0x20, 0xdd, 0xb4, 0xc8, 0xfe, 0x6a, 0xc2, 0x23, 0x87, 0xb9, 0x9f, 0xd1, 0xd8,
-	0x0f, 0xe2, 0xf9, 0x36, 0x85, 0xb6, 0x50, 0x8e, 0xf3, 0x38, 0xde, 0x32, 0xe5, 0x37, 0x26, 0x58,
-	0x0e, 0x73, 0x3f, 0x8f, 0x89, 0x1b, 0xd2, 0x53, 0x76, 0xe2, 0x9d, 0x53, 0x3f, 0x0f, 0xe9, 0x16,
-	0x1d, 0x01, 0xed, 0x43, 0x1d, 0x53, 0x92, 0xb1, 0xd8, 0xaa, 0xcb, 0xa9, 0x62, 0x64, 0xff, 0xa9,
-	0x12, 0xf5, 0x25, 0x09, 0xc2, 0xad, 0x4a, 0xd4, 0xff, 0x3d, 0xd0, 0x6f, 0xda, 0xd4, 0x3d, 0x8f,
-	0x52, 0x7f, 0xbb, 0xcc, 0xe7, 0x67, 0x13, 0x5e, 0x13, 0x19, 0x42, 0x93, 0x34, 0x60, 0x69, 0xc0,
-	0x83, 0x6f, 0x37, 0xcd, 0x7d, 0x7e, 0x34, 0x01, 0x39, 0xcc, 0x3d, 0x24, 0xb1, 0x47, 0xc3, 0x70,
-	0xd3, 0xd2, 0xd8, 0xfe, 0x41, 0x5d, 0x7e, 0x21, 0x6f, 0xd3, 0x82, 0xf7, 0xbb, 0x0a, 0xde, 0x29,
-	0x4d, 0xa3, 0x20, 0x26, 0x7c, 0xbb, 0xde, 0xe6, 0xbf, 0x35, 0xd8, 0x93, 0x7a, 0x3f, 0xa5, 0x59,
-	0x46, 0xe6, 0x14, 0xbd, 0x0b, 0xad, 0x4c, 0x77, 0x4e, 0x52, 0x7a, 0x7b, 0xbc, 0xaf, 0xbb, 0x94,
-	0x6a, 0x4b, 0x35, 0x35, 0xf0, 0x12, 0x8a, 0x9e, 0x41, 0x5d, 0x36, 0x74, 0xea, 0x58, 0xed, 0xf1,
-	0xab, 0x9a, 0x54, 0xea, 0x63, 0xa6, 0x06, 0x2e, 0x40, 0x02, 0x1e, 0xca, 0x2e, 0x42, 0x1e, 0xb6,
-	0x04, 0x2f, 0xf5, 0x16, 0x02, 0xae, 0x40, 0xe8, 0x03, 0xd8, 0x0b, 0x4b, 0xb5, 0xbb, 0x88, 0xc4,
-	0xeb, 0x15, 0x52, 0xb9, 0xae, 0x4f, 0x0d, 0x5c, 0x21, 0xa0, 0xe7, 0xd0, 0x48, 0x54, 0x6d, 0x2d,
-	0x5a, 0xaf, 0xae, 0xe6, 0x96, 0x4b, 0xee, 0xd4, 0xc0, 0x1a, 0x26, 0x18, 0xa9, 0xaa, 0x69, 0xd2,
-	0x8a, 0x4a, 0x8c, 0x72, 0xa9, 0x13, 0x8c, 0x02, 0x86, 0x3e, 0x86, 0x57, 0xf2, 0x95, 0x5a, 0x62,
-	0x35, 0x24, 0xf5, 0x2d, 0x4d, 0xbd, 0xb7, 0xd6, 0x4c, 0x0d, 0xbc, 0x46, 0x14, 0x01, 0x3a, 0x93,
-	0xee, 0x6d, 0x35, 0xab, 0x01, 0x2a, 0x79, 0xba, 0x08, 0x90, 0x02, 0xa9, 0x6b, 0x2b, 0xbc, 0xd1,
-	0x6a, 0xad, 0x5e, 0x5b, 0xd9, 0x34, 0xd5, 0xb5, 0x15, 0x5f, 0xd0, 0x04, 0x3a, 0x69, 0xd9, 0x97,
-	0x2c, 0x28, 0xde, 0x98, 0x3e, 0xeb, 0x9a, 0x69, 0x4d, 0x0d, 0x5c, 0xa5, 0xa0, 0xf7, 0x00, 0xbc,
-	0x85, 0x73, 0x58, 0x6d, 0xb9, 0xc0, 0x13, 0xbd, 0xc0, 0x8a, 0xa7, 0x4c, 0x0d, 0x5c, 0x02, 0x0b,
-	0xd9, 0x9e, 0xce, 0x6a, 0x6b, 0xaf, 0x2a, 0xbb, 0x9a, 0xee, 0x42, 0xf6, 0x02, 0x2a, 0xb6, 0xe4,
-	0x8b, 0x7c, 0xb3, 0x3a, 0xd5, 0x2d, 0x57, 0x32, 0x51, 0x6c, 0xb9, 0x04, 0x4f, 0x9a, 0x50, 0x97,
-	0x7f, 0x60, 0x32, 0xfb, 0x18, 0x90, 0x04, 0x9c, 0xf0, 0x94, 0x92, 0x48, 0x27, 0xc0, 0x43, 0xd8,
-	0x59, 0x24, 0xed, 0xce, 0xcc, 0x47, 0xef, 0x40, 0x23, 0x52, 0x53, 0xc5, 0xcb, 0x7e, 0x2c, 0xf7,
-	0x29, 0x27, 0x0d, 0xd6, 0x08, 0xfb, 0x4b, 0xe8, 0xa8, 0x74, 0xc6, 0xf4, 0x22, 0xa7, 0x19, 0x5f,
-	0x5b, 0xad, 0x0b, 0xb5, 0x2f, 0x08, 0xf7, 0xce, 0xe5, 0x5a, 0x4d, 0xac, 0x06, 0xe8, 0x6d, 0xe8,
-	0xbc, 0x4c, 0x99, 0x96, 0x30, 0xf3, 0x0b, 0x07, 0xa8, 0x7e, 0x1c, 0x7f, 0x07, 0x35, 0x65, 0x2d,
-	0x2f, 0x44, 0x91, 0x4c, 0x58, 0xca, 0xd1, 0xba, 0x96, 0xde, 0xfe, 0x9a, 0x3d, 0x1c, 0x89, 0xff,
-	0x52, 0xe8, 0x43, 0x78, 0xf4, 0x11, 0xe5, 0x4a, 0x9d, 0x24, 0x64, 0x08, 0x2d, 0x5e, 0xc8, 0x42,
-	0x70, 0xef, 0xc9, 0x72, 0xc5, 0x4a, 0x5c, 0x9e, 0x9b, 0x13, 0xeb, 0xea, 0xb6, 0x6f, 0x5e, 0xdf,
-	0xf6, 0xcd, 0x7f, 0x6e, 0xfb, 0xe6, 0xe5, 0x5d, 0xdf, 0xb8, 0xbe, 0xeb, 0x1b, 0x37, 0x77, 0x7d,
-	0xc3, 0xad, 0xcb, 0xbd, 0x5e, 0xfc, 0x17, 0x00, 0x00, 0xff, 0xff, 0x5f, 0x8c, 0x37, 0x3b, 0x2f,
-	0x0e, 0x00, 0x00,
+	// 894 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xdc, 0x57, 0x41, 0x8f, 0xdb, 0x44,
+	0x14, 0xb6, 0x77, 0xbb, 0xd9, 0xe4, 0x65, 0x77, 0x4b, 0x87, 0xb0, 0x1d, 0x02, 0x24, 0x2b, 0x8b,
+	0x43, 0x25, 0xd4, 0xa4, 0x4a, 0x25, 0x24, 0x2e, 0x80, 0xb2, 0xda, 0x92, 0x18, 0x90, 0xe8, 0xec,
+	0x22, 0x0e, 0x9c, 0xc6, 0xf6, 0x34, 0x6b, 0xc9, 0xf6, 0xb8, 0xf6, 0x18, 0x01, 0x07, 0x7e, 0x43,
+	0x8f, 0x48, 0x20, 0xf8, 0x17, 0x20, 0x90, 0x7a, 0xef, 0x09, 0xf5, 0x82, 0xd4, 0x13, 0xa0, 0xdd,
+	0x3f, 0x82, 0x66, 0xc6, 0xe3, 0xd8, 0x49, 0x7f, 0x40, 0xd2, 0x5b, 0xc6, 0xf3, 0x7d, 0x33, 0xdf,
+	0xbc, 0x99, 0xf7, 0xbd, 0x17, 0x18, 0x86, 0x89, 0x60, 0x59, 0x42, 0xa3, 0x31, 0xcd, 0x62, 0x1a,
+	0xd0, 0x31, 0x4d, 0xc3, 0x31, 0xfb, 0x86, 0x25, 0x62, 0x94, 0x66, 0x5c, 0x70, 0xb4, 0x4b, 0xd3,
+	0xb0, 0x3f, 0x5c, 0x70, 0xbe, 0x88, 0xd8, 0x58, 0x7d, 0xf2, 0x8a, 0x47, 0x63, 0x11, 0xc6, 0x2c,
+	0x17, 0x34, 0x4e, 0x35, 0xaa, 0xff, 0xd2, 0x65, 0x1e, 0x17, 0xac, 0x60, 0x25, 0xe0, 0xad, 0xd5,
+	0x15, 0x58, 0x9c, 0x8a, 0xef, 0xca, 0xc9, 0xbb, 0x8b, 0x50, 0x5c, 0x16, 0xde, 0xc8, 0xe7, 0xf1,
+	0x78, 0xc1, 0x17, 0x7c, 0x89, 0x92, 0x23, 0x35, 0x50, 0xbf, 0x34, 0xdc, 0x79, 0x6a, 0xc3, 0x2d,
+	0x97, 0x7b, 0xe7, 0x85, 0x17, 0x87, 0x42, 0xb0, 0xe0, 0x4c, 0xca, 0x45, 0x3d, 0xd8, 0x73, 0xb9,
+	0x37, 0x0f, 0xb0, 0x7d, 0x62, 0xdf, 0xe9, 0x10, 0x3d, 0x40, 0x7d, 0x68, 0x4b, 0x28, 0x13, 0xf3,
+	0x00, 0xef, 0xa8, 0x89, 0x6a, 0x2c, 0x19, 0x0f, 0xa5, 0x44, 0xbc, 0xab, 0x19, 0x6a, 0x80, 0x3e,
+	0x84, 0xfd, 0xd3, 0x8c, 0x51, 0xc1, 0x02, 0x7c, 0xe3, 0xc4, 0xbe, 0xd3, 0x9d, 0xf4, 0x47, 0x5a,
+	0xfb, 0xc8, 0xa8, 0x1a, 0x5d, 0x98, 0xd3, 0x4f, 0xdb, 0xcf, 0xfe, 0x19, 0x5a, 0x4f, 0xfe, 0x1d,
+	0xda, 0xc4, 0x90, 0xd0, 0x09, 0xec, 0xba, 0xdc, 0xc3, 0x7b, 0x8a, 0xdb, 0x1e, 0xd1, 0x34, 0x1c,
+	0xb9, 0xdc, 0x9b, 0xde, 0x90, 0x48, 0x22, 0xa7, 0x9c, 0x1f, 0x6d, 0x38, 0x72, 0xb9, 0xa7, 0xb6,
+	0xdb, 0x2c, 0xf1, 0xce, 0x6f, 0x5a, 0xda, 0x67, 0x8c, 0xe6, 0x9b, 0x16, 0xd7, 0xb7, 0xa1, 0x73,
+	0x1a, 0x15, 0xb9, 0x60, 0xd9, 0x3c, 0x50, 0xd1, 0xed, 0x90, 0xe5, 0x07, 0xe7, 0x6f, 0x1b, 0xde,
+	0x30, 0xc2, 0x09, 0x13, 0x45, 0x96, 0x6c, 0x95, 0x7e, 0x74, 0x0c, 0x2d, 0xc2, 0x68, 0xce, 0x13,
+	0xdc, 0x52, 0x53, 0xe5, 0xc8, 0xf9, 0xc5, 0x86, 0x9e, 0x39, 0xd7, 0xd9, 0xb7, 0x69, 0x98, 0x6d,
+	0xda, 0x8b, 0xf9, 0xdd, 0x86, 0x9b, 0x2e, 0xf7, 0xbe, 0x60, 0x49, 0x10, 0x26, 0x8b, 0x6d, 0x7a,
+	0x32, 0xa5, 0x72, 0x52, 0x24, 0xc9, 0x96, 0x29, 0x7f, 0x61, 0x03, 0x76, 0xb9, 0xf7, 0x65, 0x42,
+	0xbd, 0x88, 0x5d, 0xf0, 0x73, 0xff, 0x92, 0x05, 0x45, 0xc4, 0x5e, 0x85, 0xf7, 0xfe, 0x97, 0x36,
+	0xa0, 0x07, 0x34, 0x8c, 0x5e, 0x8d, 0x04, 0xfe, 0xc3, 0x14, 0x2b, 0xdf, 0x67, 0x2c, 0xd8, 0x2e,
+	0x53, 0xfd, 0x55, 0x9b, 0x2a, 0x61, 0x69, 0x16, 0xf2, 0x2c, 0x14, 0xe1, 0xf7, 0x9b, 0xe6, 0x3e,
+	0x3f, 0xdb, 0x80, 0x5c, 0xee, 0x9d, 0xd2, 0xc4, 0x67, 0x51, 0xb4, 0x69, 0x69, 0xec, 0xfc, 0xa4,
+	0x2f, 0xbf, 0x94, 0xb7, 0x69, 0xc1, 0xfb, 0x53, 0x07, 0xef, 0x82, 0x65, 0x71, 0x98, 0x50, 0xb1,
+	0x5d, 0x6f, 0xf3, 0x69, 0x0b, 0x0e, 0x94, 0xde, 0xcf, 0x59, 0x9e, 0xd3, 0x05, 0x43, 0xef, 0x43,
+	0x27, 0x37, 0x1d, 0xa1, 0x92, 0xde, 0x9d, 0x1c, 0x9b, 0xee, 0xab, 0xd9, 0x2a, 0xce, 0x2c, 0xb2,
+	0x84, 0xa2, 0xbb, 0xd0, 0x52, 0x8d, 0xaa, 0x3e, 0x56, 0x77, 0xf2, 0xba, 0x21, 0xd5, 0xfa, 0xb3,
+	0x99, 0x45, 0x4a, 0x90, 0x84, 0x47, 0xaa, 0x3b, 0x52, 0x87, 0xad, 0xc1, 0x6b, 0x3d, 0x93, 0x84,
+	0x6b, 0x10, 0x9a, 0xc2, 0x61, 0x54, 0xef, 0x49, 0xaa, 0x50, 0xd4, 0x59, 0x8d, 0x86, 0x65, 0x66,
+	0x91, 0x26, 0x05, 0x7d, 0x04, 0x07, 0x51, 0xad, 0xfe, 0x97, 0xad, 0xe5, 0x9b, 0x8d, 0x25, 0xea,
+	0xbd, 0xc1, 0xcc, 0x22, 0x0d, 0x02, 0xba, 0x07, 0xfb, 0xa9, 0xae, 0xcf, 0xca, 0x9c, 0xba, 0x93,
+	0x9e, 0xe1, 0xd6, 0xcb, 0xf6, 0xcc, 0x22, 0x06, 0x26, 0x19, 0x99, 0xae, 0x8b, 0x78, 0xbf, 0xc9,
+	0xa8, 0x97, 0x4b, 0xc9, 0x28, 0x61, 0xe8, 0x53, 0x78, 0xad, 0x58, 0xa9, 0x47, 0xb8, 0xad, 0xa8,
+	0xef, 0x18, 0xea, 0x4b, 0xeb, 0xd5, 0xcc, 0x22, 0x6b, 0x44, 0x19, 0xe4, 0x47, 0xaa, 0x02, 0xe0,
+	0x4e, 0x33, 0xc8, 0xb5, 0xba, 0x20, 0x83, 0xac, 0x41, 0xfa, 0xea, 0x4b, 0x7f, 0xc5, 0xb0, 0x7a,
+	0xf5, 0x75, 0xe3, 0xd5, 0x57, 0x5f, 0x7e, 0x91, 0x97, 0x93, 0xd5, 0xbd, 0x0d, 0x77, 0x9b, 0x97,
+	0xb3, 0x6e, 0x7c, 0xf2, 0x72, 0x1a, 0x14, 0xf4, 0x01, 0x80, 0x5f, 0xb9, 0x0f, 0x3e, 0x50, 0x0b,
+	0xdc, 0x36, 0x0b, 0xac, 0xf8, 0xd2, 0xcc, 0x22, 0x35, 0xb0, 0x94, 0xed, 0x1b, 0x67, 0xc0, 0x87,
+	0x4d, 0xd9, 0x4d, 0xcb, 0x90, 0xb2, 0x2b, 0xa8, 0xdc, 0x52, 0x54, 0x39, 0x8b, 0x8f, 0x9a, 0x5b,
+	0xae, 0x64, 0xb3, 0xdc, 0x72, 0x09, 0x9e, 0xb6, 0xa1, 0xa5, 0xfe, 0xdc, 0xe5, 0xce, 0x43, 0x40,
+	0x0a, 0x70, 0x2e, 0x32, 0x46, 0x63, 0x93, 0x44, 0x47, 0xb0, 0x53, 0x25, 0xfe, 0xce, 0x3c, 0x40,
+	0xef, 0xc1, 0x7e, 0xac, 0xa7, 0xca, 0xec, 0xb8, 0xa5, 0xf6, 0xa9, 0x27, 0x1e, 0x31, 0x08, 0xe7,
+	0x6b, 0x38, 0xd4, 0x96, 0x40, 0xd8, 0xe3, 0x82, 0xe5, 0x62, 0x6d, 0xb5, 0x1e, 0xec, 0x7d, 0x45,
+	0x85, 0x7f, 0xa9, 0xd6, 0x6a, 0x13, 0x3d, 0x40, 0xef, 0xc2, 0xe1, 0x83, 0x8c, 0x1b, 0x09, 0xf3,
+	0xa0, 0x74, 0x91, 0xe6, 0xc7, 0xc9, 0x0f, 0xb0, 0xa7, 0xed, 0xe9, 0xbe, 0x2c, 0xb4, 0x29, 0xcf,
+	0x04, 0x5a, 0xd7, 0xd2, 0x3f, 0x5e, 0xb3, 0x98, 0x33, 0xf9, 0x3f, 0x13, 0x7d, 0x0c, 0x37, 0x3f,
+	0x61, 0x42, 0xab, 0x53, 0x84, 0x1c, 0xa1, 0xea, 0x85, 0x54, 0x82, 0xfb, 0xb7, 0x97, 0x2b, 0x36,
+	0xe2, 0x72, 0xcf, 0x9e, 0xe2, 0x67, 0x57, 0x03, 0xfb, 0xf9, 0xd5, 0xc0, 0xfe, 0xef, 0x6a, 0x60,
+	0x3f, 0xb9, 0x1e, 0x58, 0xcf, 0xaf, 0x07, 0xd6, 0x8b, 0xeb, 0x81, 0xe5, 0xb5, 0xd4, 0x5e, 0xf7,
+	0xff, 0x0f, 0x00, 0x00, 0xff, 0xff, 0xe9, 0x63, 0x1c, 0xf5, 0x4b, 0x0f, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -1956,6 +2073,62 @@ func (m *JobLeasedEvent) MarshalTo(dAtA []byte) (int, error) {
 	return i, nil
 }
 
+func (m *JobLeaseReturnedEvent) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *JobLeaseReturnedEvent) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if len(m.JobId) > 0 {
+		dAtA[i] = 0xa
+		i++
+		i = encodeVarintEvent(dAtA, i, uint64(len(m.JobId)))
+		i += copy(dAtA[i:], m.JobId)
+	}
+	if len(m.JobSetId) > 0 {
+		dAtA[i] = 0x12
+		i++
+		i = encodeVarintEvent(dAtA, i, uint64(len(m.JobSetId)))
+		i += copy(dAtA[i:], m.JobSetId)
+	}
+	if len(m.Queue) > 0 {
+		dAtA[i] = 0x1a
+		i++
+		i = encodeVarintEvent(dAtA, i, uint64(len(m.Queue)))
+		i += copy(dAtA[i:], m.Queue)
+	}
+	dAtA[i] = 0x22
+	i++
+	i = encodeVarintEvent(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdTime(m.Created)))
+	n5, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.Created, dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n5
+	if len(m.ClusterId) > 0 {
+		dAtA[i] = 0x2a
+		i++
+		i = encodeVarintEvent(dAtA, i, uint64(len(m.ClusterId)))
+		i += copy(dAtA[i:], m.ClusterId)
+	}
+	if len(m.Reason) > 0 {
+		dAtA[i] = 0x32
+		i++
+		i = encodeVarintEvent(dAtA, i, uint64(len(m.Reason)))
+		i += copy(dAtA[i:], m.Reason)
+	}
+	return i, nil
+}
+
 func (m *JobLeaseExpiredEvent) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -1992,11 +2165,11 @@ func (m *JobLeaseExpiredEvent) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0x22
 	i++
 	i = encodeVarintEvent(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdTime(m.Created)))
-	n5, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.Created, dAtA[i:])
+	n6, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.Created, dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n5
+	i += n6
 	return i, nil
 }
 
@@ -2036,11 +2209,11 @@ func (m *JobPendingEvent) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0x22
 	i++
 	i = encodeVarintEvent(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdTime(m.Created)))
-	n6, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.Created, dAtA[i:])
+	n7, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.Created, dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n6
+	i += n7
 	if len(m.ClusterId) > 0 {
 		dAtA[i] = 0x2a
 		i++
@@ -2086,11 +2259,11 @@ func (m *JobRunningEvent) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0x22
 	i++
 	i = encodeVarintEvent(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdTime(m.Created)))
-	n7, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.Created, dAtA[i:])
+	n8, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.Created, dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n7
+	i += n8
 	if len(m.ClusterId) > 0 {
 		dAtA[i] = 0x2a
 		i++
@@ -2136,11 +2309,11 @@ func (m *JobUnableToScheduleEvent) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0x22
 	i++
 	i = encodeVarintEvent(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdTime(m.Created)))
-	n8, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.Created, dAtA[i:])
+	n9, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.Created, dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n8
+	i += n9
 	if len(m.ClusterId) > 0 {
 		dAtA[i] = 0x2a
 		i++
@@ -2192,11 +2365,11 @@ func (m *JobFailedEvent) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0x22
 	i++
 	i = encodeVarintEvent(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdTime(m.Created)))
-	n9, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.Created, dAtA[i:])
+	n10, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.Created, dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n9
+	i += n10
 	if len(m.ClusterId) > 0 {
 		dAtA[i] = 0x2a
 		i++
@@ -2248,11 +2421,11 @@ func (m *JobSucceededEvent) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0x22
 	i++
 	i = encodeVarintEvent(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdTime(m.Created)))
-	n10, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.Created, dAtA[i:])
+	n11, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.Created, dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n10
+	i += n11
 	if len(m.ClusterId) > 0 {
 		dAtA[i] = 0x2a
 		i++
@@ -2298,11 +2471,11 @@ func (m *JobReprioritizedEvent) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0x22
 	i++
 	i = encodeVarintEvent(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdTime(m.Created)))
-	n11, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.Created, dAtA[i:])
+	n12, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.Created, dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n11
+	i += n12
 	return i, nil
 }
 
@@ -2342,11 +2515,11 @@ func (m *JobCancellingEvent) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0x22
 	i++
 	i = encodeVarintEvent(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdTime(m.Created)))
-	n12, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.Created, dAtA[i:])
+	n13, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.Created, dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n12
+	i += n13
 	return i, nil
 }
 
@@ -2386,11 +2559,11 @@ func (m *JobCancelledEvent) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0x22
 	i++
 	i = encodeVarintEvent(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdTime(m.Created)))
-	n13, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.Created, dAtA[i:])
+	n14, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.Created, dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n13
+	i += n14
 	return i, nil
 }
 
@@ -2430,11 +2603,11 @@ func (m *JobTerminatedEvent) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0x22
 	i++
 	i = encodeVarintEvent(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdTime(m.Created)))
-	n14, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.Created, dAtA[i:])
+	n15, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.Created, dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n14
+	i += n15
 	if len(m.ClusterId) > 0 {
 		dAtA[i] = 0x2a
 		i++
@@ -2460,11 +2633,11 @@ func (m *EventMessage) MarshalTo(dAtA []byte) (int, error) {
 	var l int
 	_ = l
 	if m.Events != nil {
-		nn15, err := m.Events.MarshalTo(dAtA[i:])
+		nn16, err := m.Events.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += nn15
+		i += nn16
 	}
 	return i, nil
 }
@@ -2475,11 +2648,11 @@ func (m *EventMessage_Submitted) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0xa
 		i++
 		i = encodeVarintEvent(dAtA, i, uint64(m.Submitted.Size()))
-		n16, err := m.Submitted.MarshalTo(dAtA[i:])
+		n17, err := m.Submitted.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n16
+		i += n17
 	}
 	return i, nil
 }
@@ -2489,11 +2662,11 @@ func (m *EventMessage_Queued) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x12
 		i++
 		i = encodeVarintEvent(dAtA, i, uint64(m.Queued.Size()))
-		n17, err := m.Queued.MarshalTo(dAtA[i:])
+		n18, err := m.Queued.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n17
+		i += n18
 	}
 	return i, nil
 }
@@ -2503,21 +2676,7 @@ func (m *EventMessage_Leased) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x1a
 		i++
 		i = encodeVarintEvent(dAtA, i, uint64(m.Leased.Size()))
-		n18, err := m.Leased.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n18
-	}
-	return i, nil
-}
-func (m *EventMessage_LeaseExpired) MarshalTo(dAtA []byte) (int, error) {
-	i := 0
-	if m.LeaseExpired != nil {
-		dAtA[i] = 0x22
-		i++
-		i = encodeVarintEvent(dAtA, i, uint64(m.LeaseExpired.Size()))
-		n19, err := m.LeaseExpired.MarshalTo(dAtA[i:])
+		n19, err := m.Leased.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
@@ -2525,13 +2684,13 @@ func (m *EventMessage_LeaseExpired) MarshalTo(dAtA []byte) (int, error) {
 	}
 	return i, nil
 }
-func (m *EventMessage_Pending) MarshalTo(dAtA []byte) (int, error) {
+func (m *EventMessage_LeaseReturned) MarshalTo(dAtA []byte) (int, error) {
 	i := 0
-	if m.Pending != nil {
-		dAtA[i] = 0x2a
+	if m.LeaseReturned != nil {
+		dAtA[i] = 0x22
 		i++
-		i = encodeVarintEvent(dAtA, i, uint64(m.Pending.Size()))
-		n20, err := m.Pending.MarshalTo(dAtA[i:])
+		i = encodeVarintEvent(dAtA, i, uint64(m.LeaseReturned.Size()))
+		n20, err := m.LeaseReturned.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
@@ -2539,13 +2698,13 @@ func (m *EventMessage_Pending) MarshalTo(dAtA []byte) (int, error) {
 	}
 	return i, nil
 }
-func (m *EventMessage_Running) MarshalTo(dAtA []byte) (int, error) {
+func (m *EventMessage_LeaseExpired) MarshalTo(dAtA []byte) (int, error) {
 	i := 0
-	if m.Running != nil {
-		dAtA[i] = 0x32
+	if m.LeaseExpired != nil {
+		dAtA[i] = 0x2a
 		i++
-		i = encodeVarintEvent(dAtA, i, uint64(m.Running.Size()))
-		n21, err := m.Running.MarshalTo(dAtA[i:])
+		i = encodeVarintEvent(dAtA, i, uint64(m.LeaseExpired.Size()))
+		n21, err := m.LeaseExpired.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
@@ -2553,13 +2712,13 @@ func (m *EventMessage_Running) MarshalTo(dAtA []byte) (int, error) {
 	}
 	return i, nil
 }
-func (m *EventMessage_UnableToSchedule) MarshalTo(dAtA []byte) (int, error) {
+func (m *EventMessage_Pending) MarshalTo(dAtA []byte) (int, error) {
 	i := 0
-	if m.UnableToSchedule != nil {
-		dAtA[i] = 0x3a
+	if m.Pending != nil {
+		dAtA[i] = 0x32
 		i++
-		i = encodeVarintEvent(dAtA, i, uint64(m.UnableToSchedule.Size()))
-		n22, err := m.UnableToSchedule.MarshalTo(dAtA[i:])
+		i = encodeVarintEvent(dAtA, i, uint64(m.Pending.Size()))
+		n22, err := m.Pending.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
@@ -2567,13 +2726,13 @@ func (m *EventMessage_UnableToSchedule) MarshalTo(dAtA []byte) (int, error) {
 	}
 	return i, nil
 }
-func (m *EventMessage_Failed) MarshalTo(dAtA []byte) (int, error) {
+func (m *EventMessage_Running) MarshalTo(dAtA []byte) (int, error) {
 	i := 0
-	if m.Failed != nil {
-		dAtA[i] = 0x42
+	if m.Running != nil {
+		dAtA[i] = 0x3a
 		i++
-		i = encodeVarintEvent(dAtA, i, uint64(m.Failed.Size()))
-		n23, err := m.Failed.MarshalTo(dAtA[i:])
+		i = encodeVarintEvent(dAtA, i, uint64(m.Running.Size()))
+		n23, err := m.Running.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
@@ -2581,13 +2740,13 @@ func (m *EventMessage_Failed) MarshalTo(dAtA []byte) (int, error) {
 	}
 	return i, nil
 }
-func (m *EventMessage_Succeeded) MarshalTo(dAtA []byte) (int, error) {
+func (m *EventMessage_UnableToSchedule) MarshalTo(dAtA []byte) (int, error) {
 	i := 0
-	if m.Succeeded != nil {
-		dAtA[i] = 0x4a
+	if m.UnableToSchedule != nil {
+		dAtA[i] = 0x42
 		i++
-		i = encodeVarintEvent(dAtA, i, uint64(m.Succeeded.Size()))
-		n24, err := m.Succeeded.MarshalTo(dAtA[i:])
+		i = encodeVarintEvent(dAtA, i, uint64(m.UnableToSchedule.Size()))
+		n24, err := m.UnableToSchedule.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
@@ -2595,13 +2754,13 @@ func (m *EventMessage_Succeeded) MarshalTo(dAtA []byte) (int, error) {
 	}
 	return i, nil
 }
-func (m *EventMessage_Reprioritized) MarshalTo(dAtA []byte) (int, error) {
+func (m *EventMessage_Failed) MarshalTo(dAtA []byte) (int, error) {
 	i := 0
-	if m.Reprioritized != nil {
-		dAtA[i] = 0x52
+	if m.Failed != nil {
+		dAtA[i] = 0x4a
 		i++
-		i = encodeVarintEvent(dAtA, i, uint64(m.Reprioritized.Size()))
-		n25, err := m.Reprioritized.MarshalTo(dAtA[i:])
+		i = encodeVarintEvent(dAtA, i, uint64(m.Failed.Size()))
+		n25, err := m.Failed.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
@@ -2609,13 +2768,13 @@ func (m *EventMessage_Reprioritized) MarshalTo(dAtA []byte) (int, error) {
 	}
 	return i, nil
 }
-func (m *EventMessage_Cancelling) MarshalTo(dAtA []byte) (int, error) {
+func (m *EventMessage_Succeeded) MarshalTo(dAtA []byte) (int, error) {
 	i := 0
-	if m.Cancelling != nil {
-		dAtA[i] = 0x5a
+	if m.Succeeded != nil {
+		dAtA[i] = 0x52
 		i++
-		i = encodeVarintEvent(dAtA, i, uint64(m.Cancelling.Size()))
-		n26, err := m.Cancelling.MarshalTo(dAtA[i:])
+		i = encodeVarintEvent(dAtA, i, uint64(m.Succeeded.Size()))
+		n26, err := m.Succeeded.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
@@ -2623,13 +2782,13 @@ func (m *EventMessage_Cancelling) MarshalTo(dAtA []byte) (int, error) {
 	}
 	return i, nil
 }
-func (m *EventMessage_Cancelled) MarshalTo(dAtA []byte) (int, error) {
+func (m *EventMessage_Reprioritized) MarshalTo(dAtA []byte) (int, error) {
 	i := 0
-	if m.Cancelled != nil {
-		dAtA[i] = 0x62
+	if m.Reprioritized != nil {
+		dAtA[i] = 0x5a
 		i++
-		i = encodeVarintEvent(dAtA, i, uint64(m.Cancelled.Size()))
-		n27, err := m.Cancelled.MarshalTo(dAtA[i:])
+		i = encodeVarintEvent(dAtA, i, uint64(m.Reprioritized.Size()))
+		n27, err := m.Reprioritized.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
@@ -2637,17 +2796,45 @@ func (m *EventMessage_Cancelled) MarshalTo(dAtA []byte) (int, error) {
 	}
 	return i, nil
 }
-func (m *EventMessage_Terminated) MarshalTo(dAtA []byte) (int, error) {
+func (m *EventMessage_Cancelling) MarshalTo(dAtA []byte) (int, error) {
 	i := 0
-	if m.Terminated != nil {
-		dAtA[i] = 0x6a
+	if m.Cancelling != nil {
+		dAtA[i] = 0x62
 		i++
-		i = encodeVarintEvent(dAtA, i, uint64(m.Terminated.Size()))
-		n28, err := m.Terminated.MarshalTo(dAtA[i:])
+		i = encodeVarintEvent(dAtA, i, uint64(m.Cancelling.Size()))
+		n28, err := m.Cancelling.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n28
+	}
+	return i, nil
+}
+func (m *EventMessage_Cancelled) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
+	if m.Cancelled != nil {
+		dAtA[i] = 0x6a
+		i++
+		i = encodeVarintEvent(dAtA, i, uint64(m.Cancelled.Size()))
+		n29, err := m.Cancelled.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n29
+	}
+	return i, nil
+}
+func (m *EventMessage_Terminated) MarshalTo(dAtA []byte) (int, error) {
+	i := 0
+	if m.Terminated != nil {
+		dAtA[i] = 0x72
+		i++
+		i = encodeVarintEvent(dAtA, i, uint64(m.Terminated.Size()))
+		n30, err := m.Terminated.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n30
 	}
 	return i, nil
 }
@@ -2676,11 +2863,11 @@ func (m *EventStreamMessage) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x12
 		i++
 		i = encodeVarintEvent(dAtA, i, uint64(m.Message.Size()))
-		n29, err := m.Message.MarshalTo(dAtA[i:])
+		n31, err := m.Message.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n29
+		i += n31
 	}
 	return i, nil
 }
@@ -2803,6 +2990,37 @@ func (m *JobLeasedEvent) Size() (n int) {
 	l = github_com_gogo_protobuf_types.SizeOfStdTime(m.Created)
 	n += 1 + l + sovEvent(uint64(l))
 	l = len(m.ClusterId)
+	if l > 0 {
+		n += 1 + l + sovEvent(uint64(l))
+	}
+	return n
+}
+
+func (m *JobLeaseReturnedEvent) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.JobId)
+	if l > 0 {
+		n += 1 + l + sovEvent(uint64(l))
+	}
+	l = len(m.JobSetId)
+	if l > 0 {
+		n += 1 + l + sovEvent(uint64(l))
+	}
+	l = len(m.Queue)
+	if l > 0 {
+		n += 1 + l + sovEvent(uint64(l))
+	}
+	l = github_com_gogo_protobuf_types.SizeOfStdTime(m.Created)
+	n += 1 + l + sovEvent(uint64(l))
+	l = len(m.ClusterId)
+	if l > 0 {
+		n += 1 + l + sovEvent(uint64(l))
+	}
+	l = len(m.Reason)
 	if l > 0 {
 		n += 1 + l + sovEvent(uint64(l))
 	}
@@ -3115,6 +3333,18 @@ func (m *EventMessage_Leased) Size() (n int) {
 	_ = l
 	if m.Leased != nil {
 		l = m.Leased.Size()
+		n += 1 + l + sovEvent(uint64(l))
+	}
+	return n
+}
+func (m *EventMessage_LeaseReturned) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.LeaseReturned != nil {
+		l = m.LeaseReturned.Size()
 		n += 1 + l + sovEvent(uint64(l))
 	}
 	return n
@@ -3875,6 +4105,252 @@ func (m *JobLeasedEvent) Unmarshal(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.ClusterId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipEvent(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthEvent
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthEvent
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *JobLeaseReturnedEvent) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowEvent
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: JobLeaseReturnedEvent: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: JobLeaseReturnedEvent: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field JobId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowEvent
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthEvent
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthEvent
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.JobId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field JobSetId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowEvent
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthEvent
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthEvent
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.JobSetId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Queue", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowEvent
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthEvent
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthEvent
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Queue = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Created", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowEvent
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthEvent
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthEvent
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := github_com_gogo_protobuf_types.StdTimeUnmarshal(&m.Created, dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ClusterId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowEvent
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthEvent
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthEvent
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ClusterId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Reason", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowEvent
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthEvent
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthEvent
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Reason = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -6112,6 +6588,41 @@ func (m *EventMessage) Unmarshal(dAtA []byte) error {
 			iNdEx = postIndex
 		case 4:
 			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field LeaseReturned", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowEvent
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthEvent
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthEvent
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			v := &JobLeaseReturnedEvent{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			m.Events = &EventMessage_LeaseReturned{v}
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field LeaseExpired", wireType)
 			}
 			var msglen int
@@ -6145,7 +6656,7 @@ func (m *EventMessage) Unmarshal(dAtA []byte) error {
 			}
 			m.Events = &EventMessage_LeaseExpired{v}
 			iNdEx = postIndex
-		case 5:
+		case 6:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Pending", wireType)
 			}
@@ -6180,7 +6691,7 @@ func (m *EventMessage) Unmarshal(dAtA []byte) error {
 			}
 			m.Events = &EventMessage_Pending{v}
 			iNdEx = postIndex
-		case 6:
+		case 7:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Running", wireType)
 			}
@@ -6215,7 +6726,7 @@ func (m *EventMessage) Unmarshal(dAtA []byte) error {
 			}
 			m.Events = &EventMessage_Running{v}
 			iNdEx = postIndex
-		case 7:
+		case 8:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field UnableToSchedule", wireType)
 			}
@@ -6250,7 +6761,7 @@ func (m *EventMessage) Unmarshal(dAtA []byte) error {
 			}
 			m.Events = &EventMessage_UnableToSchedule{v}
 			iNdEx = postIndex
-		case 8:
+		case 9:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Failed", wireType)
 			}
@@ -6285,7 +6796,7 @@ func (m *EventMessage) Unmarshal(dAtA []byte) error {
 			}
 			m.Events = &EventMessage_Failed{v}
 			iNdEx = postIndex
-		case 9:
+		case 10:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Succeeded", wireType)
 			}
@@ -6320,7 +6831,7 @@ func (m *EventMessage) Unmarshal(dAtA []byte) error {
 			}
 			m.Events = &EventMessage_Succeeded{v}
 			iNdEx = postIndex
-		case 10:
+		case 11:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Reprioritized", wireType)
 			}
@@ -6355,7 +6866,7 @@ func (m *EventMessage) Unmarshal(dAtA []byte) error {
 			}
 			m.Events = &EventMessage_Reprioritized{v}
 			iNdEx = postIndex
-		case 11:
+		case 12:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Cancelling", wireType)
 			}
@@ -6390,7 +6901,7 @@ func (m *EventMessage) Unmarshal(dAtA []byte) error {
 			}
 			m.Events = &EventMessage_Cancelling{v}
 			iNdEx = postIndex
-		case 12:
+		case 13:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Cancelled", wireType)
 			}
@@ -6425,7 +6936,7 @@ func (m *EventMessage) Unmarshal(dAtA []byte) error {
 			}
 			m.Events = &EventMessage_Cancelled{v}
 			iNdEx = postIndex
-		case 13:
+		case 14:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Terminated", wireType)
 			}

--- a/internal/armada/api/event.proto
+++ b/internal/armada/api/event.proto
@@ -30,6 +30,15 @@ message JobLeasedEvent {
     string ClusterId = 5;
 }
 
+message JobLeaseReturnedEvent {
+    string JobId = 1;
+    string JobSetId = 2;
+    string Queue = 3;
+    google.protobuf.Timestamp Created = 4 [(gogoproto.stdtime) = true, (gogoproto.nullable) = false];
+    string ClusterId = 5;
+    string Reason = 6;
+}
+
 message JobLeaseExpiredEvent {
     string JobId = 1;
     string JobSetId = 2;
@@ -113,16 +122,17 @@ message EventMessage {
         JobSubmittedEvent submitted = 1;
         JobQueuedEvent queued = 2;
         JobLeasedEvent leased = 3;
-        JobLeaseExpiredEvent leaseExpired = 4;
-        JobPendingEvent pending = 5;
-        JobRunningEvent running = 6;
-        JobUnableToScheduleEvent unableToSchedule = 7;
-        JobFailedEvent failed = 8;
-        JobSucceededEvent succeeded = 9;
-        JobReprioritizedEvent reprioritized = 10;
-        JobCancellingEvent cancelling = 11;
-        JobCancelledEvent cancelled = 12;
-        JobTerminatedEvent terminated = 13;
+        JobLeaseReturnedEvent leaseReturned = 4;
+        JobLeaseExpiredEvent leaseExpired = 5;
+        JobPendingEvent pending = 6;
+        JobRunningEvent running = 7;
+        JobUnableToScheduleEvent unableToSchedule = 8;
+        JobFailedEvent failed = 9;
+        JobSucceededEvent succeeded = 10;
+        JobReprioritizedEvent reprioritized = 11;
+        JobCancellingEvent cancelling = 12;
+        JobCancelledEvent cancelled = 13;
+        JobTerminatedEvent terminated = 14;
     }
 }
 

--- a/internal/armada/api/event_util.go
+++ b/internal/armada/api/event_util.go
@@ -21,6 +21,8 @@ func UnwrapEvent(message *EventMessage) (Event, error) {
 		return event.Queued, nil
 	case *EventMessage_Leased:
 		return event.Leased, nil
+	case *EventMessage_LeaseReturned:
+		return event.LeaseReturned, nil
 	case *EventMessage_LeaseExpired:
 		return event.LeaseExpired, nil
 	case *EventMessage_Pending:
@@ -63,6 +65,12 @@ func Wrap(event Event) (*EventMessage, error) {
 		return &EventMessage{
 			Events: &EventMessage_Leased{
 				Leased: typed,
+			},
+		}, nil
+	case *JobLeaseReturnedEvent:
+		return &EventMessage{
+			Events: &EventMessage_LeaseReturned{
+				LeaseReturned: typed,
 			},
 		}, nil
 	case *JobLeaseExpiredEvent:

--- a/internal/client/service/watch.go
+++ b/internal/client/service/watch.go
@@ -122,6 +122,8 @@ func updateJobInfo(info *JobInfo, event api.Event) {
 		info.Status = Queued
 	case *api.JobLeasedEvent:
 		info.Status = Leased
+	case *api.JobLeaseReturnedEvent:
+		info.Status = Queued
 	case *api.JobUnableToScheduleEvent:
 		// NOOP
 	case *api.JobLeaseExpiredEvent:

--- a/internal/executor/application.go
+++ b/internal/executor/application.go
@@ -65,6 +65,7 @@ func StartUp(config configuration.ExecutorConfiguration) (func(), *sync.WaitGrou
 
 	clusterAllocationService := service.NewClusterAllocationService(
 		clusterContext,
+		eventReporter,
 		jobLeaseService,
 		clusterUtilisationService)
 

--- a/internal/executor/reporter/event.go
+++ b/internal/executor/reporter/event.go
@@ -58,6 +58,17 @@ func CreateJobUnableToScheduleEvent(pod *v1.Pod, reason string, clusterId string
 	}
 }
 
+func CreateJobLeaseReturnedEvent(pod *v1.Pod, reason string, clusterId string) api.Event {
+	return &api.JobLeaseReturnedEvent{
+		JobId:     pod.Labels[domain.JobId],
+		JobSetId:  pod.Labels[domain.JobSetId],
+		Queue:     pod.Labels[domain.Queue],
+		Created:   time.Now(),
+		ClusterId: clusterId,
+		Reason:    reason,
+	}
+}
+
 func CreateJobFailedEvent(pod *v1.Pod, reason string, clusterId string) api.Event {
 	return &api.JobFailedEvent{
 		JobId:     pod.Labels[domain.JobId],

--- a/internal/executor/service/cluster_allocation.go
+++ b/internal/executor/service/cluster_allocation.go
@@ -63,7 +63,7 @@ func (allocationService *ClusterAllocationService) submitJobs(jobsToSubmit []*ap
 
 	for _, job := range jobsToSubmit {
 		pod := createPod(job)
-		_, err := allocationService.submitJob(job)
+		_, err := allocationService.clusterContext.SubmitPod(pod)
 
 		if err != nil {
 			log.Errorf("Failed to submit job %s because %s", job.Id, err)
@@ -83,7 +83,7 @@ func (allocationService *ClusterAllocationService) submitJobs(jobsToSubmit []*ap
 
 	err := allocationService.failJobs(toBeFailedJobs)
 	if err != nil {
-		log.Errorf("Failed to fail jobs because %s", err)
+		log.Errorf("Failed to report failed jobs as done because %s", err)
 	}
 }
 
@@ -115,11 +115,6 @@ func (allocationService *ClusterAllocationService) returnLease(pod *v1.Pod, reas
 			log.Errorf("Failed to report event %+v because %s", leaseReturnedEvent, err)
 		}
 	}
-}
-
-func (allocationService *ClusterAllocationService) submitJob(job *api.Job) (*v1.Pod, error) {
-	pod := createPod(job)
-	return allocationService.clusterContext.SubmitPod(pod)
 }
 
 func createPod(job *api.Job) *v1.Pod {


### PR DESCRIPTION
When a pod is submitted to Kubernetes and it fails, it is either because:
 - The pod and therefore job's podSpec are invalid
 - Some transient issue

We identify which of these it is, based on if it returns unprocessable entity status code (422)

If invalid podSpec
 - Send fail event
 - Report job done


else
 - Send lease returned event
 - Return lease