### PR TITLE
Making the build more stable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,21 +43,30 @@ jobs:
             - machine-go-mod-v1-{{ checksum "go.sum" }}
 
       - run:
-          name: ineffassign
-          command: go run github.com/gordonklaus/ineffassign .
-
-      - run:
           name: Test
           command: make tests
+
+      - run:
+          name: Build & Run e2e tests
+          command: make build-ci tests-e2e
+
+      - run: cat go.sum
+
+      - save_cache:
+          key: machine-go-mod-v1-{{ checksum "go.sum" }}
+          paths:
+            - "/home/circleci/go/pkg/mod"
+            - "/home/circleci/go/cache"
+
+      - run:
+          name: ineffassign
+          command: go run github.com/gordonklaus/ineffassign .
 
       - run:
           name: Check formatting
           command: |
             exit $(go run golang.org/x/tools/cmd/goimports -l -local "github.com/G-Research/armada" . | wc -l)
 
-      - run:
-          name: Build & Run e2e tests
-          command: make build-ci tests-e2e
 
       - store_artifacts:
           path: bin/armadactl
@@ -87,14 +96,6 @@ jobs:
 
             docker tag armada-executor gresearchdev/armada-executor-dev:${TAG}
             docker push gresearchdev/armada-executor-dev:${TAG}
-
-      - run: cat go.sum
-
-      - save_cache:
-          key: machine-go-mod-v1-{{ checksum "go.sum" }}
-          paths:
-            - "/home/circleci/go/pkg/mod"
-            - "/home/circleci/go/cache"
   deploy:
     docker:
       - image: alpine/helm:2.13.1

--- a/e2e/test/basic_test.go
+++ b/e2e/test/basic_test.go
@@ -43,7 +43,7 @@ func TestCanSubmitJob_ReceivingAllExpectedEvents(t *testing.T) {
 
 		eventsClient := api.NewEventClient(connection)
 
-		timeout, _ := context.WithTimeout(context.Background(), 20*time.Second)
+		timeout, _ := context.WithTimeout(context.Background(), 30*time.Second)
 
 		service.WatchJobSet(eventsClient, jobRequest.JobSetId, true, timeout, func(state map[string]*service.JobInfo, e api.Event) bool {
 			currentStatus := state[e.GetJobId()].Status


### PR DESCRIPTION
* Increasing timeout of e2e jobs
* Moving cache to just surround where we build/test the project
    * This means things like format checking are excluded from the cache but also have to run after cache activities
