### PR TITLE
Making prometheus rule dynamically reference service

### DIFF
--- a/deployment/executor/templates/prometheusrule.yaml
+++ b/deployment/executor/templates/prometheusrule.yaml
@@ -34,7 +34,7 @@ spec:
           expr: sum(armada:executor:pod:queue) by (label_queue_id, phase)
 
         - record: armada:executor:rest:request:histogram95
-          expr: histogram_quantile(0.95, sum(rate(rest_client_request_duration_seconds_bucket{service="armada-executor"}[30s])) by (endpoint, verb, url, le))
+          expr: histogram_quantile(0.95, sum(rate(rest_client_request_duration_seconds_bucket{service="{{ include "executor.name" . }}"}[30s])) by (endpoint, verb, url, le))
 
         - record: armada:executor:log:rate
           expr: sum(rate(log_messages[30s])) by (level)


### PR DESCRIPTION
We know the name of the service when the chart runs, so we should use it rather than assuming it is "armada-executor"