### PR TITLE
Fixing quick start job submission files format

### DIFF
--- a/docs/quickstart/job-queue-a.yaml
+++ b/docs/quickstart/job-queue-a.yaml
@@ -1,7 +1,7 @@
-queue: queue-a
-jobSetId: job-set-1
 jobs:
-  - priority: 0
+  - queue: queue-a
+    jobSetId: job-set-1
+    priority: 0
     podSpec:
       terminationGracePeriodSeconds: 0
       restartPolicy: Never

--- a/docs/quickstart/job-queue-b.yaml
+++ b/docs/quickstart/job-queue-b.yaml
@@ -1,7 +1,7 @@
-queue: queue-b
-jobSetId: job-set-1
 jobs:
-  - priority: 0
+  - queue: queue-b
+    jobSetId: job-set-1
+    priority: 0
     podSpec:
       terminationGracePeriodSeconds: 0
       restartPolicy: Never


### PR DESCRIPTION
These files were accidentally updated to match the current state of the repo

Instead they should match the current state of the quick start guide (which uses v0.0.1)

This should make the quick start guide work again