### PR TITLE
Quickstart: Disable unnecessary components

### DIFF
--- a/docs/quickstart/executor-prometheus-values.yaml
+++ b/docs/quickstart/executor-prometheus-values.yaml
@@ -1,3 +1,9 @@
+alertmanager:
+  enabled: false
+
+grafana:
+  enabled: false
+
 prometheus:
   prometheusSpec:
     serviceMonitorSelectorNilUsesHelmValues: false

--- a/docs/quickstart/server-prometheus-values.yaml
+++ b/docs/quickstart/server-prometheus-values.yaml
@@ -1,3 +1,6 @@
+alertmanager:
+  enabled: false
+
 prometheus:
   prometheusSpec:
     serviceMonitorSelectorNilUsesHelmValues: false


### PR DESCRIPTION
Neither server nor executor require Alertmanager in quickstart. Executors also don't need Grafana.