### PR TITLE
Making readinessProbe work by updating helm chart

### DIFF
--- a/deployment/armada/templates/deployment.yaml
+++ b/deployment/armada/templates/deployment.yaml
@@ -45,6 +45,9 @@ spec:
             - containerPort: 9000
               protocol: TCP
               name: metrics
+            - containerPort: {{ .Values.applicationConfig.httpPort }}
+              protocol: TCP
+              name: rest
           volumeMounts:
             - name: user-config
               mountPath: /config/application_config.yaml
@@ -57,7 +60,6 @@ spec:
             allowPrivilegeEscalation: false
           readinessProbe:
             httpGet:
-              host: localhost
               path: /health
               port: rest
             initialDelaySeconds: 5


### PR DESCRIPTION
Making server container expose http port called rest

Removing localhost as host from readinessProbe
 - This seems to make it fail by using localhost for the machine instead of the container
 - By default it goes to the correct host