### PR TITLE
Quickstart: Disable webhooks and TLS proxy

### DIFF
--- a/docs/quickstart/executor-prometheus-values.yaml
+++ b/docs/quickstart/executor-prometheus-values.yaml
@@ -10,3 +10,9 @@ prometheus:
     ruleSelectorNilUsesHelmValues: false
   service:
     type: NodePort
+
+prometheusOperator:
+  admissionWebhooks:
+    enabled: false
+  tlsProxy:
+    enabled: false

--- a/docs/quickstart/server-prometheus-values.yaml
+++ b/docs/quickstart/server-prometheus-values.yaml
@@ -9,3 +9,9 @@ grafana:
   service:
     type: NodePort
     nodePort: 30001
+
+prometheusOperator:
+  admissionWebhooks:
+    enabled: false
+  tlsProxy:
+    enabled: false


### PR DESCRIPTION
This change makes the prometheus-operator chart install time go down from 1m10s to 10s in my environment. This means it shaves 3 minutes off the whole quickstart as we install this chart in each cluster.

It doesn't appear these webhooks are required for the quickstart, the demo image in #251 was generated from an environment using these settings.