### PR TITLE
Fixing helm chart format

### DIFF
--- a/deployment/armada/templates/deployment.yaml
+++ b/deployment/armada/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
             {{- toYaml .Values.env | nindent 12 -}}
           {{- end }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 -}}
+            {{- toYaml .Values.resources | nindent 12 }}
           ports:
             - containerPort:  {{ .Values.applicationConfig.grpcPort }}
               protocol: TCP

--- a/deployment/executor/templates/deployment.yaml
+++ b/deployment/executor/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
 {{ toYaml .Values.env | indent 12 }}
 {{- end }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 -}}
+            {{- toYaml .Values.resources | nindent 12 }}
           ports:
             - containerPort: 9001
               protocol: TCP
@@ -49,9 +49,9 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
       nodeSelector:
-        {{- toYaml .Values.nodeSelector | nindent 8 -}}
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
       tolerations:
-        {{- toYaml .Values.tolerations | nindent 8 -}}
+        {{- toYaml .Values.tolerations | nindent 8 }}
       volumes:
         - name: user-config
           secret:

--- a/deployment/executor/templates/secret.yaml
+++ b/deployment/executor/templates/secret.yaml
@@ -9,5 +9,5 @@ type: Opaque
 data:
   {{ include "executor.config.filename" . }}: |
   {{- if .Values.applicationConfig }}
-  {{- toYaml .Values.applicationConfig | b64enc | indent 4 }}
+  {{ toYaml .Values.applicationConfig | b64enc | indent 4 }}
   {{- end }}


### PR DESCRIPTION
Currently the helm charts generated are misaligned
 - i.e Sections like ports was falling under resources and therefore was invalid
This allows them to be applied successfully