### PR TITLE
Quick start fixes

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -71,7 +71,7 @@ helm install stable/prometheus-operator --name=prometheus-operator -f docs/quick
 kubectl apply -f docs/quickstart/prometheus-kubemetrics-rules.yaml
 
 # Install executor
-helm template ./deployment/executor --set image.tag=$ARMADA_VERSION --set applicationConfig.armada.url="$DOCKERHOSTIP:30000" --set prometheus.enabled=true | kubectl apply -f -
+helm template ./deployment/executor --set image.tag=$ARMADA_VERSION --set applicationConfig.apiConnection.armadaUrl="$DOCKERHOSTIP:30000" --set prometheus.enabled=true | kubectl apply -f -
 ```
 Second executor:
 ```bash
@@ -87,7 +87,7 @@ helm install stable/prometheus-operator --name=prometheus-operator -f docs/quick
 kubectl apply -f docs/quickstart/prometheus-kubemetrics-rules.yaml
 
 # Install executor
-helm template ./deployment/executor --set image.tag=$ARMADA_VERSION --set applicationConfig.armada.url="$DOCKERHOSTIP:30000" --set prometheus.enabled=true | kubectl apply -f -
+helm template ./deployment/executor --set image.tag=$ARMADA_VERSION --set applicationConfig.apiConnection.armadaUrl="$DOCKERHOSTIP:30000" --set prometheus.enabled=true | kubectl apply -f -
 ```
 ### Grafana configuration
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -71,7 +71,7 @@ helm install stable/prometheus-operator --name=prometheus-operator -f docs/quick
 kubectl apply -f docs/quickstart/prometheus-kubemetrics-rules.yaml
 
 # Install executor
-helm template ./deployment/executor --set image.tag=$ARMADA_VERSION --set applicationConfig.apiConnection.armadaUrl="$DOCKERHOSTIP:30000" --set applicationConfig.apiConnection=forceNoTls=true --set prometheus.enabled=true | kubectl apply -f -
+helm template ./deployment/executor --set image.tag=$ARMADA_VERSION --set applicationConfig.apiConnection.armadaUrl="$DOCKERHOSTIP:30000" --set applicationConfig.apiConnection.forceNoTls=true --set prometheus.enabled=true | kubectl apply -f -
 ```
 Second executor:
 ```bash
@@ -87,7 +87,7 @@ helm install stable/prometheus-operator --name=prometheus-operator -f docs/quick
 kubectl apply -f docs/quickstart/prometheus-kubemetrics-rules.yaml
 
 # Install executor
-helm template ./deployment/executor --set image.tag=$ARMADA_VERSION --set applicationConfig.apiConnection.armadaUrl="$DOCKERHOSTIP:30000" --set applicationConfig.apiConnection=forceNoTls=true --set prometheus.enabled=true | kubectl apply -f -
+helm template ./deployment/executor --set image.tag=$ARMADA_VERSION --set applicationConfig.apiConnection.armadaUrl="$DOCKERHOSTIP:30000" --set applicationConfig.apiConnection.forceNoTls=true --set prometheus.enabled=true | kubectl apply -f -
 ```
 ### Grafana configuration
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -71,7 +71,7 @@ helm install stable/prometheus-operator --name=prometheus-operator -f docs/quick
 kubectl apply -f docs/quickstart/prometheus-kubemetrics-rules.yaml
 
 # Install executor
-helm template ./deployment/executor --set image.tag=$ARMADA_VERSION --set applicationConfig.apiConnection.armadaUrl="$DOCKERHOSTIP:30000" --set prometheus.enabled=true | kubectl apply -f -
+helm template ./deployment/executor --set image.tag=$ARMADA_VERSION --set applicationConfig.apiConnection.armadaUrl="$DOCKERHOSTIP:30000" --set applicationConfig.apiConnection=forceNoTls=true --set prometheus.enabled=true | kubectl apply -f -
 ```
 Second executor:
 ```bash
@@ -87,7 +87,7 @@ helm install stable/prometheus-operator --name=prometheus-operator -f docs/quick
 kubectl apply -f docs/quickstart/prometheus-kubemetrics-rules.yaml
 
 # Install executor
-helm template ./deployment/executor --set image.tag=$ARMADA_VERSION --set applicationConfig.apiConnection.armadaUrl="$DOCKERHOSTIP:30000" --set prometheus.enabled=true | kubectl apply -f -
+helm template ./deployment/executor --set image.tag=$ARMADA_VERSION --set applicationConfig.apiConnection.armadaUrl="$DOCKERHOSTIP:30000" --set applicationConfig.apiConnection=forceNoTls=true --set prometheus.enabled=true | kubectl apply -f -
 ```
 ### Grafana configuration
 

--- a/internal/common/client/connection.go
+++ b/internal/common/client/connection.go
@@ -20,6 +20,7 @@ type ApiConnectionDetails struct {
 	OpenIdPasswordAuth          oidc.ClientPasswordDetails
 	OpenIdClientCredentialsAuth oidc.ClientCredentialsDetails
 	KerberosAuth                kerberos.ClientConfig
+	ForceNoTls                  bool
 }
 
 func CreateApiConnection(config *ApiConnectionDetails, additionalDialOptions ...grpc.DialOption) (*grpc.ClientConn, error) {
@@ -37,7 +38,7 @@ func CreateApiConnection(config *ApiConnectionDetails, additionalDialOptions ...
 		defaultCallOptions,
 		unuaryInterceptors,
 		streamInterceptors,
-		transportCredentials(config.ArmadaUrl))
+		transportCredentials(config))
 
 	creds, err := perRpcCredentials(config)
 	if err != nil {
@@ -69,8 +70,8 @@ func perRpcCredentials(config *ApiConnectionDetails) (credentials.PerRPCCredenti
 	return nil, nil
 }
 
-func transportCredentials(url string) grpc.DialOption {
-	if !strings.Contains(url, "localhost") {
+func transportCredentials(config *ApiConnectionDetails) grpc.DialOption {
+	if !config.ForceNoTls && !strings.Contains(config.ArmadaUrl, "localhost") {
 		return grpc.WithTransportCredentials(credentials.NewClientTLSFromCert(nil, ""))
 	}
 	return grpc.WithInsecure()


### PR DESCRIPTION
Updating how armada url is specified, as the structure has now changed
Forcing the executors in the quick start to not use a tls connection (as the server isn't running behind nginx, so nothing is handling tls on server side)