### PR TITLE
Fix handling of int64 in swagger.

### DIFF
--- a/client/DotNet/Armada.Client.Test/Tests.cs
+++ b/client/DotNet/Armada.Client.Test/Tests.cs
@@ -27,6 +27,7 @@ namespace GResearch.Armada.Client.Test
                         Name = "Container1",
                         Image = "index.docker.io/library/ubuntu:latest",
                         Args = new[] {"sleep", "10s"},
+                        SecurityContext = new V1SecurityContext{RunAsUser = 1000}, 
                         Resources = new V1ResourceRequirements
                         {
                             Requests = new Dictionary<string, string>

--- a/client/DotNet/Armada.Client/ClientGenerated.cs
+++ b/client/DotNet/Armada.Client/ClientGenerated.cs
@@ -934,7 +934,7 @@ namespace GResearch.Armada.Client
     public partial class IntstrIntOrString 
     {
         [Newtonsoft.Json.JsonProperty("type", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Type { get; set; }
+        public long? Type { get; set; }
     
         [Newtonsoft.Json.JsonProperty("intVal", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public int? IntVal { get; set; }
@@ -2002,16 +2002,16 @@ namespace GResearch.Armada.Client
         public V1WindowsSecurityContextOptions WindowsOptions { get; set; }
     
         [Newtonsoft.Json.JsonProperty("runAsUser", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string RunAsUser { get; set; }
+        public long? RunAsUser { get; set; }
     
         [Newtonsoft.Json.JsonProperty("runAsGroup", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string RunAsGroup { get; set; }
+        public long? RunAsGroup { get; set; }
     
         [Newtonsoft.Json.JsonProperty("runAsNonRoot", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public bool? RunAsNonRoot { get; set; }
     
         [Newtonsoft.Json.JsonProperty("supplementalGroups", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.Collections.Generic.ICollection<string> SupplementalGroups { get; set; }
+        public System.Collections.Generic.ICollection<long> SupplementalGroups { get; set; }
     
         /// <summary>1. The owning GID will be the FSGroup
         /// 2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
@@ -2020,7 +2020,7 @@ namespace GResearch.Armada.Client
         /// If unset, the Kubelet will not modify the ownership and permissions of any volume.
         /// +optional</summary>
         [Newtonsoft.Json.JsonProperty("fsGroup", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string FsGroup { get; set; }
+        public long? FsGroup { get; set; }
     
         [Newtonsoft.Json.JsonProperty("sysctls", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.ICollection<V1Sysctl> Sysctls { get; set; }
@@ -2045,10 +2045,10 @@ namespace GResearch.Armada.Client
         public string RestartPolicy { get; set; }
     
         [Newtonsoft.Json.JsonProperty("terminationGracePeriodSeconds", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string TerminationGracePeriodSeconds { get; set; }
+        public long? TerminationGracePeriodSeconds { get; set; }
     
         [Newtonsoft.Json.JsonProperty("activeDeadlineSeconds", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string ActiveDeadlineSeconds { get; set; }
+        public long? ActiveDeadlineSeconds { get; set; }
     
         [Newtonsoft.Json.JsonProperty("dnsPolicy", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string DnsPolicy { get; set; }
@@ -2450,10 +2450,10 @@ namespace GResearch.Armada.Client
         public V1WindowsSecurityContextOptions WindowsOptions { get; set; }
     
         [Newtonsoft.Json.JsonProperty("runAsUser", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string RunAsUser { get; set; }
+        public long? RunAsUser { get; set; }
     
         [Newtonsoft.Json.JsonProperty("runAsGroup", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string RunAsGroup { get; set; }
+        public long? RunAsGroup { get; set; }
     
         [Newtonsoft.Json.JsonProperty("runAsNonRoot", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public bool? RunAsNonRoot { get; set; }
@@ -2481,7 +2481,7 @@ namespace GResearch.Armada.Client
         public string Audience { get; set; }
     
         [Newtonsoft.Json.JsonProperty("expirationSeconds", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string ExpirationSeconds { get; set; }
+        public long? ExpirationSeconds { get; set; }
     
         /// <summary>Path is the path relative to the mount point of the file to project the
         /// token into.</summary>
@@ -2560,7 +2560,7 @@ namespace GResearch.Armada.Client
         public string Effect { get; set; }
     
         [Newtonsoft.Json.JsonProperty("tolerationSeconds", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string TolerationSeconds { get; set; }
+        public long? TolerationSeconds { get; set; }
     
     
     }

--- a/internal/armada/api/api.swagger.go
+++ b/internal/armada/api/api.swagger.go
@@ -666,7 +666,7 @@ func SwaggerJsonTemplate() string {
 		"      \"type\": \"object\",\n" +
 		"      \"properties\": {\n" +
 		"        \"type\": {\n" +
-		"          \"type\": \"string\",\n" +
+		"          \"type\": \"integer\",\n" +
 		"          \"format\": \"int64\"\n" +
 		"        },\n" +
 		"        \"intVal\": {\n" +
@@ -1911,12 +1911,12 @@ func SwaggerJsonTemplate() string {
 		"          \"title\": \"Windows security options.\\n+optional\"\n" +
 		"        },\n" +
 		"        \"runAsUser\": {\n" +
-		"          \"type\": \"string\",\n" +
+		"          \"type\": \"integer\",\n" +
 		"          \"format\": \"int64\",\n" +
 		"          \"title\": \"The UID to run the entrypoint of the container process.\\nDefaults to user specified in image metadata if unspecified.\\nMay also be set in SecurityContext.  If set in both SecurityContext and\\nPodSecurityContext, the value specified in SecurityContext takes precedence\\nfor that container.\\n+optional\"\n" +
 		"        },\n" +
 		"        \"runAsGroup\": {\n" +
-		"          \"type\": \"string\",\n" +
+		"          \"type\": \"integer\",\n" +
 		"          \"format\": \"int64\",\n" +
 		"          \"title\": \"The GID to run the entrypoint of the container process.\\nUses runtime default if unset.\\nMay also be set in SecurityContext.  If set in both SecurityContext and\\nPodSecurityContext, the value specified in SecurityContext takes precedence\\nfor that container.\\n+optional\"\n" +
 		"        },\n" +
@@ -1928,13 +1928,13 @@ func SwaggerJsonTemplate() string {
 		"        \"supplementalGroups\": {\n" +
 		"          \"type\": \"array\",\n" +
 		"          \"items\": {\n" +
-		"            \"type\": \"string\",\n" +
+		"            \"type\": \"integer\",\n" +
 		"            \"format\": \"int64\"\n" +
 		"          },\n" +
 		"          \"title\": \"A list of groups applied to the first process run in each container, in addition\\nto the container's primary GID.  If unspecified, no groups will be added to\\nany container.\\n+optional\"\n" +
 		"        },\n" +
 		"        \"fsGroup\": {\n" +
-		"          \"type\": \"string\",\n" +
+		"          \"type\": \"integer\",\n" +
 		"          \"format\": \"int64\",\n" +
 		"          \"description\": \"1. The owning GID will be the FSGroup\\n2. The setgid bit is set (new files created in the volume will be owned by FSGroup)\\n3. The permission bits are OR'd with rw-rw----\\n\\nIf unset, the Kubelet will not modify the ownership and permissions of any volume.\\n+optional\",\n" +
 		"          \"title\": \"A special supplemental group that applies to all containers in a pod.\\nSome volume types allow the Kubelet to change the ownership of that volume\\nto be owned by the pod:\"\n" +
@@ -1978,12 +1978,12 @@ func SwaggerJsonTemplate() string {
 		"          \"title\": \"Restart policy for all containers within the pod.\\nOne of Always, OnFailure, Never.\\nDefault to Always.\\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy\\n+optional\"\n" +
 		"        },\n" +
 		"        \"terminationGracePeriodSeconds\": {\n" +
-		"          \"type\": \"string\",\n" +
+		"          \"type\": \"integer\",\n" +
 		"          \"format\": \"int64\",\n" +
 		"          \"title\": \"Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request.\\nValue must be non-negative integer. The value zero indicates delete immediately.\\nIf this value is nil, the default grace period will be used instead.\\nThe grace period is the duration in seconds after the processes running in the pod are sent\\na termination signal and the time when the processes are forcibly halted with a kill signal.\\nSet this value longer than the expected cleanup time for your process.\\nDefaults to 30 seconds.\\n+optional\"\n" +
 		"        },\n" +
 		"        \"activeDeadlineSeconds\": {\n" +
-		"          \"type\": \"string\",\n" +
+		"          \"type\": \"integer\",\n" +
 		"          \"format\": \"int64\",\n" +
 		"          \"title\": \"Optional duration in seconds the pod may be active on the node relative to\\nStartTime before the system will actively try to mark it failed and kill associated containers.\\nValue must be a positive integer.\\n+optional\"\n" +
 		"        },\n" +
@@ -2490,12 +2490,12 @@ func SwaggerJsonTemplate() string {
 		"          \"title\": \"Windows security options.\\n+optional\"\n" +
 		"        },\n" +
 		"        \"runAsUser\": {\n" +
-		"          \"type\": \"string\",\n" +
+		"          \"type\": \"integer\",\n" +
 		"          \"format\": \"int64\",\n" +
 		"          \"title\": \"The UID to run the entrypoint of the container process.\\nDefaults to user specified in image metadata if unspecified.\\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\\nPodSecurityContext, the value specified in SecurityContext takes precedence.\\n+optional\"\n" +
 		"        },\n" +
 		"        \"runAsGroup\": {\n" +
-		"          \"type\": \"string\",\n" +
+		"          \"type\": \"integer\",\n" +
 		"          \"format\": \"int64\",\n" +
 		"          \"title\": \"The GID to run the entrypoint of the container process.\\nUses runtime default if unset.\\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\\nPodSecurityContext, the value specified in SecurityContext takes precedence.\\n+optional\"\n" +
 		"        },\n" +
@@ -2529,7 +2529,7 @@ func SwaggerJsonTemplate() string {
 		"          \"title\": \"Audience is the intended audience of the token. A recipient of a token\\nmust identify itself with an identifier specified in the audience of the\\ntoken, and otherwise should reject the token. The audience defaults to the\\nidentifier of the apiserver.\\n+optional\"\n" +
 		"        },\n" +
 		"        \"expirationSeconds\": {\n" +
-		"          \"type\": \"string\",\n" +
+		"          \"type\": \"integer\",\n" +
 		"          \"format\": \"int64\",\n" +
 		"          \"title\": \"ExpirationSeconds is the requested duration of validity of the service\\naccount token. As the token approaches expiration, the kubelet volume\\nplugin will proactively rotate the service account token. The kubelet will\\nstart trying to rotate the token if the token is older than 80 percent of\\nits time to live or if the token is older than 24 hours.Defaults to 1 hour\\nand must be at least 10 minutes.\\n+optional\"\n" +
 		"        },\n" +
@@ -2615,7 +2615,7 @@ func SwaggerJsonTemplate() string {
 		"          \"title\": \"Effect indicates the taint effect to match. Empty means match all taint effects.\\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.\\n+optional\"\n" +
 		"        },\n" +
 		"        \"tolerationSeconds\": {\n" +
-		"          \"type\": \"string\",\n" +
+		"          \"type\": \"integer\",\n" +
 		"          \"format\": \"int64\",\n" +
 		"          \"title\": \"TolerationSeconds represents the period of time the toleration (which must be\\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\\nit is not set, which means tolerate the taint forever (do not evict). Zero and\\nnegative values will be treated as 0 (evict immediately) by the system.\\n+optional\"\n" +
 		"        }\n" +

--- a/internal/armada/api/api.swagger.json
+++ b/internal/armada/api/api.swagger.json
@@ -655,7 +655,7 @@
       "type": "object",
       "properties": {
         "type": {
-          "type": "string",
+          "type": "integer",
           "format": "int64"
         },
         "intVal": {
@@ -1900,12 +1900,12 @@
           "title": "Windows security options.\n+optional"
         },
         "runAsUser": {
-          "type": "string",
+          "type": "integer",
           "format": "int64",
           "title": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence\nfor that container.\n+optional"
         },
         "runAsGroup": {
-          "type": "string",
+          "type": "integer",
           "format": "int64",
           "title": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence\nfor that container.\n+optional"
         },
@@ -1917,13 +1917,13 @@
         "supplementalGroups": {
           "type": "array",
           "items": {
-            "type": "string",
+            "type": "integer",
             "format": "int64"
           },
           "title": "A list of groups applied to the first process run in each container, in addition\nto the container's primary GID.  If unspecified, no groups will be added to\nany container.\n+optional"
         },
         "fsGroup": {
-          "type": "string",
+          "type": "integer",
           "format": "int64",
           "description": "1. The owning GID will be the FSGroup\n2. The setgid bit is set (new files created in the volume will be owned by FSGroup)\n3. The permission bits are OR'd with rw-rw----\n\nIf unset, the Kubelet will not modify the ownership and permissions of any volume.\n+optional",
           "title": "A special supplemental group that applies to all containers in a pod.\nSome volume types allow the Kubelet to change the ownership of that volume\nto be owned by the pod:"
@@ -1967,12 +1967,12 @@
           "title": "Restart policy for all containers within the pod.\nOne of Always, OnFailure, Never.\nDefault to Always.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy\n+optional"
         },
         "terminationGracePeriodSeconds": {
-          "type": "string",
+          "type": "integer",
           "format": "int64",
           "title": "Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request.\nValue must be non-negative integer. The value zero indicates delete immediately.\nIf this value is nil, the default grace period will be used instead.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nDefaults to 30 seconds.\n+optional"
         },
         "activeDeadlineSeconds": {
-          "type": "string",
+          "type": "integer",
           "format": "int64",
           "title": "Optional duration in seconds the pod may be active on the node relative to\nStartTime before the system will actively try to mark it failed and kill associated containers.\nValue must be a positive integer.\n+optional"
         },
@@ -2479,12 +2479,12 @@
           "title": "Windows security options.\n+optional"
         },
         "runAsUser": {
-          "type": "string",
+          "type": "integer",
           "format": "int64",
           "title": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\n+optional"
         },
         "runAsGroup": {
-          "type": "string",
+          "type": "integer",
           "format": "int64",
           "title": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\n+optional"
         },
@@ -2518,7 +2518,7 @@
           "title": "Audience is the intended audience of the token. A recipient of a token\nmust identify itself with an identifier specified in the audience of the\ntoken, and otherwise should reject the token. The audience defaults to the\nidentifier of the apiserver.\n+optional"
         },
         "expirationSeconds": {
-          "type": "string",
+          "type": "integer",
           "format": "int64",
           "title": "ExpirationSeconds is the requested duration of validity of the service\naccount token. As the token approaches expiration, the kubelet volume\nplugin will proactively rotate the service account token. The kubelet will\nstart trying to rotate the token if the token is older than 80 percent of\nits time to live or if the token is older than 24 hours.Defaults to 1 hour\nand must be at least 10 minutes.\n+optional"
         },
@@ -2604,7 +2604,7 @@
           "title": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.\n+optional"
         },
         "tolerationSeconds": {
-          "type": "string",
+          "type": "integer",
           "format": "int64",
           "title": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.\n+optional"
         }


### PR DESCRIPTION
GRPC gateway uses strings to represent int64 according to proto3 specification, but this is incompatible with kubernetes types and json marshaller we use.