### PR TITLE
Publishing dotnet-client to nuget.org on release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,6 +172,22 @@ jobs:
             docker tag gresearchdev/armada-executor-dev:${TAG} gresearchdev/armada-executor:${RELEASE_TAG}
             docker push gresearchdev/armada-executor:${RELEASE_TAG}
 
+  release-dotnet-client:
+    docker:
+      - image: mcr.microsoft.com/dotnet/core/sdk:3.0.101-alpine3.10
+    working_directory: /go/src/github.com/G-Research/k8s-batch
+    steps:
+      - checkout
+
+      - run:
+          name: Release dotnet client
+          command: |
+            RELEASE_TAG=${CIRCLE_TAG#"v"}
+            dotnet pack client/DotNet/Armada.Client/Armada.Client.csproj -c Release -p:PackageVersion=${RELEASE_TAG} -o ./bin/client/DotNet
+            dotnet nuget push ./bin/client/DotNet/G-Research.Armada.Client.${RELEASE_TAG}.nupkg -k ${NUGET_API_KEY} -s https://api.nuget.org/v3/index.json
+
+      - store_artifacts:
+          path: bin/client/DotNet/*
 
 workflows:
   version: 2
@@ -190,3 +206,10 @@ workflows:
               only: /.*/
             branches:
               ignore: /.*/
+      - release-dotnet-client:
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/
+

--- a/client/DotNet/Armada.Client/Armada.Client.csproj
+++ b/client/DotNet/Armada.Client/Armada.Client.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="NSwag.CodeGeneration.CSharp" Version="13.1.3" />
   </ItemGroup>
 
-  <Target Name="NSwag" BeforeTargets="Build">
+  <Target Name="NSwag">
     <Exec Command="$(NSwagExe_Core30) openapi2csclient /ProtectedMethods:ArmadaClient.GetJobSetEventsAsync /classname:ArmadaClient /namespace:GResearch.Armada.Client /input:../../../internal/armada/api/api.swagger.json /output:ClientGenerated.cs" />
   </Target>
   

--- a/scripts/proto.sh
+++ b/scripts/proto.sh
@@ -32,4 +32,5 @@ go run github.com/wlbr/templify -e -p=api -f=SwaggerJson  internal/armada/api/ap
 # Fix all imports ordering
 go run golang.org/x/tools/cmd/goimports -w -local "github.com/G-Research/armada" ./internal/armada/api/
 
-
+# Genereate dotnet client to match the swagger
+dotnet msbuild ./client/DotNet/Armada.Client /t:NSwag


### PR DESCRIPTION
Now when a release tag is generated publish our dotnet client to nuget.org
 - This is to make it more easily accessible to people wanting to use it

Also the dotnet client no longer is generated on dotnet build
Instead it is generated as part of running the proto.sh, to make sure it stays in sync with when the swagger gets updated