### PR TITLE
Support watching multiple job IDs.

### DIFF
--- a/cmd/armadactl/cmd/watch.go
+++ b/cmd/armadactl/cmd/watch.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"sync"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -23,42 +24,51 @@ func init() {
 	watchCmd.Flags().Bool("exit-if-inactive", false, "Exit if there are no more active jobs")
 }
 
+func watchJobSet(cmd *cobra.Command, jobSetId string, waitgroup *sync.WaitGroup) {
+	defer waitgroup.Done()
+	raw, _ := cmd.Flags().GetBool("raw")
+	exit_on_inactive, _ := cmd.Flags().GetBool("exit-if-inactive")
+	log.Infof("Watching job set %s", jobSetId)
+
+	apiConnectionDetails := client.ExtractCommandlineArmadaApiConnectionDetails()
+
+	util.WithConnection(apiConnectionDetails, func(conn *grpc.ClientConn) {
+		eventsClient := api.NewEventClient(conn)
+		client.WatchJobSet(eventsClient, jobSetId, true, context.Background(), func(state *domain.WatchContext, e api.Event) bool {
+			if raw {
+				data, err := json.Marshal(e)
+				if err != nil {
+					log.Error(e)
+				} else {
+					log.Infof("%s %s\n", reflect.TypeOf(e), string(data))
+				}
+			} else {
+				summary := fmt.Sprintf("%s | ", e.GetCreated().Format(time.Stamp))
+				summary += state.GetCurrentStateSummary()
+				summary += fmt.Sprintf(" | event: %s, job id: %s", reflect.TypeOf(e), e.GetJobId())
+				log.Info(summary)
+			}
+			if exit_on_inactive && state.GetNumberOfJobs() == state.GetNumberOfFinishedJobs() {
+				return true
+			}
+			return false
+		})
+	})
+
+}
+
 // watchCmd represents the watch command
 var watchCmd = &cobra.Command{
 	Use:   "watch",
 	Short: "Watch job events in job set.",
-	Long:  `This command will list all job set events and `,
-	Args:  cobra.ExactArgs(1),
+	Long:  `This command will list all job set events for the given job set IDs.`,
+	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-
-		jobSetId := args[0]
-		raw, _ := cmd.Flags().GetBool("raw")
-		exit_on_inactive, _ := cmd.Flags().GetBool("exit-if-inactive")
-		log.Infof("Watching job set %s", jobSetId)
-
-		apiConnectionDetails := client.ExtractCommandlineArmadaApiConnectionDetails()
-
-		util.WithConnection(apiConnectionDetails, func(conn *grpc.ClientConn) {
-			eventsClient := api.NewEventClient(conn)
-			client.WatchJobSet(eventsClient, jobSetId, true, context.Background(), func(state *domain.WatchContext, e api.Event) bool {
-				if raw {
-					data, err := json.Marshal(e)
-					if err != nil {
-						log.Error(e)
-					} else {
-						log.Infof("%s %s\n", reflect.TypeOf(e), string(data))
-					}
-				} else {
-					summary := fmt.Sprintf("%s | ", e.GetCreated().Format(time.Stamp))
-					summary += state.GetCurrentStateSummary()
-					summary += fmt.Sprintf(" | event: %s, job id: %s", reflect.TypeOf(e), e.GetJobId())
-					log.Info(summary)
-				}
-				if exit_on_inactive && state.GetNumberOfJobs() == state.GetNumberOfFinishedJobs() {
-					return true
-				}
-				return false
-			})
-		})
+		wg := &sync.WaitGroup{}
+		for _, jobSetId := range args {
+			wg.Add(1)
+			go watchJobSet(cmd, jobSetId, wg)
+		}
+		wg.Wait()
 	},
 }


### PR DESCRIPTION
Fixes part of #162, specifically the bit that covers `armadactl watch`.
