### PR TITLE
Preventing dotnet client from hanging unexpectedly when it is cancelled

### DIFF
--- a/client/DotNet/Armada.Client/Client.cs
+++ b/client/DotNet/Armada.Client/Client.cs
@@ -100,7 +100,7 @@ namespace GResearch.Armada.Client
                         try
                         {
                             failCount = 0;
-                            while (!reader.EndOfStream && !ct.IsCancellationRequested)
+                            while (!ct.IsCancellationRequested && !reader.EndOfStream)
                             {
                                 var line = await reader.ReadLineAsync();
                                 var eventMessage =


### PR DESCRIPTION
To exit the watch of the dotnet client, we cancel the CancellationToken

However if you cancel when at the end of the stream (i.e on last message) then the watch will hang while EndOfStream looks for the next line

Swapping the order of these 2 in the if statement causes it to exit as expected
 - As the cancelled token is checked first, which fails the if and breaks out of the watch

We should also consider doing some work so a cancel in general is not blocked on EndOfStream check
 - This would require a different way to watching, so I am not doing it in this commit