### PR TITLE
Implement fake executor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,6 +98,9 @@ jobs:
 
             docker tag armada-executor gresearchdev/armada-executor-dev:${TAG}
             docker push gresearchdev/armada-executor-dev:${TAG}
+
+            docker tag armada-fakeexecutor gresearchdev/armada-fakeexecutor-dev:${TAG}
+            docker push gresearchdev/armada-fakeexecutor-dev:${TAG}
   deploy:
     docker:
       - image: alpine/helm:2.13.1

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,6 @@ armadactl
 [Rr]eleases/
 x64/
 x86/
-build/
 bld/
 [Bb]in/
 [Oo]bj/

--- a/build/fakeexecutor/Dockerfile
+++ b/build/fakeexecutor/Dockerfile
@@ -1,0 +1,15 @@
+FROM alpine:3.10
+
+RUN apk update && apk add --no-cache ca-certificates
+
+RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
+
+USER armada
+
+COPY ./bin/linux/fakeexecutor /app/
+
+COPY /config/executor/ /app/config/executor
+
+WORKDIR /app
+
+ENTRYPOINT ["./fakeexecutor"]

--- a/cmd/fakeexecutor/main.go
+++ b/cmd/fakeexecutor/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
+	"github.com/G-Research/armada/internal/common"
+	"github.com/G-Research/armada/internal/executor/configuration"
+	"github.com/G-Research/armada/internal/executor/fake"
+)
+
+const CustomConfigLocation string = "config"
+
+func init() {
+	pflag.String(CustomConfigLocation, "", "Fully qualified path to application configuration file")
+	pflag.Parse()
+}
+
+func main() {
+	common.ConfigureLogging()
+	common.BindCommandlineArguments()
+
+	var config configuration.ExecutorConfiguration
+	userSpecifiedConfig := viper.GetString(CustomConfigLocation)
+	common.LoadConfig(&config, "./config/executor", userSpecifiedConfig)
+
+	shutdownChannel := make(chan os.Signal, 1)
+	signal.Notify(shutdownChannel, syscall.SIGINT, syscall.SIGTERM)
+
+	shutdownMetricServer := common.ServeMetrics(config.MetricsPort)
+	defer shutdownMetricServer()
+
+	shutdown, wg := fake.StartUp(config)
+	go func() {
+		<-shutdownChannel
+		shutdown()
+	}()
+	wg.Wait()
+}

--- a/internal/executor/context/cluster_context.go
+++ b/internal/executor/context/cluster_context.go
@@ -33,6 +33,8 @@ type ClusterContext interface {
 	DeletePods(pods []*v1.Pod)
 
 	GetClusterId() string
+
+	Stop()
 }
 
 type KubernetesClusterContext struct {

--- a/internal/executor/fake/application.go
+++ b/internal/executor/fake/application.go
@@ -1,0 +1,16 @@
+package fake
+
+import (
+	"sync"
+
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/G-Research/armada/internal/executor"
+	"github.com/G-Research/armada/internal/executor/configuration"
+)
+
+func StartUp(config configuration.ExecutorConfiguration) (func(), *sync.WaitGroup) {
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	return executor.StartUpWithContext(config, &fakeClusterContext{clusterId: config.Application.ClusterId, pods: map[string]*v1.Pod{}}, make([]chan bool, 0), wg)
+}

--- a/internal/executor/fake/context.go
+++ b/internal/executor/fake/context.go
@@ -1,0 +1,143 @@
+package fake
+
+import (
+	"math/rand"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+type fakeClusterContext struct {
+	clusterId string
+	handlers  []*cache.ResourceEventHandlerFuncs
+	rwLock    sync.RWMutex
+	pods      map[string]*v1.Pod
+}
+
+func (fakeClusterContext) Stop() {
+}
+
+func (c *fakeClusterContext) AddPodEventHandler(handler cache.ResourceEventHandlerFuncs) {
+	c.handlers = append(c.handlers, &handler)
+}
+
+func (c *fakeClusterContext) GetBatchPods() ([]*v1.Pod, error) {
+	c.rwLock.Lock()
+	defer c.rwLock.Unlock()
+
+	pods := []*v1.Pod{}
+	for _, p := range c.pods {
+		pods = append(pods, p)
+	}
+	return pods, nil
+}
+
+func (c *fakeClusterContext) GetAllPods() ([]*v1.Pod, error) {
+	return c.GetBatchPods()
+}
+
+func (c *fakeClusterContext) GetActiveBatchPods() ([]*v1.Pod, error) {
+	return c.GetBatchPods()
+}
+
+func (c *fakeClusterContext) GetNodes() ([]*v1.Node, error) {
+	return []*v1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: c.clusterId + "-mega-node",
+			},
+			Spec: v1.NodeSpec{
+				Unschedulable: false,
+			},
+			Status: v1.NodeStatus{
+				Allocatable: map[v1.ResourceName]resource.Quantity{
+					"cpu":    resource.MustParse("1000"),
+					"memory": resource.MustParse("10Ti"),
+				},
+			},
+		},
+	}, nil
+}
+
+func (c *fakeClusterContext) SubmitPod(pod *v1.Pod, owner string) (*v1.Pod, error) {
+	c.rwLock.Lock()
+	defer c.rwLock.Unlock()
+	c.pods[pod.Name] = pod
+	pod.Status.Phase = v1.PodPending
+
+	for _, h := range c.handlers {
+		h.AddFunc(pod)
+	}
+	go func() {
+		time.Sleep(time.Duration(rand.Float32()+1) * 100 * time.Millisecond)
+		oldPod := pod.DeepCopy()
+		pod.Spec.NodeName = c.clusterId + "-mega-node"
+		pod.Status.Phase = v1.PodRunning
+		for _, h := range c.handlers {
+			h.UpdateFunc(oldPod, pod)
+		}
+
+		runtime := extractSleepTime(pod)
+
+		time.Sleep(time.Duration(runtime) * time.Second)
+		oldPod = pod.DeepCopy()
+		pod.Status.Phase = v1.PodSucceeded
+		for _, h := range c.handlers {
+			h.UpdateFunc(oldPod, pod)
+		}
+	}()
+
+	return pod, nil
+}
+
+func extractSleepTime(pod *v1.Pod) float32 {
+	command := append(pod.Spec.Containers[0].Command, pod.Spec.Containers[0].Args...)
+	commandString := strings.Join(command, " ")
+
+	// command needs to be in the form: sleep sleep $(( (RANDOM % 60) + 100 ))
+	r, e := regexp.Compile("\\(RANDOM *% *([0-9]+)\\) *\\+ *([0-9]+)")
+	if e == nil {
+		randomCallMatches := r.FindStringSubmatch(commandString)
+		if len(randomCallMatches) == 3 {
+			random, _ := strconv.Atoi(randomCallMatches[1])
+			fixed, _ := strconv.Atoi(randomCallMatches[2])
+			return rand.Float32()*float32(random) + float32(fixed)
+		}
+	}
+	log.Errorf("Default sleep 1s, could not interpret command: %s", commandString)
+	return 1
+}
+
+func (fakeClusterContext) AddAnnotation(pod *v1.Pod, annotations map[string]string) error {
+	// just annotate previously returned object, this relies on not copying pods when returning them from context
+	for k, v := range annotations {
+		pod.Annotations[k] = v
+	}
+	return nil
+}
+
+func (c *fakeClusterContext) DeletePods(pods []*v1.Pod) {
+	go func() {
+		// wait a little before actual delete
+		time.Sleep(100 * time.Millisecond)
+
+		c.rwLock.Lock()
+		defer c.rwLock.Unlock()
+
+		for _, p := range pods {
+			delete(c.pods, p.Name)
+		}
+	}()
+}
+
+func (c *fakeClusterContext) GetClusterId() string {
+	return c.clusterId
+}

--- a/internal/executor/fake/context.go
+++ b/internal/executor/fake/context.go
@@ -102,7 +102,7 @@ func extractSleepTime(pod *v1.Pod) float32 {
 	command := append(pod.Spec.Containers[0].Command, pod.Spec.Containers[0].Args...)
 	commandString := strings.Join(command, " ")
 
-	// command needs to be in the form: sleep sleep $(( (RANDOM % 60) + 100 ))
+	// command needs to be in the form: sleep $(( (RANDOM % 60) + 100 ))
 	r, e := regexp.Compile("\\(RANDOM *% *([0-9]+)\\) *\\+ *([0-9]+)")
 	if e == nil {
 		randomCallMatches := r.FindStringSubmatch(commandString)

--- a/internal/executor/reporter/job_event_reporter.go
+++ b/internal/executor/reporter/job_event_reporter.go
@@ -22,10 +22,10 @@ type EventReporter interface {
 
 type JobEventReporter struct {
 	eventClient    api.EventClient
-	clusterContext *context.KubernetesClusterContext
+	clusterContext context.ClusterContext
 }
 
-func NewJobEventReporter(clusterContext *context.KubernetesClusterContext, eventClient api.EventClient) *JobEventReporter {
+func NewJobEventReporter(clusterContext context.ClusterContext, eventClient api.EventClient) *JobEventReporter {
 
 	reporter := &JobEventReporter{
 		eventClient:    eventClient,

--- a/makefile
+++ b/makefile
@@ -11,6 +11,9 @@ build-server:
 build-executor:
 	$(gobuild) -o ./bin/executor cmd/executor/main.go
 
+build-fakeexecutor:
+	$(gobuild) -o ./bin/executor cmd/fakeexecutor/main.go
+
 build-armadactl:
 	$(gobuild) -o ./bin/armadactl cmd/armadactl/main.go
 
@@ -30,7 +33,7 @@ build-armadactl-release: build-armadactl-multiplatform
 build-load-tester:
 	$(gobuild) -o ./bin/armada-load-tester cmd/armada-load-tester/main.go
 
-build: build-server build-executor build-armadactl build-load-tester
+build: build-server build-executor build-fakeexecutor build-armadactl build-load-tester
 
 build-docker-server:
 	$(gobuildlinux) -o ./bin/linux/server cmd/armada/main.go
@@ -40,7 +43,11 @@ build-docker-executor:
 	$(gobuildlinux) -o ./bin/linux/executor cmd/executor/main.go
 	docker build $(dockerFlags) -t armada-executor -f ./build/executor/Dockerfile .
 
-build-docker: build-docker-server build-docker-executor
+build-docker-fakeexecutor:
+	$(gobuildlinux) -o ./bin/linux/fakeexecutor cmd/fakeexecutor/main.go
+	docker build $(dockerFlags) -t armada-fakeexecutor -f ./build/fakeexecutor/Dockerfile .
+
+build-docker: build-docker-server build-docker-executor build-docker-fakeexecutor
 
 build-ci: gobuild=$(gobuildlinux)
 build-ci: build-docker build-armadactl build-load-tester


### PR DESCRIPTION
This is part of #13.
Fake executor component pretends to be executor, but instead of creating pods on Kubernetes cluster it produces expected job events without actually running anything. It can be used to stress test the Armada server component.
