### PR TITLE
Export running pod metrics from executor.

### DIFF
--- a/config/executor/config.yaml
+++ b/config/executor/config.yaml
@@ -7,6 +7,7 @@ task:
   jobLeaseRenewalInterval: 15s
   podDeletionInterval: 5s
   allocateSpareClusterCapacityInterval: 5s
+  podMetricsInterval: 1s
 apiConnection:
   armadaUrl : "localhost:50051"
 metricsPort: 9001

--- a/internal/executor/application.go
+++ b/internal/executor/application.go
@@ -88,7 +88,7 @@ func StartUpWithContext(config configuration.ExecutorConfiguration, clusterConte
 	stopSignals = append(stopSignals, scheduleBackgroundTask(jobLeaseService.ManageJobLeases, config.Task.JobLeaseRenewalInterval, "job_lease_renewal", wg))
 	stopSignals = append(stopSignals, scheduleBackgroundTask(eventReporter.ReportMissingJobEvents, config.Task.MissingJobEventReconciliationInterval, "event_reconciliation", wg))
 	stopSignals = append(stopSignals, scheduleBackgroundTask(stuckPodDetector.HandleStuckPods, config.Task.StuckPodScanInterval, "stuck_pod", wg))
-	stopSignals = append(stopSignals, scheduleBackgroundTask(contextMetrics.UpdatePodMetrics, config.Task.PodMetricsInterval, "pod_metrics", wg))
+	stopSignals = append(stopSignals, scheduleBackgroundTask(contextMetrics.UpdateMetrics, config.Task.PodMetricsInterval, "pod_metrics", wg))
 
 	return func() {
 		stopTasks(stopSignals)

--- a/internal/executor/application.go
+++ b/internal/executor/application.go
@@ -57,8 +57,6 @@ func StartUpWithContext(config configuration.ExecutorConfiguration, clusterConte
 	usageClient := api.NewUsageClient(conn)
 	eventClient := api.NewEventClient(conn)
 
-	contextMetrics := pod_metrics.NewClusterContextMetrics(clusterContext)
-
 	eventReporter := reporter.NewJobEventReporter(
 		clusterContext,
 		eventClient)
@@ -82,6 +80,8 @@ func StartUpWithContext(config configuration.ExecutorConfiguration, clusterConte
 		eventReporter,
 		jobLeaseService,
 		clusterUtilisationService)
+
+	contextMetrics := pod_metrics.NewClusterContextMetrics(clusterContext, clusterUtilisationService)
 
 	stopSignals = append(stopSignals, scheduleBackgroundTask(clusterUtilisationService.ReportClusterUtilisation, config.Task.UtilisationReportingInterval, "utilisation_reporting", wg))
 	stopSignals = append(stopSignals, scheduleBackgroundTask(clusterAllocationService.AllocateSpareClusterCapacity, config.Task.AllocateSpareClusterCapacityInterval, "job_lease_request", wg))

--- a/internal/executor/configuration/types.go
+++ b/internal/executor/configuration/types.go
@@ -22,6 +22,7 @@ type TaskConfiguration struct {
 	AllocateSpareClusterCapacityInterval  time.Duration
 	StuckPodScanInterval                  time.Duration
 	PodDeletionInterval                   time.Duration
+	PodMetricsInterval                    time.Duration
 }
 
 type ExecutorConfiguration struct {

--- a/internal/executor/metrics/pod_metrics/cluster_context.go
+++ b/internal/executor/metrics/pod_metrics/cluster_context.go
@@ -1,0 +1,159 @@
+package pod_metrics
+
+import (
+	"github.com/google/martian/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/G-Research/armada/internal/common"
+	"github.com/G-Research/armada/internal/executor/context"
+	"github.com/G-Research/armada/internal/executor/domain"
+	metrics "github.com/G-Research/armada/internal/executor/metrics"
+)
+
+const (
+	leasedPhase = "Leased"
+	queueLabel  = "queue"
+	phaseLabel  = "phase"
+)
+
+type ClusterContextMetrics struct {
+	context context.ClusterContext
+
+	knownQueues map[string]bool
+
+	podCountTotal    *prometheus.CounterVec
+	podCount         *prometheus.GaugeVec
+	podCpuRequest    *prometheus.GaugeVec
+	podMemoryRequest *prometheus.GaugeVec
+}
+
+func NewClusterContextMetrics(context context.ClusterContext) *ClusterContextMetrics {
+	m := &ClusterContextMetrics{
+		context:     context,
+		knownQueues: map[string]bool{},
+		podCountTotal: promauto.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: metrics.ArmadaExecutorMetricsPrefix + "job_pod_total",
+				Help: "Counter for pods in different phases by queue",
+			},
+			[]string{queueLabel, phaseLabel}),
+
+		podCount: promauto.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: metrics.ArmadaExecutorMetricsPrefix + "job_pod",
+				Help: "Pods in different phases by queue",
+			},
+			[]string{queueLabel, phaseLabel}),
+		podCpuRequest: promauto.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: metrics.ArmadaExecutorMetricsPrefix + "job_pod_cpu_request",
+				Help: "Pod cpu requests in different phases by queue",
+			},
+			[]string{queueLabel, phaseLabel}),
+
+		podMemoryRequest: promauto.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: metrics.ArmadaExecutorMetricsPrefix + "job_pod_memory_request_bytes",
+				Help: "Pod memory requests in different phases by queue",
+			},
+			[]string{queueLabel, phaseLabel}),
+	}
+
+	context.AddPodEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			pod, ok := obj.(*v1.Pod)
+			if !ok {
+				return
+			}
+			m.reportPhase(pod)
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			oldPod, ok1 := oldObj.(*v1.Pod)
+			newPod, ok2 := newObj.(*v1.Pod)
+			if !ok1 || !ok2 || oldPod.Status.Phase == newPod.Status.Phase {
+				return
+			}
+			m.reportPhase(newPod)
+		},
+	})
+	return m
+}
+
+func (m *ClusterContextMetrics) reportPhase(pod *v1.Pod) {
+	queue, present := pod.Labels[domain.Queue]
+	if !present {
+		return
+	}
+	m.podCountTotal.WithLabelValues(queue, string(pod.Status.Phase)).Inc()
+}
+
+type podMetric struct {
+	cpu    float64
+	memory float64
+	count  float64
+}
+
+func (m *ClusterContextMetrics) UpdatePodMetrics() {
+	pods, e := m.context.GetBatchPods()
+	if e != nil {
+		log.Errorf("Unable to update metrics: %v", e)
+	}
+
+	podMetrics := map[string]map[string]*podMetric{}
+
+	for _, pod := range pods {
+		queue, present := pod.Labels[domain.Queue]
+		if !present {
+			continue
+		}
+
+		phase := string(pod.Status.Phase)
+		if phase == "" {
+			phase = leasedPhase
+		}
+
+		queueMetric, ok := podMetrics[queue]
+		if !ok {
+			queueMetric = createPodPhaseMetric()
+			podMetrics[queue] = queueMetric
+		}
+
+		resources := common.TotalResourceRequest(&pod.Spec).AsFloat()
+
+		queueMetric[phase].count++
+		queueMetric[phase].memory += resources[string(v1.ResourceMemory)]
+		queueMetric[phase].cpu += resources[string(v1.ResourceCPU)]
+	}
+
+	// reset metric for queues without pods
+	for q, _ := range m.knownQueues {
+		_, exists := podMetrics[q]
+		if !exists {
+			podMetrics[q] = createPodPhaseMetric()
+		}
+	}
+
+	for queue, queueMetric := range podMetrics {
+		m.knownQueues[queue] = true
+
+		for phase, phaseMetric := range queueMetric {
+			m.podCount.WithLabelValues(queue, phase).Set(phaseMetric.count)
+			m.podCpuRequest.WithLabelValues(queue, phase).Set(phaseMetric.cpu)
+			m.podMemoryRequest.WithLabelValues(queue, phase).Set(phaseMetric.memory)
+		}
+	}
+}
+
+func createPodPhaseMetric() map[string]*podMetric {
+	return map[string]*podMetric{
+		leasedPhase:             {},
+		string(v1.PodPending):   {},
+		string(v1.PodRunning):   {},
+		string(v1.PodSucceeded): {},
+		string(v1.PodFailed):    {},
+		string(v1.PodUnknown):   {},
+	}
+}

--- a/internal/executor/metrics/pod_metrics/cluster_context.go
+++ b/internal/executor/metrics/pod_metrics/cluster_context.go
@@ -118,7 +118,7 @@ type podMetric struct {
 	count  float64
 }
 
-func (m *ClusterContextMetrics) UpdatePodMetrics() {
+func (m *ClusterContextMetrics) UpdateMetrics() {
 	pods, e := m.context.GetBatchPods()
 	if e != nil {
 		log.Errorf("Unable to update metrics: %v", e)

--- a/internal/executor/service/cluster_utilisation.go
+++ b/internal/executor/service/cluster_utilisation.go
@@ -16,6 +16,7 @@ import (
 
 type UtilisationService interface {
 	GetAvailableClusterCapacity() (*common.ComputeResources, []map[string]string, error)
+	GetAllAvailableProcessingNodes() ([]*v1.Node, error)
 }
 
 type ClusterUtilisationService struct {
@@ -36,7 +37,7 @@ func NewClusterUtilisationService(
 }
 
 func (clusterUtilisationService *ClusterUtilisationService) ReportClusterUtilisation() {
-	allAvailableProcessingNodes, err := clusterUtilisationService.getAllAvailableProcessingNodes()
+	allAvailableProcessingNodes, err := clusterUtilisationService.GetAllAvailableProcessingNodes()
 	if err != nil {
 		log.Errorf("Failed to get required information to report cluster usage because %s", err)
 		return
@@ -67,7 +68,7 @@ func (clusterUtilisationService *ClusterUtilisationService) ReportClusterUtilisa
 }
 
 func (clusterUtilisationService *ClusterUtilisationService) GetAvailableClusterCapacity() (*common.ComputeResources, []map[string]string, error) {
-	processingNodes, err := clusterUtilisationService.getAllAvailableProcessingNodes()
+	processingNodes, err := clusterUtilisationService.GetAllAvailableProcessingNodes()
 	if err != nil {
 		return new(common.ComputeResources), nil, fmt.Errorf("Failed getting available cluster capacity due to: %s", err)
 	}
@@ -91,7 +92,7 @@ func (clusterUtilisationService *ClusterUtilisationService) GetAvailableClusterC
 	return &availableResource, availableLabels, nil
 }
 
-func (clusterUtilisationService *ClusterUtilisationService) getAllAvailableProcessingNodes() ([]*v1.Node, error) {
+func (clusterUtilisationService *ClusterUtilisationService) GetAllAvailableProcessingNodes() ([]*v1.Node, error) {
 	allNodes, err := clusterUtilisationService.clusterContext.GetNodes()
 	if err != nil {
 		return []*v1.Node{}, err


### PR DESCRIPTION
With this we can reduce dependency on metric server and have metrics for fake executor.