### PR TITLE
Expirying events after a given period of time

### DIFF
--- a/config/armada/config.yaml
+++ b/config/armada/config.yaml
@@ -33,3 +33,6 @@ scheduling:
     memory: 100000000 # 100Mb
     cpu: 0.25
   maximalClusterFractionToSchedule: 0.25
+eventRetention:
+  expiryEnabled: true
+  retentionDuration: 336h # Specified as a Go duration, values less than 0 (i.e -1) will result in infinite retention

--- a/internal/armada/configuration/types.go
+++ b/internal/armada/configuration/types.go
@@ -29,7 +29,8 @@ type ArmadaConfig struct {
 	PermissionGroupMapping map[permissions.Permission][]string
 	PermissionScopeMapping map[permissions.Permission][]string
 
-	Scheduling SchedulingConfig
+	Scheduling     SchedulingConfig
+	EventRetention EventRetentionPolicy
 }
 
 type OpenIdAuthenticationConfig struct {
@@ -52,4 +53,9 @@ type SchedulingConfig struct {
 	QueueLeaseBatchSize                       uint
 	MinimumResourceToSchedule                 common.ComputeResourcesFloat
 	MaximalClusterFractionToSchedule          float64
+}
+
+type EventRetentionPolicy struct {
+	ExpiryEnabled     bool
+	RetentionDuration time.Duration
 }

--- a/internal/armada/server.go
+++ b/internal/armada/server.go
@@ -37,7 +37,7 @@ func Serve(config *configuration.ArmadaConfig) (*grpc.Server, *sync.WaitGroup) {
 		usageRepository := repository.NewRedisUsageRepository(db)
 		queueRepository := repository.NewRedisQueueRepository(db)
 
-		eventRepository := repository.NewRedisEventRepository(eventsDb)
+		eventRepository := repository.NewRedisEventRepository(eventsDb, config.EventRetention)
 
 		metricsRecorder := metrics.ExposeDataMetrics(queueRepository, jobRepository)
 

--- a/internal/armada/server/event_test.go
+++ b/internal/armada/server/event_test.go
@@ -3,17 +3,19 @@ package server
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/go-redis/redis"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 
 	"github.com/G-Research/armada/internal/armada/api"
+	"github.com/G-Research/armada/internal/armada/configuration"
 	"github.com/G-Research/armada/internal/armada/repository"
 )
 
 func TestEventServer_ReportUsage(t *testing.T) {
-	withEventServer(func(s *EventServer) {
+	withEventServer(configuration.EventRetentionPolicy{ExpiryEnabled: false}, func(s *EventServer) {
 
 		jobSetId := "set1"
 		stream := &eventStreamMock{}
@@ -45,10 +47,30 @@ func TestEventServer_ReportUsage(t *testing.T) {
 }
 
 func TestEventServer_GetJobSetEvents_EmptyStreamShouldNotFail(t *testing.T) {
-	withEventServer(func(s *EventServer) {
+	withEventServer(configuration.EventRetentionPolicy{ExpiryEnabled: false}, func(s *EventServer) {
 
 		stream := &eventStreamMock{}
 		e := s.GetJobSetEvents(&api.JobSetRequest{Id: "test", Watch: false}, stream)
+		assert.Nil(t, e)
+		assert.Equal(t, 0, len(stream.sendMessages))
+	})
+}
+
+func TestEventServer_EventsShouldBeRemovedAfterEventRetentionTime(t *testing.T) {
+	eventRetention := configuration.EventRetentionPolicy{ExpiryEnabled: true, RetentionDuration: time.Second * 2}
+	withEventServer(eventRetention, func(s *EventServer) {
+		jobSetId := "set1"
+		stream := &eventStreamMock{}
+		reportEvent(t, s, &api.JobSubmittedEvent{JobSetId: jobSetId})
+
+		e := s.GetJobSetEvents(&api.JobSetRequest{Id: jobSetId, Watch: false}, stream)
+		assert.Nil(t, e)
+		assert.Equal(t, 1, len(stream.sendMessages))
+
+		time.Sleep(eventRetention.RetentionDuration + time.Millisecond*100)
+
+		stream = &eventStreamMock{}
+		e = s.GetJobSetEvents(&api.JobSetRequest{Id: jobSetId, Watch: false}, stream)
 		assert.Nil(t, e)
 		assert.Equal(t, 0, len(stream.sendMessages))
 	})
@@ -60,12 +82,12 @@ func reportEvent(t *testing.T, s *EventServer, event api.Event) {
 	assert.Nil(t, e)
 }
 
-func withEventServer(action func(s *EventServer)) {
+func withEventServer(eventRetention configuration.EventRetentionPolicy, action func(s *EventServer)) {
 
 	// using real redis instance as miniredis does not support streams
 	client := redis.NewClient(&redis.Options{Addr: "localhost:6379", DB: 10})
 
-	repo := repository.NewRedisEventRepository(client)
+	repo := repository.NewRedisEventRepository(client, eventRetention)
 	server := NewEventServer(&fakePermissionChecker{}, repo)
 
 	client.FlushDB()

--- a/internal/armada/server/submit_test.go
+++ b/internal/armada/server/submit_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/G-Research/armada/internal/armada/api"
+	"github.com/G-Research/armada/internal/armada/configuration"
 	"github.com/G-Research/armada/internal/armada/repository"
 	"github.com/G-Research/armada/internal/common/util"
 )
@@ -133,7 +134,7 @@ func withSubmitServer(action func(s *SubmitServer)) {
 
 	jobRepo := repository.NewRedisJobRepository(client)
 	queueRepo := repository.NewRedisQueueRepository(client)
-	eventRepo := repository.NewRedisEventRepository(client)
+	eventRepo := repository.NewRedisEventRepository(client, configuration.EventRetentionPolicy{ExpiryEnabled: false})
 	server := NewSubmitServer(&fakePermissionChecker{}, jobRepo, queueRepo, eventRepo)
 
 	err := queueRepo.CreateQueue(&api.Queue{Name: "test"})


### PR DESCRIPTION
Currently we retain events forever, however this will not be sustainable in production, especially as we use Redis which is in memory

Eventually we'll run out of space (memory in Redis's case) to hold events

Now you can configure:
 - If Armada should expire events (On by default)
 - How long it should retain events for before expiring them (2 weeks by default)

This should prevent Armada grinding to a halt eventually due to hitting storage limits