### PR TITLE
Fixing the final summary on loadtest

### DIFF
--- a/internal/client/load-test.go
+++ b/internal/client/load-test.go
@@ -75,6 +75,9 @@ func watchJobInfoChannel(eventChannel chan api.Event) (*sync.WaitGroup, chan boo
 			case <-tickChannel.C:
 				log.Info(aggregatedCurrentState.GetCurrentStateSummary())
 			case <-stop:
+				for event := range eventChannel {
+					aggregatedCurrentState.ProcessEvent(event)
+				}
 				log.Info(aggregatedCurrentState.GetCurrentStateSummary())
 				complete.Done()
 				return

--- a/internal/client/load-test.go
+++ b/internal/client/load-test.go
@@ -75,6 +75,7 @@ func watchJobInfoChannel(eventChannel chan api.Event) (*sync.WaitGroup, chan boo
 			case <-tickChannel.C:
 				log.Info(aggregatedCurrentState.GetCurrentStateSummary())
 			case <-stop:
+				close(eventChannel)
 				for event := range eventChannel {
 					aggregatedCurrentState.ProcessEvent(event)
 				}


### PR DESCRIPTION
Occasionally the final state printed out from the loadtest does not have all jobs in a "final" state

Usually when this happens, 1 job is left in "running" and only appears to happen under heavy load

This is because we are using a buffered channel, so the consumer is not quite keeping up with the event producers when the load is high

We stop the consumer as soon as all producers are finished, this can leave some events on the buffered channel that the consumer hasn't read yet.

Now when we stop the consumer, we finish reading all events left on the event channel before printing final state