### PR TITLE
Making lease expiry configurable and moving it to background loop

### DIFF
--- a/cmd/armada/main.go
+++ b/cmd/armada/main.go
@@ -41,10 +41,10 @@ func main() {
 	shutdownGateway := armada.ServeGateway(config.HttpPort, config.GrpcPort)
 	defer shutdownGateway()
 
-	s, wg := armada.Serve(&config)
+	shutdown, wg := armada.Serve(&config)
 	go func() {
 		<-stopSignal
-		s.GracefulStop()
+		shutdown()
 	}()
 	wg.Wait()
 }

--- a/config/armada/config.yaml
+++ b/config/armada/config.yaml
@@ -35,6 +35,9 @@ scheduling:
   maximalClusterFractionToSchedule:
     memory: 0.25
     cpu: 0.25
+  lease:
+    expireAfter: 15m
+    expiryLoopInterval: 5s
 eventRetention:
   expiryEnabled: true
   retentionDuration: 336h # Specified as a Go duration

--- a/internal/armada/configuration/types.go
+++ b/internal/armada/configuration/types.go
@@ -53,9 +53,15 @@ type SchedulingConfig struct {
 	QueueLeaseBatchSize                       uint
 	MinimumResourceToSchedule                 common.ComputeResourcesFloat
 	MaximalClusterFractionToSchedule          map[string]float64
+	Lease                                     LeaseSettings
 }
 
 type EventRetentionPolicy struct {
 	ExpiryEnabled     bool
 	RetentionDuration time.Duration
+}
+
+type LeaseSettings struct {
+	ExpireAfter        time.Duration
+	ExpiryLoopInterval time.Duration
 }

--- a/internal/armada/scheduling/lease.go
+++ b/internal/armada/scheduling/lease.go
@@ -1,0 +1,63 @@
+package scheduling
+
+import (
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/G-Research/armada/internal/armada/api"
+	"github.com/G-Research/armada/internal/armada/repository"
+)
+
+type LeaseManager struct {
+	jobRepository       repository.JobRepository
+	queueRepository     repository.QueueRepository
+	eventRepository     repository.EventRepository
+	leaseExpiryDuration time.Duration
+}
+
+func NewLeaseManager(
+	jobRepository repository.JobRepository,
+	queueRepository repository.QueueRepository,
+	eventRepository repository.EventRepository,
+	leaseExpiryDuration time.Duration) *LeaseManager {
+	return &LeaseManager{
+		jobRepository:       jobRepository,
+		queueRepository:     queueRepository,
+		eventRepository:     eventRepository,
+		leaseExpiryDuration: leaseExpiryDuration}
+}
+
+func (l *LeaseManager) ExpireLeases() {
+	queues, e := l.queueRepository.GetAllQueues()
+	if e != nil {
+		log.Error(e)
+		return
+	}
+
+	deadline := time.Now().Add(-l.leaseExpiryDuration)
+	for _, queue := range queues {
+		jobs, e := l.jobRepository.ExpireLeases(queue.Name, deadline)
+		now := time.Now()
+		if e != nil {
+			log.Error(e)
+		} else {
+			for _, job := range jobs {
+				event, e := api.Wrap(&api.JobLeaseExpiredEvent{
+					JobId:    job.Id,
+					Queue:    job.Queue,
+					JobSetId: job.JobSetId,
+					Created:  now,
+				})
+				if e != nil {
+					log.Error(e)
+				} else {
+					e := l.eventRepository.ReportEvent(event)
+					if e != nil {
+						log.Error(e)
+					}
+				}
+			}
+		}
+	}
+}

--- a/internal/armada/server/lease.go
+++ b/internal/armada/server/lease.go
@@ -72,9 +72,6 @@ func (q AggregatedQueueServer) LeaseJobs(ctx context.Context, request *api.Lease
 		return nil, e
 	}
 
-	// TODO: doing cleanup here for simplicity, should happen in background loop instead
-	expireOldJobs(q.jobRepository, q.eventRepository, queues, 2*time.Minute)
-
 	activeQueues, e := q.jobRepository.FilterActiveQueues(queues)
 	if e != nil {
 		return nil, e
@@ -348,34 +345,6 @@ func filterPriorityMapByKeys(original map[*api.Queue]scheduling.QueuePriorityInf
 		}
 	}
 	return result
-}
-
-func expireOldJobs(jobRepository repository.JobRepository, eventRepository repository.EventRepository, queues []*api.Queue, expiryInterval time.Duration) {
-	deadline := time.Now().Add(-expiryInterval)
-	for _, queue := range queues {
-		jobs, e := jobRepository.ExpireLeases(queue.Name, deadline)
-		now := time.Now()
-		if e != nil {
-			log.Error(e)
-		} else {
-			for _, job := range jobs {
-				event, e := api.Wrap(&api.JobLeaseExpiredEvent{
-					JobId:    job.Id,
-					Queue:    job.Queue,
-					JobSetId: job.JobSetId,
-					Created:  now,
-				})
-				if e != nil {
-					log.Error(e)
-				} else {
-					e := eventRepository.ReportEvent(event)
-					if e != nil {
-						log.Error(e)
-					}
-				}
-			}
-		}
-	}
 }
 
 func closeToDeadline(ctx context.Context) bool {

--- a/internal/armada/server_test.go
+++ b/internal/armada/server_test.go
@@ -116,7 +116,7 @@ func withRunningServer(action func(client api.SubmitClient, leaseClient api.Aggr
 
 	// cleanup prometheus in case there are registered metrics already present
 	prometheus.DefaultRegisterer = prometheus.NewRegistry()
-	server, _ := Serve(&configuration.ArmadaConfig{
+	shutdown, _ := Serve(&configuration.ArmadaConfig{
 		AnonymousAuth: true,
 		GrpcPort:      50052,
 		Redis: redis.UniversalOptions{
@@ -136,7 +136,7 @@ func withRunningServer(action func(client api.SubmitClient, leaseClient api.Aggr
 			QueueLeaseBatchSize: 100,
 		},
 	})
-	defer server.Stop()
+	defer shutdown()
 
 	conn, err := grpc.Dial("localhost:50052", grpc.WithInsecure(), grpc.WithDefaultCallOptions(grpc.WaitForReady(true)))
 	if err != nil {


### PR DESCRIPTION
You can now configure:
 - lease expireAfter - The amount of time for leases to expire
 - lease expiryLoopInterval - How frequently the background loop expiring leases runs

Additionally I have moved remove all lease expiry from LeaseJobs and made it a background job
 - This should remove potential slowdown from LeaseJobs
 - Have a better separation of responsibilities
 - Lets us control how often lease expiry is checked, rather than relying on executor calls to the server to call expire leases