### PR TITLE
Refactoring background task code to common

### DIFF
--- a/internal/armada/metrics/metrics.go
+++ b/internal/armada/metrics/metrics.go
@@ -9,7 +9,7 @@ import (
 	"github.com/G-Research/armada/internal/common"
 )
 
-const metricPrefix = "armada_"
+const MetricPrefix = "armada_"
 
 func ExposeDataMetrics(
 	queueRepository repository.QueueRepository,
@@ -31,28 +31,28 @@ type QueueInfoCollector struct {
 }
 
 var queueSizeDesc = prometheus.NewDesc(
-	metricPrefix+"queue_size",
+	MetricPrefix+"queue_size",
 	"Number of jobs in a queue",
 	[]string{"queueName"},
 	nil,
 )
 
 var queuePriorityDesc = prometheus.NewDesc(
-	metricPrefix+"queue_priority",
+	MetricPrefix+"queue_priority",
 	"Priority of a queue",
 	[]string{"queueName"},
 	nil,
 )
 
 var queueUsageDesc = prometheus.NewDesc(
-	metricPrefix+"queue_resource_usage",
+	MetricPrefix+"queue_resource_usage",
 	"Resource usage of a queue",
 	[]string{"cluster", "queueName", "resourceType"},
 	nil,
 )
 
 var clusterCapacityDesc = prometheus.NewDesc(
-	metricPrefix+"cluster_capacity",
+	MetricPrefix+"cluster_capacity",
 	"Cluster capacity",
 	[]string{"cluster", "resourceType"},
 	nil,

--- a/internal/common/task/background_task.go
+++ b/internal/common/task/background_task.go
@@ -1,0 +1,97 @@
+package task
+
+import (
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type task struct {
+	function    func()
+	interval    time.Duration
+	metricName  string
+	stopChannel chan bool
+}
+
+// BackgroundTaskManager is not threadsafe, it should only be accessed from a single thread.
+type BackgroundTaskManager struct {
+	tasks         []*task
+	metricsPrefix string
+	wg            *sync.WaitGroup
+}
+
+func NewBackgroundTaskManager(metricsPrefix string) *BackgroundTaskManager {
+	return &BackgroundTaskManager{
+		tasks:         []*task{},
+		metricsPrefix: metricsPrefix,
+		wg:            &sync.WaitGroup{},
+	}
+}
+
+func (m *BackgroundTaskManager) Register(backgroundTask func(), interval time.Duration, metricName string) {
+	task := &task{
+		function:    backgroundTask,
+		interval:    interval,
+		metricName:  metricName,
+		stopChannel: make(chan bool),
+	}
+	m.startBackgroundTask(task)
+	m.tasks = append(m.tasks, task)
+}
+
+func (m *BackgroundTaskManager) StopAll(timeout time.Duration) bool {
+	m.stopTasks()
+	return m.waitForShutdownCompletion(timeout)
+}
+
+func (m *BackgroundTaskManager) startBackgroundTask(task *task) {
+	var taskDurationHistogram = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    m.metricsPrefix + task.metricName + "_latency_seconds",
+			Help:    "Background loop " + task.metricName + " latency in seconds",
+			Buckets: prometheus.ExponentialBuckets(0.01, 2, 10),
+		})
+
+	m.wg.Add(1)
+	go func() {
+		start := time.Now()
+		task.function()
+		duration := time.Since(start)
+		taskDurationHistogram.Observe(duration.Seconds())
+
+		for {
+			select {
+			case <-time.After(task.interval):
+			case <-task.stopChannel:
+				m.wg.Done()
+				return
+			}
+			innerStart := time.Now()
+			task.function()
+			innerDuration := time.Since(innerStart)
+			taskDurationHistogram.Observe(innerDuration.Seconds())
+		}
+	}()
+}
+
+func (m *BackgroundTaskManager) waitForShutdownCompletion(timeout time.Duration) bool {
+	c := make(chan struct{})
+	go func() {
+		defer close(c)
+		m.wg.Wait()
+	}()
+	select {
+	case <-c:
+		return false // completed normally
+	case <-time.After(timeout):
+		return true // timed out
+	}
+}
+
+func (m *BackgroundTaskManager) stopTasks() {
+	for _, task := range m.tasks {
+		task.stopChannel <- true
+	}
+}

--- a/internal/executor/application.go
+++ b/internal/executor/application.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/G-Research/armada/internal/armada/api"
 	"github.com/G-Research/armada/internal/common/client"
+	"github.com/G-Research/armada/internal/common/task"
 	"github.com/G-Research/armada/internal/executor/cluster"
 	"github.com/G-Research/armada/internal/executor/configuration"
 	"github.com/G-Research/armada/internal/executor/context"
@@ -39,13 +40,13 @@ func StartUp(config configuration.ExecutorConfiguration) (func(), *sync.WaitGrou
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 
-	stopSignals := make([]chan bool, 0)
-	stopSignals = append(stopSignals, scheduleBackgroundTask(clusterContext.ProcessPodsToDelete, config.Task.PodDeletionInterval, "pod_deletion", wg))
+	taskManager := task.NewBackgroundTaskManager(metrics.ArmadaExecutorMetricsPrefix)
+	taskManager.Register(clusterContext.ProcessPodsToDelete, config.Task.PodDeletionInterval, "pod_deletion")
 
-	return StartUpWithContext(config, clusterContext, stopSignals, wg)
+	return StartUpWithContext(config, clusterContext, taskManager, wg)
 }
 
-func StartUpWithContext(config configuration.ExecutorConfiguration, clusterContext context.ClusterContext, stopSignals []chan bool, wg *sync.WaitGroup) (func(), *sync.WaitGroup) {
+func StartUpWithContext(config configuration.ExecutorConfiguration, clusterContext context.ClusterContext, taskManager *task.BackgroundTaskManager, wg *sync.WaitGroup) (func(), *sync.WaitGroup) {
 
 	conn, err := createConnectionToApi(config)
 	if err != nil {
@@ -85,20 +86,19 @@ func StartUpWithContext(config configuration.ExecutorConfiguration, clusterConte
 
 	contextMetrics := pod_metrics.NewClusterContextMetrics(clusterContext, clusterUtilisationService)
 
-	stopSignals = append(stopSignals, stopReporter)
-	stopSignals = append(stopSignals, scheduleBackgroundTask(clusterUtilisationService.ReportClusterUtilisation, config.Task.UtilisationReportingInterval, "utilisation_reporting", wg))
-	stopSignals = append(stopSignals, scheduleBackgroundTask(clusterAllocationService.AllocateSpareClusterCapacity, config.Task.AllocateSpareClusterCapacityInterval, "job_lease_request", wg))
-	stopSignals = append(stopSignals, scheduleBackgroundTask(jobLeaseService.ManageJobLeases, config.Task.JobLeaseRenewalInterval, "job_lease_renewal", wg))
-	stopSignals = append(stopSignals, scheduleBackgroundTask(eventReporter.ReportMissingJobEvents, config.Task.MissingJobEventReconciliationInterval, "event_reconciliation", wg))
-	stopSignals = append(stopSignals, scheduleBackgroundTask(stuckPodDetector.HandleStuckPods, config.Task.StuckPodScanInterval, "stuck_pod", wg))
-	stopSignals = append(stopSignals, scheduleBackgroundTask(contextMetrics.UpdateMetrics, config.Task.PodMetricsInterval, "pod_metrics", wg))
+	taskManager.Register(clusterUtilisationService.ReportClusterUtilisation, config.Task.UtilisationReportingInterval, "utilisation_reporting")
+	taskManager.Register(clusterAllocationService.AllocateSpareClusterCapacity, config.Task.AllocateSpareClusterCapacityInterval, "job_lease_request")
+	taskManager.Register(jobLeaseService.ManageJobLeases, config.Task.JobLeaseRenewalInterval, "job_lease_renewal")
+	taskManager.Register(eventReporter.ReportMissingJobEvents, config.Task.MissingJobEventReconciliationInterval, "event_reconciliation")
+	taskManager.Register(stuckPodDetector.HandleStuckPods, config.Task.StuckPodScanInterval, "stuck_pod")
+	taskManager.Register(contextMetrics.UpdateMetrics, config.Task.PodMetricsInterval, "pod_metrics")
 
 	return func() {
-		stopTasks(stopSignals)
+		stopReporter <- true
 		clusterContext.Stop()
 		conn.Close()
 		wg.Done()
-		if waitForShutdownCompletion(wg, 2*time.Second) {
+		if taskManager.StopAll(2 * time.Second) {
 			log.Warnf("Graceful shutdown timed out")
 		}
 		log.Infof("Shutdown complete")
@@ -109,58 +109,4 @@ func createConnectionToApi(config configuration.ExecutorConfiguration) (*grpc.Cl
 	return client.CreateApiConnection(&config.ApiConnection,
 		grpc.WithChainUnaryInterceptor(grpc_prometheus.UnaryClientInterceptor),
 		grpc.WithChainStreamInterceptor(grpc_prometheus.StreamClientInterceptor))
-}
-
-func waitForShutdownCompletion(wg *sync.WaitGroup, timeout time.Duration) bool {
-	c := make(chan struct{})
-	go func() {
-		defer close(c)
-		wg.Wait()
-	}()
-	select {
-	case <-c:
-		return false // completed normally
-	case <-time.After(timeout):
-		return true // timed out
-	}
-}
-
-func scheduleBackgroundTask(task func(), interval time.Duration, metricName string, wg *sync.WaitGroup) chan bool {
-	stop := make(chan bool)
-
-	var taskDurationHistogram = promauto.NewHistogram(
-		prometheus.HistogramOpts{
-			Name:    metrics.ArmadaExecutorMetricsPrefix + metricName + "_latency_seconds",
-			Help:    "Background loop " + metricName + " latency in seconds",
-			Buckets: prometheus.ExponentialBuckets(0.01, 2, 10),
-		})
-
-	wg.Add(1)
-	go func() {
-		start := time.Now()
-		task()
-		duration := time.Since(start)
-		taskDurationHistogram.Observe(duration.Seconds())
-
-		for {
-			select {
-			case <-time.After(interval):
-			case <-stop:
-				wg.Done()
-				return
-			}
-			innerStart := time.Now()
-			task()
-			innerDuration := time.Since(innerStart)
-			taskDurationHistogram.Observe(innerDuration.Seconds())
-		}
-	}()
-
-	return stop
-}
-
-func stopTasks(taskChannels []chan bool) {
-	for _, channel := range taskChannels {
-		channel <- true
-	}
 }

--- a/internal/executor/application.go
+++ b/internal/executor/application.go
@@ -6,8 +6,6 @@ import (
 	"time"
 
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 
@@ -97,11 +95,11 @@ func StartUpWithContext(config configuration.ExecutorConfiguration, clusterConte
 		stopReporter <- true
 		clusterContext.Stop()
 		conn.Close()
-		wg.Done()
 		if taskManager.StopAll(2 * time.Second) {
 			log.Warnf("Graceful shutdown timed out")
 		}
 		log.Infof("Shutdown complete")
+		wg.Done()
 	}, wg
 }
 

--- a/internal/executor/fake/application.go
+++ b/internal/executor/fake/application.go
@@ -3,13 +3,15 @@ package fake
 import (
 	"sync"
 
+	"github.com/G-Research/armada/internal/common/task"
 	"github.com/G-Research/armada/internal/executor"
 	"github.com/G-Research/armada/internal/executor/configuration"
 	"github.com/G-Research/armada/internal/executor/fake/context"
+	"github.com/G-Research/armada/internal/executor/metrics"
 )
 
 func StartUp(config configuration.ExecutorConfiguration) (func(), *sync.WaitGroup) {
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
-	return executor.StartUpWithContext(config, context.NewFakeClusterContext(config.Application.ClusterId), make([]chan bool, 0), wg)
+	return executor.StartUpWithContext(config, context.NewFakeClusterContext(config.Application.ClusterId), task.NewBackgroundTaskManager(metrics.ArmadaExecutorMetricsPrefix), wg)
 }


### PR DESCRIPTION
Now server and executor components use the shared BackgroundTaskManager for managing their background tasks

This is better code reuse and makes sure improvements are shared between these components