### PR TITLE
Add test for high priority user with unschedulable jobs, improve leasing.

### DIFF
--- a/internal/armada/scheduling/lease_test.go
+++ b/internal/armada/scheduling/lease_test.go
@@ -3,6 +3,7 @@ package scheduling
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
@@ -64,8 +65,8 @@ func Test_distributeRemainder_highPriorityUserDoesNotBlockOthers(t *testing.T) {
 		},
 	}
 
-	//ctx, _ := context.WithDeadline(context.Background(), time.Now().Add(time.Second))
-	ctx := context.Background()
+	// the leasing logic stops scheduling 1s before the deadline
+	ctx, _ := context.WithDeadline(context.Background(), time.Now().Add(2*time.Second))
 
 	c := leaseContext{
 		ctx: ctx,

--- a/internal/armada/scheduling/lease_test.go
+++ b/internal/armada/scheduling/lease_test.go
@@ -1,11 +1,16 @@
 package scheduling
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/G-Research/armada/internal/armada/api"
+	"github.com/G-Research/armada/internal/armada/configuration"
+	"github.com/G-Research/armada/internal/common"
 )
 
 func Test_matchRequirements(t *testing.T) {
@@ -25,4 +30,98 @@ func Test_matchRequirements(t *testing.T) {
 		{Labels: map[string]string{"x": "y"}},
 		{Labels: map[string]string{"armada/region": "eu", "armada/zone": "1", "x": "y"}},
 	}}))
+}
+
+func Test_distributeRemainder_highPriorityUserDoesNotBlockOthers(t *testing.T) {
+
+	queue1 := &api.Queue{Name: "queue1", PriorityFactor: 1}
+	queue2 := &api.Queue{Name: "queue2", PriorityFactor: 1}
+
+	scarcity := map[string]float64{"cpu": 1, "gpu": 1}
+
+	priorities := map[*api.Queue]QueuePriorityInfo{
+		queue1: {
+			Priority:     1000,
+			CurrentUsage: common.ComputeResources{"cpu": resource.MustParse("100"), "memory": resource.MustParse("80Gi")}},
+		queue2: {
+			Priority:     0.5,
+			CurrentUsage: common.ComputeResources{"cpu": resource.MustParse("0"), "memory": resource.MustParse("0")}},
+	}
+	requestSize := common.ComputeResources{"cpu": resource.MustParse("10"), "memory": resource.MustParse("1Gi")}
+
+	repository := &fakeJobQueueRepository{
+		jobsByQueue: map[string][]*api.Job{
+			"queue1": {
+				&api.Job{PodSpec: classicPodSpec},
+				&api.Job{PodSpec: classicPodSpec},
+				&api.Job{PodSpec: classicPodSpec},
+				&api.Job{PodSpec: classicPodSpec},
+				&api.Job{PodSpec: classicPodSpec},
+			},
+			"queue2": {
+				&api.Job{RequiredNodeLabels: map[string]string{"impossible": "label"}, PodSpec: classicPodSpec},
+			},
+		},
+	}
+
+	//ctx, _ := context.WithDeadline(context.Background(), time.Now().Add(time.Second))
+	ctx := context.Background()
+
+	c := leaseContext{
+		ctx: ctx,
+		schedulingConfig: &configuration.SchedulingConfig{
+			QueueLeaseBatchSize: 10,
+		},
+		onJobsLeased:     func(a []*api.Job) {},
+		request:          &api.LeaseRequest{ClusterId: "c1", Resources: requestSize},
+		resourceScarcity: scarcity,
+		priorities:       priorities,
+		slices:           SliceResource(scarcity, priorities, requestSize.AsFloat()),
+		repository:       repository,
+		queueCache:       map[string][]*api.Job{},
+	}
+
+	jobs, e := c.distributeRemainder(1000)
+	assert.Nil(t, e)
+	assert.Equal(t, 5, len(jobs))
+}
+
+var classicPodSpec = &v1.PodSpec{
+	Containers: []v1.Container{{
+		Name:  "Container1",
+		Image: "index.docker.io/library/ubuntu:latest",
+		Args:  []string{"sleep", "10s"},
+		Resources: v1.ResourceRequirements{
+			Requests: v1.ResourceList{"cpu": resource.MustParse("1"), "memory": resource.MustParse("1Mi")},
+			Limits:   v1.ResourceList{"cpu": resource.MustParse("1"), "memory": resource.MustParse("1Mi")},
+		}}}}
+
+type fakeJobQueueRepository struct {
+	jobsByQueue map[string][]*api.Job
+}
+
+func (r *fakeJobQueueRepository) PeekQueue(queue string, limit int64) ([]*api.Job, error) {
+	jobs, exists := r.jobsByQueue[queue]
+	if !exists {
+		return []*api.Job{}, nil
+	}
+	if int64(len(jobs)) > limit {
+		jobs = jobs[:limit]
+	}
+	return jobs, nil
+}
+
+func (r *fakeJobQueueRepository) TryLeaseJobs(clusterId string, queue string, jobs []*api.Job) ([]*api.Job, error) {
+	remainingJobs := []*api.Job{}
+outer:
+	for _, j := range r.jobsByQueue[queue] {
+		for _, l := range jobs {
+			if j == l {
+				continue outer
+			}
+		}
+		remainingJobs = append(remainingJobs, j)
+	}
+	r.jobsByQueue[queue] = remainingJobs
+	return jobs, nil
 }

--- a/internal/armada/scheduling/resources.go
+++ b/internal/armada/scheduling/resources.go
@@ -62,6 +62,22 @@ func ResourcesFloatAsUsage(resourceScarcity map[string]float64, resources common
 	return usage
 }
 
+func QueueSlicesToShares(resourceScarcity map[string]float64, slices map[*api.Queue]common.ComputeResourcesFloat) map[*api.Queue]float64 {
+	shares := map[*api.Queue]float64{}
+	for queue, slice := range slices {
+		shares[queue] = ResourcesFloatAsUsage(resourceScarcity, slice)
+	}
+	return shares
+}
+
+func SumQueueSlices(slices map[*api.Queue]common.ComputeResourcesFloat) common.ComputeResourcesFloat {
+	sum := common.ComputeResourcesFloat{}
+	for _, slice := range slices {
+		sum.Add(slice)
+	}
+	return sum
+}
+
 func ResourceScarcityFromReports(reports map[string]*api.ClusterUsageReport) map[string]float64 {
 	availableResources := sumReportResources(reports)
 	return calculateResourceScarcity(availableResources.AsFloat())

--- a/internal/armada/server/lease.go
+++ b/internal/armada/server/lease.go
@@ -81,7 +81,6 @@ func (q AggregatedQueueServer) LeaseJobs(ctx context.Context, request *api.Lease
 		request,
 		activeClusterReports,
 		clusterPriorities,
-		queues,
 		activeQueues)
 
 	if e != nil {


### PR DESCRIPTION
Once a queue does not have any jobs which can be scheduled, it is removed from the loop and remaining resources get sliced for remaining queues. Previously we did not slice the resources again so  the remaining queues could not use all possible resources.