### PR TITLE
Fixing watch when waitForNew = false

### DIFF
--- a/cmd/armadactl/cmd/analyze.go
+++ b/cmd/armadactl/cmd/analyze.go
@@ -46,6 +46,11 @@ var analyzeCmd = &cobra.Command{
 				return false
 			})
 
+			if jobState == nil {
+				log.Infof("No events found in jobset %s (queue: %s)", jobSetId, queue)
+				return
+			}
+
 			for id, jobInfo := range jobState.GetCurrentState() {
 				if jobInfo.Status != domain.Succeeded {
 					jobEvents := events[id]


### PR DESCRIPTION
Currently when waitForNew=false we make 2 calls
 - The first gets all the events up until now
 - The second will then call get events again but from the current (end) location

Then we rely on the second call getting 0 events (as it started watching from the end) to recognise it should exit.
 - We also go into the err handling block twice, print EOF twice and wait 10 seconds total

This is a terrible experience for the user, there is a 10 second delay and we print EOF a couple times.

Now we just exit when we see EOF returned from the stream, which is typical of how streams say they are finished.