### PR TITLE
Quickstart improvements

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -27,6 +27,29 @@ brew install helm kind kubernetes-cli
 
 Ensure at least 5GB of RAM are allocated to the Docker VM (see Preferences -> Resources -> Advanced).
 
+#### Windows
+
+You can install the pre-requisites with [Chocolatey](https://chocolatey.org):
+
+```cmd
+choco install git docker-desktop kubernetes-helm kind kubernetes-cli
+```
+
+Ensure at least 5GB of RAM are allocated to the Docker VM (see Settings -> Resources -> Advanced).
+
+In order to follow the instructions below as-is, you should also install [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/about).
+After you installed the distro of your choice, open a terminal and alias the following commands:
+
+```bash
+alias git=git.exe
+alias docker=docker.exe
+alias helm=helm.exe
+alias kind=kind.exe
+alias kubectl=kubectl.exe
+```
+
+All the commands below should be executed in a Windows directory (i.e. `/mnt/c/Users/<username>`) so change to it before going further.
+
 ### Helm
 
 Make sure helm is configured to use the official Helm stable charts:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -26,6 +26,14 @@ brew install helm kind kubernetes-cli
 
 Ensure at least 5GB of RAM are allocated to the Docker VM (see Preferences -> Resources -> Advanced).
 
+### Helm
+
+Make sure helm is configured to use the official Helm stable charts:
+
+```bash
+helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+```
+
 ## Installation
 This guide will install Armada on 3 local Kubernetes clusters; one server and two executor clusters. 
 
@@ -44,9 +52,6 @@ All commands are intended to be run from the root of the repository.
 kind create cluster --name quickstart-armada-server --config ./docs/quickstart/kind-config-server.yaml
 export KUBECONFIG=$(kind get kubeconfig-path --name="quickstart-armada-server")
 
-# Configure Helm
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
-
 # Install Redis
 helm install redis stable/redis-ha -f docs/quickstart/redis-values.yaml
 
@@ -64,9 +69,6 @@ kind create cluster --name quickstart-armada-executor-0 --config ./docs/quicksta
 export DOCKERHOSTIP=$(ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+')
 export KUBECONFIG=$(kind get kubeconfig-path --name="quickstart-armada-executor-0")	
 
-# Configure Helm
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
-
 # Install Prometheus
 helm install prometheus-operator stable/prometheus-operator -f docs/quickstart/executor-prometheus-values.yaml --set prometheus.service.nodePort=30002
 
@@ -79,9 +81,6 @@ Second executor:
 kind create cluster --name quickstart-armada-executor-1 --config ./docs/quickstart/kind-config-executor-1.yaml
 export DOCKERHOSTIP=$(ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+')
 export KUBECONFIG=$(kind get kubeconfig-path --name="quickstart-armada-executor-1")	
-
-# Configure Helm
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
 
 # Install Prometheus
 helm install prometheus-operator stable/prometheus-operator -f docs/quickstart/executor-prometheus-values.yaml --set prometheus.service.nodePort=30003

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -37,18 +37,7 @@ choco install git docker-desktop kubernetes-helm kind kubernetes-cli
 
 Ensure at least 5GB of RAM are allocated to the Docker VM (see Settings -> Resources -> Advanced).
 
-In order to follow the instructions below as-is, you should also install [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/about).
-After you installed the distro of your choice, open a terminal and alias the following commands:
-
-```bash
-alias git=git.exe
-alias docker=docker.exe
-alias helm=helm.exe
-alias kind=kind.exe
-alias kubectl=kubectl.exe
-```
-
-All the commands below should be executed in a Windows directory (i.e. `/mnt/c/Users/<username>`) so change to it before going further.
+All the commands below should be executed in Git Bash.
 
 ### Helm
 
@@ -128,7 +117,16 @@ curl -X POST -i http://admin:prom-operator@localhost:30001/api/dashboards/import
 
 The following steps download the `armadactl` CLI to the current directory:
 ```bash
-curl -L https://github.com/G-Research/armada/releases/download/$ARMADA_VERSION/armadactl-$ARMADA_VERSION-$(uname)-amd64.tar.gz | tar xzf -
+SYSTEM=$(uname | sed 's/MINGW.*/windows/' | tr A-Z a-z)
+if [ $SYSTEM == "windows" ]
+then
+  ARCHIVE_TYPE=zip
+  UNARCHIVE="zcat > armadactl.exe"
+else
+  ARCHIVE_TYPE=tar.gz
+  UNARCHIVE="tar xzf -"
+fi
+curl -L https://github.com/G-Research/armada/releases/download/$ARMADA_VERSION/armadactl-$ARMADA_VERSION-$SYSTEM-amd64.$ARCHIVE_TYPE | sh -c "$UNARCHIVE"
 ```
 
 ## Usage

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -50,7 +50,6 @@ All commands are intended to be run from the root of the repository.
 
 ```bash
 kind create cluster --name quickstart-armada-server --config ./docs/quickstart/kind-config-server.yaml
-export KUBECONFIG=$(kind get kubeconfig-path --name="quickstart-armada-server")
 
 # Install Redis
 helm install redis stable/redis-ha -f docs/quickstart/redis-values.yaml
@@ -67,7 +66,6 @@ First executor:
 ```bash
 kind create cluster --name quickstart-armada-executor-0 --config ./docs/quickstart/kind-config-executor-0.yaml
 export DOCKERHOSTIP=$(ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+')
-export KUBECONFIG=$(kind get kubeconfig-path --name="quickstart-armada-executor-0")	
 
 # Install Prometheus
 helm install prometheus-operator stable/prometheus-operator -f docs/quickstart/executor-prometheus-values.yaml --set prometheus.service.nodePort=30002
@@ -80,7 +78,6 @@ Second executor:
 ```bash
 kind create cluster --name quickstart-armada-executor-1 --config ./docs/quickstart/kind-config-executor-1.yaml
 export DOCKERHOSTIP=$(ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+')
-export KUBECONFIG=$(kind get kubeconfig-path --name="quickstart-armada-executor-1")	
 
 # Install Prometheus
 helm install prometheus-operator stable/prometheus-operator -f docs/quickstart/executor-prometheus-values.yaml --set prometheus.service.nodePort=30003

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -98,10 +98,7 @@ curl -X POST -i http://admin:prom-operator@localhost:30001/api/dashboards/import
 
 The following steps download the `armadactl` CLI to the current directory:
 ```bash
-armadaCtlTar=armadactl-$ARMADA_VERSION-linux-amd64.tar
-curl -LO https://github.com/G-Research/armada/releases/download/$ARMADA_VERSION/$armadaCtlTar.gz
-gunzip $armadaCtlTar.gz && tar xf $armadaCtlTar && rm $armadaCtlTar
-chmod u+x armadactl
+curl -L https://github.com/G-Research/armada/releases/download/$ARMADA_VERSION/armadactl-$ARMADA_VERSION-$(uname)-amd64.tar.gz | tar xzf -
 ```
 
 ## Usage

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -3,14 +3,28 @@
 The purpose of this guide is to install a minimal local Armada deployment for testing and evaluation purposes.
 
 ## Pre-requisites
-- Linux OS
+
 - Git
 - Docker
 - Helm v3
 - Kind
 - Kubectl
+### OS specifics
 
-N.B.  Ensure the current user has permission to run the `docker` command without `sudo`.
+#### Linux
+
+Ensure the current user has permission to run the `docker` command without `sudo`.
+
+#### macOS
+
+You can install the pre-requisites with [Homebrew](https://brew.sh):
+
+```bash
+brew cask install docker
+brew install helm kind kubernetes-cli
+```
+
+Ensure at least 5GB of RAM are allocated to the Docker VM (see Preferences -> Resources -> Advanced).
 
 ## Installation
 This guide will install Armada on 3 local Kubernetes clusters; one server and two executor clusters. 

--- a/docs/quickstart/executor-prometheus-values.yaml
+++ b/docs/quickstart/executor-prometheus-values.yaml
@@ -10,6 +10,7 @@ prometheus:
     ruleSelectorNilUsesHelmValues: false
   service:
     type: NodePort
+    nodePort: 30001
 
 prometheusOperator:
   admissionWebhooks:

--- a/docs/quickstart/executor-prometheus-values.yaml
+++ b/docs/quickstart/executor-prometheus-values.yaml
@@ -16,3 +16,4 @@ prometheusOperator:
     enabled: false
   tlsProxy:
     enabled: false
+  createCustomResource: false

--- a/docs/quickstart/kind-config-executor-0.yaml
+++ b/docs/quickstart/kind-config-executor-0.yaml
@@ -1,8 +1,0 @@
-kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha3
-nodes:
-- role: control-plane
-- role: worker
-  extraPortMappings:
-  - containerPort: 30002
-    hostPort: 30002

--- a/docs/quickstart/kind-config-executor.yaml
+++ b/docs/quickstart/kind-config-executor.yaml
@@ -3,6 +3,3 @@ apiVersion: kind.sigs.k8s.io/v1alpha3
 nodes:
 - role: control-plane
 - role: worker
-  extraPortMappings:
-  - containerPort: 30003
-    hostPort: 30003

--- a/docs/quickstart/kind-config-server.yaml
+++ b/docs/quickstart/kind-config-server.yaml
@@ -8,6 +8,3 @@ nodes:
     hostPort: 30000
   - containerPort: 30001
     hostPort: 30001
-  extraMounts:
-  - containerPath: /mounts
-    hostPath: /var/lib/kind/mounts

--- a/docs/quickstart/server-prometheus-values.yaml
+++ b/docs/quickstart/server-prometheus-values.yaml
@@ -15,3 +15,4 @@ prometheusOperator:
     enabled: false
   tlsProxy:
     enabled: false
+  createCustomResource: false


### PR DESCRIPTION
* Fix Prometheus installation warnings
* Make it work on macOS and Windows
* Remove obsolete and duplicate commands
* Do not rely on the Docker host IP