### PR TITLE
Increasing gaps between client retries

### DIFF
--- a/internal/common/client.go
+++ b/internal/common/client.go
@@ -6,5 +6,5 @@ import (
 )
 
 func ContextWithDefaultTimeout() (context.Context, context.CancelFunc) {
-	return context.WithTimeout(context.Background(), 5*time.Second)
+	return context.WithTimeout(context.Background(), 10*time.Second)
 }

--- a/pkg/client/connection.go
+++ b/pkg/client/connection.go
@@ -26,7 +26,7 @@ type ApiConnectionDetails struct {
 func CreateApiConnection(config *ApiConnectionDetails, additionalDialOptions ...grpc.DialOption) (*grpc.ClientConn, error) {
 
 	retryOpts := []grpc_retry.CallOption{
-		grpc_retry.WithBackoff(grpc_retry.BackoffExponential(300 * time.Millisecond)),
+		grpc_retry.WithBackoff(grpc_retry.BackoffExponential(1 * time.Second)),
 		grpc_retry.WithMax(3),
 	}
 


### PR DESCRIPTION
Currently all retries happen within 1.8s. This isn't that long and brief failures don't recover in time

This gives a little more time between retries to better handle temporary failures