### PR TITLE
Making cluster_context_test more reliable 

### DIFF
--- a/internal/executor/context/cluster_context_test.go
+++ b/internal/executor/context/cluster_context_test.go
@@ -390,6 +390,7 @@ func waitForContextSync(t *testing.T, context *KubernetesClusterContext, pods []
 		time.Sleep(50 * time.Millisecond)
 	}
 
+	t.Error("Timed out waiting for context sync. Submitted pods were never synced to context.")
 	t.Fail()
 }
 

--- a/internal/executor/context/cluster_context_test.go
+++ b/internal/executor/context/cluster_context_test.go
@@ -178,7 +178,7 @@ func TestKubernetesClusterContext_AddAnnotation(t *testing.T) {
 	assert.Nil(t, err)
 
 	updateOccurred := false
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 20; i++ {
 		pods, err := clusterContext.GetActiveBatchPods()
 		assert.Nil(t, err)
 		if pods[0].Annotations["test"] == "annotation" {
@@ -333,7 +333,7 @@ func TestKubernetesClusterContext_GetNodes(t *testing.T) {
 	assert.Nil(t, err)
 
 	nodeFound := false
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 20; i++ {
 		nodes, err := clusterContext.GetNodes()
 		assert.Nil(t, err)
 		if len(nodes) > 0 {
@@ -368,7 +368,7 @@ func submitPodsWithWait(t *testing.T, context *KubernetesClusterContext, pods ..
 }
 
 func waitForContextSync(t *testing.T, context *KubernetesClusterContext, pods []*v1.Pod) {
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 20; i++ {
 		existingPods, err := context.podInformer.Lister().List(labels.Everything())
 		assert.Nil(t, err)
 


### PR DESCRIPTION
The tests in this file occasionally fail
 - This is due to "transient" pods sometimes not being truly transient. This has been fixed by preventing the context from syncing when adding these "transient" pods, making them truly transient
 - The tests relied on the order of events between informer receiving new pod event, and then propagating it to the functions watching these events having finished before the asserts should happen

The tests no longer rely on any ordering and instead wait until the state becomes the expected one or fail if the desired state is not reached in a reasonable amount of time