### PR TITLE
Adding recorded metrics for resource metrics on armada server

### DIFF
--- a/deployment/armada/templates/prometheusrule.yaml
+++ b/deployment/armada/templates/prometheusrule.yaml
@@ -23,6 +23,12 @@ spec:
         - record: armada:queue:ideal_current_share
           expr: (armada:queue:size > bool 1) * (1 / armada:queue:priority) / scalar(sum((armada:queue:size > bool 1) * (1 / armada:queue:priority))) * 100
 
+        - record: armada:queue:resource:allocated
+          expr: avg(sum(armada_queue_resource_allocated) by (cluster, pod, resourceType)) by (cluster, resourceType)
+
+        - record: armada:queue:resource:used
+          expr: avg(sum(armada_queue_resource_used) by (cluster, pod, queueName, resourceType)) by (cluster, queueName, resourceType)
+
         - record: armada:grpc:server:histogram95
           expr: histogram_quantile(0.95, sum(rate(grpc_server_handling_seconds_bucket{grpc_type!="server_stream"}[10s])) by (grpc_method,grpc_service, le))
 
@@ -31,4 +37,10 @@ spec:
 
         - record: armada:log:rate
           expr: sum(rate(log_messages[30s])) by (level)
+
+        - record: armada:resource:available_capacity
+          expr: avg(armada_cluster_available_capacity) by (cluster, resourceType)
+
+        - record: armada:resource:capacity
+          expr: avg(armada_cluster_capacity) by (cluster, resourceType)
 {{- end }}

--- a/deployment/armada/templates/prometheusrule.yaml
+++ b/deployment/armada/templates/prometheusrule.yaml
@@ -24,7 +24,7 @@ spec:
           expr: (armada:queue:size > bool 1) * (1 / armada:queue:priority) / scalar(sum((armada:queue:size > bool 1) * (1 / armada:queue:priority))) * 100
 
         - record: armada:queue:resource:allocated
-          expr: avg(sum(armada_queue_resource_allocated) by (cluster, pod, resourceType)) by (cluster, resourceType)
+          expr: avg(sum(armada_queue_resource_allocated) by (cluster, pod, queueName, resourceType)) by (cluster, queueName, resourceType)
 
         - record: armada:queue:resource:used
           expr: avg(sum(armada_queue_resource_used) by (cluster, pod, queueName, resourceType)) by (cluster, queueName, resourceType)


### PR DESCRIPTION
Resource metrics need to be averaged to be usable, as all instances of the server provide the same metrics

These recorded metrics do the averaging for you:
 - Improve performance when using them
 - Convenience when using them