### PR TITLE
Add image tag in values.yaml for server and executor

### DIFF
--- a/deployment/armada/values.yaml
+++ b/deployment/armada/values.yaml
@@ -1,5 +1,6 @@
 image:
   repository: gresearchdev/armada-server
+  tag: v0.1.2
 resources:
   limits:
     memory: 1Gi

--- a/deployment/executor/values.yaml
+++ b/deployment/executor/values.yaml
@@ -1,5 +1,6 @@
 image:
   repository: gresearchdev/armada-executor
+  tag: v0.1.2
 resources:
   limits:
     memory: 1Gi


### PR DESCRIPTION
I was surprised that the `values.yaml` file for the server and the executor didn't include an image tag by default.  It's customary to include the version of the image in the `values.yaml` so that the chart knows what image it should use.  A user can always override it on the command-line with `--set image.tag=$ARMADA_VERSION`, but I think that would be a rare situation for an end-user rather than the norm.

Regarding documentation, I would vote to take all `$ARMADA_VERSION` references out from our examples.  It might be useful to use the command-line override in a development context when you want to push out new images often, but most end-users will expect to have the image set correctly within the chart they're using.  The docs are looking pretty good already, but I think our instructions would look even cleaner if we removed this parameter.

If there's some logic to leaving the image tag out of the values file that I'm missing, please let me know.  I just haven't seen this done before in all the helm charts I've seen.