### PR TITLE
Assume helm3 and change all 'helm template' commands to 'install'

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -71,14 +71,16 @@ helm install redis stable/redis-ha -f docs/quickstart/redis-values.yaml
 helm install prometheus-operator stable/prometheus-operator -f docs/quickstart/server-prometheus-values.yaml
 
 # Install Armada server
-helm template ./deployment/armada --set image.tag=$ARMADA_VERSION -f ./docs/quickstart/server-values.yaml | kubectl apply -f -
+helm install armada ./deployment/armada --set image.tag=$ARMADA_VERSION -f ./docs/quickstart/server-values.yaml
 
 # Get server IP for executors
 SERVER_IP=$(kubectl get nodes quickstart-armada-server-worker -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
 ```
+
 ### Executor deployments
 
 First executor:
+
 ```bash
 kind create cluster --name quickstart-armada-executor-0 --config ./docs/quickstart/kind-config-executor.yaml
 
@@ -86,13 +88,15 @@ kind create cluster --name quickstart-armada-executor-0 --config ./docs/quicksta
 helm install prometheus-operator stable/prometheus-operator -f docs/quickstart/executor-prometheus-values.yaml
 
 # Install executor
-helm template ./deployment/executor --set image.tag=$ARMADA_VERSION --set applicationConfig.apiConnection.armadaUrl="$SERVER_IP:30000" --set applicationConfig.apiConnection.forceNoTls=true --set prometheus.enabled=true --set applicationConfig.kubernetes.minimumPodAge=0s | kubectl apply -f -
-helm template ./deployment/executor-cluster-monitoring -f docs/quickstart/executor-cluster-monitoring-values.yaml --set interval=5s | kubectl apply -f -
+helm install executor ./deployment/executor --set image.tag=$ARMADA_VERSION --set applicationConfig.apiConnection.armadaUrl="$SERVER_IP:30000" -f docs/quickstart/executor-values.yaml
+helm install executor-cluster-monitoring ./deployment/executor-cluster-monitoring -f docs/quickstart/executor-cluster-monitoring-values.yaml
 
 # Get executor IP for Grafana
 EXECUTOR_0_IP=$(kubectl get nodes quickstart-armada-executor-0-worker -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
 ```
+
 Second executor:
+
 ```bash
 kind create cluster --name quickstart-armada-executor-1 --config ./docs/quickstart/kind-config-executor.yaml
 
@@ -100,8 +104,8 @@ kind create cluster --name quickstart-armada-executor-1 --config ./docs/quicksta
 helm install prometheus-operator stable/prometheus-operator -f docs/quickstart/executor-prometheus-values.yaml
 
 # Install executor
-helm template ./deployment/executor --set image.tag=$ARMADA_VERSION --set applicationConfig.apiConnection.armadaUrl="$SERVER_IP:30000" --set applicationConfig.apiConnection.forceNoTls=true --set prometheus.enabled=true --set applicationConfig.kubernetes.minimumPodAge=0s | kubectl apply -f -
-helm template ./deployment/executor-cluster-monitoring -f docs/quickstart/executor-cluster-monitoring-values.yaml --set interval=5s | kubectl apply -f -
+helm install executor ./deployment/executor --set image.tag=$ARMADA_VERSION --set applicationConfig.apiConnection.armadaUrl="$SERVER_IP:30000" -f docs/quickstart/executor-values.yaml
+helm install executor-cluster-monitoring ./deployment/executor-cluster-monitoring -f docs/quickstart/executor-cluster-monitoring-values.yaml
 
 # Get executor IP for Grafana
 EXECUTOR_1_IP=$(kubectl get nodes quickstart-armada-executor-1-worker -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')

--- a/docs/quickstart/executor-cluster-monitoring-values.yaml
+++ b/docs/quickstart/executor-cluster-monitoring-values.yaml
@@ -1,3 +1,5 @@
 additionalLabels:
   app: prometheus-operator
   release: prometheus-operator
+
+interval: 5s

--- a/docs/quickstart/executor-values.yaml
+++ b/docs/quickstart/executor-values.yaml
@@ -1,5 +1,8 @@
 applicationConfig:
   apiConnection:
+    ## Please note that this setting is insecure
+    ## Do not use this setting in a production environment
+    ## This should only be used for the quickstart and local testing
     forceNoTls: true 
   kubernetes:
     minimumPodAge: 0s

--- a/docs/quickstart/executor-values.yaml
+++ b/docs/quickstart/executor-values.yaml
@@ -1,0 +1,8 @@
+applicationConfig:
+  apiConnection:
+    forceNoTls: true 
+  kubernetes:
+    minimumPodAge: 0s
+
+prometheus:
+  enabled: true 

--- a/e2e/test/basic_test.go
+++ b/e2e/test/basic_test.go
@@ -109,7 +109,7 @@ func submitJobsAndWatch(t *testing.T, submitClient api.SubmitClient, eventsClien
 	_, err := client.SubmitJobs(submitClient, jobRequest)
 	assert.Nil(t, err)
 	receivedEvents := make(map[domain.JobStatus]bool)
-	timeout, _ := context.WithTimeout(context.Background(), 45*time.Second)
+	timeout, _ := context.WithTimeout(context.Background(), 60*time.Second)
 	client.WatchJobSet(eventsClient, jobRequest.Queue, jobRequest.JobSetId, true, timeout, func(state *domain.WatchContext, e api.Event) bool {
 		currentStatus := state.GetJobInfo(e.GetJobId()).Status
 		receivedEvents[currentStatus] = true


### PR DESCRIPTION
It felt a little weird to require Helm v3 and then do helm template piped to kubectl -- the old v2 way of avoiding using tiller. Doubly weird since half the instructions were to helm install and half were helm template.

So I changed everything to helm install on the assumption that new users will use Helm v3, like we require.

If we find that people are sending us lots of issues where we have to reply "please use helm v3, like the pre-reqs suggest," then we can always change everything back to helm template.

Oh, I also moved a few parameters to their respective values.yaml files. They didn't seem terribly interesting to me as a new user and just made the commands unnecessarily long. If anyone feels strongly that those parameters should be more visible to first time users, let me know.

-- I reopened this PR without a slash in the branch name, sorry for any confusion -- 