### PR TITLE
Add default armadactl config and kube command.

### DIFF
--- a/cmd/armadactl/cmd/kube.go
+++ b/cmd/armadactl/cmd/kube.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+
+	"github.com/G-Research/armada/internal/common"
+	"github.com/G-Research/armada/pkg/api"
+	"github.com/G-Research/armada/pkg/client"
+)
+
+func init() {
+	rootCmd.AddCommand(kubeCmd)
+
+	kubeCmd.Flags().String(
+		"jobId", "", "job to cancel")
+	kubeCmd.MarkFlagRequired("jobId")
+	kubeCmd.Flags().String(
+		"queue", "", "queue to cancel jobs from (requires job set to be specified)")
+	kubeCmd.MarkFlagRequired("queue")
+	kubeCmd.Flags().String(
+		"jobSet", "", "jobSet to cancel (requires queue to be specified)")
+	kubeCmd.MarkFlagRequired("jobSet")
+}
+
+var kubeCmd = &cobra.Command{
+	Use:   "kube",
+	Short: "output kubectl command to access pod information",
+	Long: `This command can be used to query kubernetes pods for a particular job.
+Example:
+	$(armadactl kube logs --queue my-queue --jobSet my-set --jobId 123456) -t 100
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		apiConnectionDetails := client.ExtractCommandlineArmadaApiConnectionDetails()
+
+		jobId, _ := cmd.Flags().GetString("jobId")
+		queue, _ := cmd.Flags().GetString("queue")
+		jobSetId, _ := cmd.Flags().GetString("jobSet")
+
+		verb := strings.Join(args, " ")
+
+		client.WithConnection(apiConnectionDetails, func(conn *grpc.ClientConn) {
+
+			eventsClient := api.NewEventClient(conn)
+			state := client.GetJobSetState(eventsClient, queue, jobSetId, context.Background())
+			jobInfo := state.GetJobInfo(jobId)
+
+			cmd := client.GetKubectlCommand(jobInfo.ClusterId, jobInfo.Job.Namespace, verb+" "+common.PodNamePrefix+jobId)
+
+			fmt.Println(cmd)
+		})
+	},
+}

--- a/cmd/armadactl/cmd/kube.go
+++ b/cmd/armadactl/cmd/kube.go
@@ -9,7 +9,6 @@ import (
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 
-	"github.com/G-Research/armada/internal/common"
 	"github.com/G-Research/armada/pkg/api"
 	"github.com/G-Research/armada/pkg/client"
 )
@@ -26,6 +25,8 @@ func init() {
 	kubeCmd.Flags().String(
 		"jobSet", "", "jobSet to cancel (requires queue to be specified)")
 	kubeCmd.MarkFlagRequired("jobSet")
+
+	kubeCmd.FParseErrWhitelist.UnknownFlags = true
 }
 
 var kubeCmd = &cobra.Command{
@@ -58,7 +59,7 @@ Example:
 				log.Fatalf("The job have no cluster allocated.")
 			}
 
-			cmd := client.GetKubectlCommand(jobInfo.ClusterId, jobInfo.Job.Namespace, verb+" "+common.PodNamePrefix+jobId)
+			cmd := client.GetKubectlCommand(jobInfo.ClusterId, jobInfo.Job.Namespace, jobId, verb)
 
 			fmt.Println(cmd)
 		})

--- a/cmd/armadactl/cmd/kube.go
+++ b/cmd/armadactl/cmd/kube.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 
@@ -48,6 +49,14 @@ Example:
 			eventsClient := api.NewEventClient(conn)
 			state := client.GetJobSetState(eventsClient, queue, jobSetId, context.Background())
 			jobInfo := state.GetJobInfo(jobId)
+
+			if jobInfo == nil {
+				log.Fatalf("Could not found job %s.", jobId)
+			}
+
+			if jobInfo.ClusterId == "" {
+				log.Fatalf("The job have no cluster allocated.")
+			}
 
 			cmd := client.GetKubectlCommand(jobInfo.ClusterId, jobInfo.Job.Namespace, verb+" "+common.PodNamePrefix+jobId)
 

--- a/cmd/armadactl/cmd/kube.go
+++ b/cmd/armadactl/cmd/kube.go
@@ -34,7 +34,10 @@ var kubeCmd = &cobra.Command{
 	Short: "output kubectl command to access pod information",
 	Long: `This command can be used to query kubernetes pods for a particular job.
 Example:
-	$(armadactl kube logs --queue my-queue --jobSet my-set --jobId 123456) -t 100
+	armadactl kube logs --queue my-queue --jobSet my-set --jobId 123456
+	
+In bash, you can execute it directly like this:
+	$(armadactl kube logs --queue my-queue --jobSet my-set --jobId 123456) --tail=20
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		apiConnectionDetails := client.ExtractCommandlineArmadaApiConnectionDetails()

--- a/cmd/armadactl/cmd/watch.go
+++ b/cmd/armadactl/cmd/watch.go
@@ -59,7 +59,7 @@ var watchCmd = &cobra.Command{
 						log.Errorf("Failure reason:\n%s\n", event.Reason)
 
 						jobInfo := state.GetJobInfo(event.JobId)
-						log.Errorf("You might be able to get the pod logs by running (logs are available for limited time):\n%s -t 100\n",
+						log.Errorf("You might be able to get the pod logs by running (logs are available for limited time):\n%s --tail=50\n",
 							client.GetKubectlCommand(jobInfo.ClusterId, jobInfo.Job.Namespace, event.JobId, "logs"))
 					}
 				}

--- a/cmd/armadactl/cmd/watch.go
+++ b/cmd/armadactl/cmd/watch.go
@@ -60,7 +60,7 @@ var watchCmd = &cobra.Command{
 
 						jobInfo := state.GetJobInfo(event.JobId)
 						log.Errorf("You might be able to get the pod logs by running (logs are available for limited time):\n%s -t 100\n",
-							client.GetKubectlCommand(jobInfo.ClusterId, jobInfo.Job.Namespace, "logs"))
+							client.GetKubectlCommand(jobInfo.ClusterId, jobInfo.Job.Namespace, event.JobId, "logs"))
 					}
 				}
 				if exit_on_inactive && state.GetNumberOfJobs() == state.GetNumberOfFinishedJobs() {

--- a/cmd/armadactl/cmd/watch.go
+++ b/cmd/armadactl/cmd/watch.go
@@ -57,6 +57,10 @@ var watchCmd = &cobra.Command{
 					switch event := e.(type) {
 					case *api.JobFailedEvent:
 						log.Errorf("Failure reason:\n%s\n", event.Reason)
+
+						jobInfo := state.GetJobInfo(event.JobId)
+						log.Errorf("You might be able to get the pod logs by running (logs are available for limited time):\n%s -t 100\n",
+							client.GetKubectlCommand(jobInfo.ClusterId, jobInfo.Job.Namespace, "logs"))
 					}
 				}
 				if exit_on_inactive && state.GetNumberOfJobs() == state.GetNumberOfFinishedJobs() {

--- a/internal/common/constants.go
+++ b/internal/common/constants.go
@@ -1,0 +1,3 @@
+package common
+
+const PodNamePrefix string = "armada-"

--- a/internal/executor/service/cluster_allocation.go
+++ b/internal/executor/service/cluster_allocation.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/G-Research/armada/internal/common"
 	"github.com/G-Research/armada/internal/executor/context"
 	"github.com/G-Research/armada/internal/executor/domain"
 	"github.com/G-Research/armada/internal/executor/reporter"
@@ -16,7 +17,6 @@ import (
 	"github.com/G-Research/armada/pkg/api"
 )
 
-const PodNamePrefix string = "armada-"
 const admissionWebhookValidationFailureMessage string = "admission webhook"
 
 type ClusterAllocationService struct {
@@ -147,7 +147,7 @@ func createPod(job *api.Job) *v1.Pod {
 
 	pod := v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        PodNamePrefix + job.Id,
+			Name:        common.PodNamePrefix + job.Id,
 			Labels:      labels,
 			Annotations: annotation,
 			Namespace:   job.Namespace,

--- a/internal/executor/service/cluster_allocation_test.go
+++ b/internal/executor/service/cluster_allocation_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"testing"
 
+	"github.com/G-Research/armada/internal/common"
 	"github.com/G-Research/armada/internal/executor/domain"
 	"github.com/G-Research/armada/pkg/api"
 
@@ -59,7 +60,7 @@ func TestCreatePod_CreatesExpectedPod(t *testing.T) {
 
 	expectedOutput := v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: PodNamePrefix + job.Id,
+			Name: common.PodNamePrefix + job.Id,
 			Labels: map[string]string{
 				domain.JobId: job.Id,
 				domain.Queue: job.Queue,

--- a/pkg/client/domain/watch.go
+++ b/pkg/client/domain/watch.go
@@ -93,8 +93,8 @@ func (context *WatchContext) updateStateSummary(oldJobStatus JobStatus, newJobSt
 	context.stateSummary[newJobStatus]++
 }
 
-func (context *WatchContext) GetJobInfo(jobId string) JobInfo {
-	return *context.state[jobId]
+func (context *WatchContext) GetJobInfo(jobId string) *JobInfo {
+	return context.state[jobId]
 }
 
 func (context *WatchContext) GetCurrentState() map[string]*JobInfo {

--- a/pkg/client/domain/watch.go
+++ b/pkg/client/domain/watch.go
@@ -25,6 +25,7 @@ type JobInfo struct {
 	Status     JobStatus
 	Job        *api.Job
 	LastUpdate time.Time
+	ClusterId  string
 }
 
 var statesToIncludeInSummary []JobStatus
@@ -169,6 +170,7 @@ func updateJobInfo(info *JobInfo, event api.Event) {
 		info.Status = Queued
 	case *api.JobLeasedEvent:
 		info.Status = Leased
+		info.ClusterId = typed.ClusterId
 	case *api.JobLeaseReturnedEvent:
 		info.Status = Queued
 	case *api.JobUnableToScheduleEvent:
@@ -177,12 +179,16 @@ func updateJobInfo(info *JobInfo, event api.Event) {
 		info.Status = Queued
 	case *api.JobPendingEvent:
 		info.Status = Pending
+		info.ClusterId = typed.ClusterId
 	case *api.JobRunningEvent:
 		info.Status = Running
+		info.ClusterId = typed.ClusterId
 	case *api.JobFailedEvent:
 		info.Status = Failed
+		info.ClusterId = typed.ClusterId
 	case *api.JobSucceededEvent:
 		info.Status = Succeeded
+		info.ClusterId = typed.ClusterId
 	case *api.JobReprioritizedEvent:
 		// TODO
 	case *api.JobTerminatedEvent:

--- a/pkg/client/domain/watch_test.go
+++ b/pkg/client/domain/watch_test.go
@@ -12,24 +12,24 @@ import (
 func TestWatchContext_ProcessEvent(t *testing.T) {
 	watchContext := NewWatchContext()
 
-	expected := JobInfo{Status: Pending}
+	expected := &JobInfo{Status: Pending}
 
 	watchContext.ProcessEvent(&api.JobPendingEvent{JobId: "1"})
 	result := watchContext.GetJobInfo("1")
 
-	assert.Equal(t, result, expected)
+	assert.Equal(t, expected, result)
 }
 
 func TestWatchContext_ProcessEvent_UpdatesExisting(t *testing.T) {
 	watchContext := NewWatchContext()
 
-	expected := JobInfo{Status: Running}
+	expected := &JobInfo{Status: Running}
 
 	watchContext.ProcessEvent(&api.JobPendingEvent{JobId: "1"})
 	watchContext.ProcessEvent(&api.JobRunningEvent{JobId: "1"})
 	result := watchContext.GetJobInfo("1")
 
-	assert.Equal(t, result, expected)
+	assert.Equal(t, expected, result)
 }
 
 func TestWatchContext_ProcessEvent_SubmittedEventAddsJobToJobInfo(t *testing.T) {
@@ -48,7 +48,7 @@ func TestWatchContext_ProcessEvent_SubmittedEventAddsJobToJobInfo(t *testing.T) 
 		},
 	}
 
-	expected := JobInfo{
+	expected := &JobInfo{
 		Status: Submitted,
 		Job:    &job,
 	}
@@ -56,7 +56,7 @@ func TestWatchContext_ProcessEvent_SubmittedEventAddsJobToJobInfo(t *testing.T) 
 	watchContext.ProcessEvent(&api.JobSubmittedEvent{JobId: "1", Job: job})
 	result := watchContext.GetJobInfo("1")
 
-	assert.Equal(t, result, expected)
+	assert.Equal(t, expected, result)
 }
 
 func TestWatchContext_GetCurrentState(t *testing.T) {
@@ -87,7 +87,7 @@ func TestWatchContext_GetCurrentStateSummary(t *testing.T) {
 	expected := "Queued:   1, Leased:   0, Pending:   1, Running:   1, Succeeded:   0, Failed:   0, Cancelled:   0"
 	result := watchContext.GetCurrentStateSummary()
 
-	assert.Equal(t, result, expected)
+	assert.Equal(t, expected, result)
 }
 
 func TestWatchContext_GetCurrentStateSummary_IsCorrectlyAlteredOnUpdateToExistingJob(t *testing.T) {
@@ -106,7 +106,7 @@ func TestWatchContext_GetNumberOfJobsInStates(t *testing.T) {
 	watchContext.ProcessEvent(&api.JobQueuedEvent{JobId: "1"})
 	result := watchContext.GetNumberOfJobsInStates([]JobStatus{Queued})
 
-	assert.Equal(t, result, 1)
+	assert.Equal(t, 1, result)
 }
 
 func TestWatchContext_GetNumberOfJobs(t *testing.T) {
@@ -115,12 +115,12 @@ func TestWatchContext_GetNumberOfJobs(t *testing.T) {
 	watchContext.ProcessEvent(&api.JobQueuedEvent{JobId: "1"})
 	result := watchContext.GetNumberOfJobs()
 
-	assert.Equal(t, result, 1)
+	assert.Equal(t, 1, result)
 
 	watchContext.ProcessEvent(&api.JobSucceededEvent{JobId: "73"})
 	result = watchContext.GetNumberOfJobs()
 
-	assert.Equal(t, result, 2)
+	assert.Equal(t, 2, result)
 }
 
 // Succeeded/failed/cancelled jobs are considered finished
@@ -128,35 +128,35 @@ func TestWatchContext_GetNumberOfFinishedJobs(t *testing.T) {
 	watchContext := NewWatchContext()
 
 	watchContext.ProcessEvent(&api.JobQueuedEvent{JobId: "1"})
-	assert.Equal(t, watchContext.GetNumberOfFinishedJobs(), 0)
+	assert.Equal(t, 0, watchContext.GetNumberOfFinishedJobs())
 
 	watchContext.ProcessEvent(&api.JobCancelledEvent{JobId: "1"})
-	assert.Equal(t, watchContext.GetNumberOfFinishedJobs(), 1)
+	assert.Equal(t, 1, watchContext.GetNumberOfFinishedJobs())
 
 	watchContext.ProcessEvent(&api.JobPendingEvent{JobId: "1"})
-	assert.Equal(t, watchContext.GetNumberOfFinishedJobs(), 0)
+	assert.Equal(t, 0, watchContext.GetNumberOfFinishedJobs())
 
 	watchContext.ProcessEvent(&api.JobSucceededEvent{JobId: "1"})
-	assert.Equal(t, watchContext.GetNumberOfFinishedJobs(), 1)
+	assert.Equal(t, 1, watchContext.GetNumberOfFinishedJobs())
 
 	watchContext.ProcessEvent(&api.JobLeasedEvent{JobId: "1"})
-	assert.Equal(t, watchContext.GetNumberOfFinishedJobs(), 0)
+	assert.Equal(t, 0, watchContext.GetNumberOfFinishedJobs())
 
 	watchContext.ProcessEvent(&api.JobRunningEvent{JobId: "2"})
-	assert.Equal(t, watchContext.GetNumberOfFinishedJobs(), 0)
+	assert.Equal(t, 0, watchContext.GetNumberOfFinishedJobs())
 
 	watchContext.ProcessEvent(&api.JobSucceededEvent{JobId: "2"})
 	watchContext.ProcessEvent(&api.JobFailedEvent{JobId: "1"})
-	assert.Equal(t, watchContext.GetNumberOfFinishedJobs(), 2)
+	assert.Equal(t, 2, watchContext.GetNumberOfFinishedJobs())
 }
 
 func TestWatchContext_GetNumberOfJobsInStates_IsCorrectlyUpdatedOnUpdateToExistingJobState(t *testing.T) {
 	watchContext := NewWatchContext()
 
 	watchContext.ProcessEvent(&api.JobQueuedEvent{JobId: "1"})
-	assert.Equal(t, watchContext.GetNumberOfJobsInStates([]JobStatus{Queued}), 1)
+	assert.Equal(t, 1, watchContext.GetNumberOfJobsInStates([]JobStatus{Queued}))
 
 	watchContext.ProcessEvent(&api.JobPendingEvent{JobId: "1"})
-	assert.Equal(t, watchContext.GetNumberOfJobsInStates([]JobStatus{Queued}), 0)
-	assert.Equal(t, watchContext.GetNumberOfJobsInStates([]JobStatus{Pending}), 1)
+	assert.Equal(t, 0, watchContext.GetNumberOfJobsInStates([]JobStatus{Queued}))
+	assert.Equal(t, 1, watchContext.GetNumberOfJobsInStates([]JobStatus{Pending}))
 }

--- a/pkg/client/kubectl.go
+++ b/pkg/client/kubectl.go
@@ -4,14 +4,16 @@ import (
 	"strings"
 
 	"github.com/spf13/viper"
+
+	"github.com/G-Research/armada/internal/common"
 )
 
-func GetKubectlCommand(cluster string, namespace string, cmd string) string {
+func GetKubectlCommand(cluster string, namespace string, jobId string, cmd string) string {
 	t := viper.GetString("kubectlCommandTemplate")
 	if t == "" {
-		t = "kubectl --context {{cluster}} -n {{namespace}} {{cmd}}"
+		t = "kubectl --context {{cluster}} -n {{namespace}} {{cmd}} {{pod}}"
 	}
-	r := strings.NewReplacer("{{cluster}}", cluster, "{{namespace}}", namespace, "{{cmd}}", cmd)
+	r := strings.NewReplacer("{{cluster}}", cluster, "{{namespace}}", namespace, "{{cmd}}", cmd, "{{pod}}", common.PodNamePrefix+jobId)
 	command := r.Replace(t)
 
 	return command

--- a/pkg/client/kubectl.go
+++ b/pkg/client/kubectl.go
@@ -9,7 +9,7 @@ import (
 func GetKubectlCommand(cluster string, namespace string, cmd string) string {
 	t := viper.GetString("kubectlCommandTemplate")
 	if t == "" {
-		t = "kubectl -n {{namespace}} {{cmd}}"
+		t = "kubectl --context {{cluster}} -n {{namespace}} {{cmd}}"
 	}
 	r := strings.NewReplacer("{{cluster}}", cluster, "{{namespace}}", namespace, "{{cmd}}", cmd)
 	command := r.Replace(t)

--- a/pkg/client/kubectl.go
+++ b/pkg/client/kubectl.go
@@ -1,0 +1,18 @@
+package client
+
+import (
+	"strings"
+
+	"github.com/spf13/viper"
+)
+
+func GetKubectlCommand(cluster string, namespace string, cmd string) string {
+	t := viper.GetString("kubectlCommandTemplate")
+	if t == "" {
+		t = "kubectl -n {{namespace}} {{cmd}}"
+	}
+	r := strings.NewReplacer("{{cluster}}", cluster, "{{namespace}}", namespace, "{{cmd}}", cmd)
+	command := r.Replace(t)
+
+	return command
+}


### PR DESCRIPTION
This adds new command to armadactl to create kubectl commands like this:
```
$(armadactl kube logs --queue my-queue --jobSet my-set --jobId 123456) -tail=100
$(armadactl kube describe pod --queue my-queue --jobSet my-set --jobId 123456)
```
Adds also global default armadactl config file.