### PR TITLE
Allow custom queue limits to be greater than the global limit

### DIFF
--- a/internal/armada/scheduling/lease.go
+++ b/internal/armada/scheduling/lease.go
@@ -93,13 +93,12 @@ func calculateQueueSchedulingLimits(
 	for _, queue := range activeQueues {
 		remainingGlobalLimit := resourceLimitPerQueue.DeepCopy()
 		if len(queue.ResourceLimits) > 0 {
-			//TODO This only allows customQueueLimit to lower globalLimit not increase it
 			customQueueLimit := totalCapacity.MulByResource(queue.ResourceLimits)
-			remainingGlobalLimit = remainingGlobalLimit.LimitWith(customQueueLimit)
+			remainingGlobalLimit = remainingGlobalLimit.MergeWith(customQueueLimit)
 		}
 		if usage, ok := currentQueueResourceAllocation[queue.Name]; ok {
 			remainingGlobalLimit.Sub(usage.AsFloat())
-			remainingGlobalLimit.LimitTo0()
+			remainingGlobalLimit.LimitToZero()
 		}
 
 		schedulingRoundLimit := schedulingLimitPerQueue.DeepCopy()

--- a/internal/armada/scheduling/resources.go
+++ b/internal/armada/scheduling/resources.go
@@ -42,11 +42,11 @@ func (info *QueueSchedulingInfo) UpdateLimits(resourceUsed common.ComputeResourc
 		}
 	}
 	info.remainingSchedulingLimit.Sub(resourceUsed)
-	info.remainingSchedulingLimit.LimitTo0()
+	info.remainingSchedulingLimit.LimitToZero()
 	info.schedulingShare = schedulingShareScaled
-	info.schedulingShare.LimitTo0()
+	info.schedulingShare.LimitToZero()
 	info.adjustedShare.Sub(resourceUsed)
-	info.adjustedShare.LimitTo0()
+	info.adjustedShare.LimitToZero()
 }
 
 func SliceResourceWithLimits(resourceScarcity map[string]float64, queueSchedulingInfo map[*api.Queue]*QueueSchedulingInfo, queuePriorities map[*api.Queue]QueuePriorityInfo, quantityToSlice common.ComputeResourcesFloat) map[*api.Queue]*QueueSchedulingInfo {

--- a/internal/common/resource.go
+++ b/internal/common/resource.go
@@ -158,7 +158,16 @@ func (a ComputeResourcesFloat) LimitWith(limit ComputeResourcesFloat) ComputeRes
 	return targetComputeResource
 }
 
-func (a ComputeResourcesFloat) LimitTo0() {
+//The merged in values take precedence and override existing values for the same key
+func (a ComputeResourcesFloat) MergeWith(merged ComputeResourcesFloat) ComputeResourcesFloat {
+	targetComputeResource := a.DeepCopy()
+	for key, value := range merged {
+		targetComputeResource[key] = value
+	}
+	return targetComputeResource
+}
+
+func (a ComputeResourcesFloat) LimitToZero() {
 	for key, value := range a {
 		a[key] = math.Max(value, 0)
 	}

--- a/internal/common/resource_test.go
+++ b/internal/common/resource_test.go
@@ -18,7 +18,7 @@ func TestComputeResourcesFloat_LimitTo0(t *testing.T) {
 	}
 
 	result := data.DeepCopy()
-	result.LimitTo0()
+	result.LimitToZero()
 
 	for key, value := range data {
 		resultValue := result[key]


### PR DESCRIPTION
It could be the case you want all queues to be capped at 40% except a special queue that is allowed 100%.
This change makes this possible, previously custom queue limits could only reduce the share from the global queue limits