### PR TITLE
Updating helm chart prometheusrule to use 2m as the rate interval

### DIFF
--- a/deployment/armada/templates/prometheusrule.yaml
+++ b/deployment/armada/templates/prometheusrule.yaml
@@ -30,10 +30,10 @@ spec:
           expr: avg(sum(armada_queue_resource_used) by (cluster, pod, queueName, resourceType)) by (cluster, queueName, resourceType)
 
         - record: armada:grpc:server:histogram95
-          expr: histogram_quantile(0.95, sum(rate(grpc_server_handling_seconds_bucket{grpc_type!="server_stream"}[10s])) by (grpc_method,grpc_service, le))
+          expr: histogram_quantile(0.95, sum(rate(grpc_server_handling_seconds_bucket{grpc_type!="server_stream"}[30s])) by (grpc_method,grpc_service, le))
 
         - record: armada:grpc:server:requestrate
-          expr: sum(rate(grpc_server_handled_total[10s])) by (grpc_method,grpc_service)
+          expr: sum(rate(grpc_server_handled_total[30s])) by (grpc_method,grpc_service)
 
         - record: armada:log:rate
           expr: sum(rate(log_messages[30s])) by (level)

--- a/deployment/armada/templates/prometheusrule.yaml
+++ b/deployment/armada/templates/prometheusrule.yaml
@@ -30,13 +30,13 @@ spec:
           expr: avg(sum(armada_queue_resource_used) by (cluster, pod, queueName, resourceType)) by (cluster, queueName, resourceType)
 
         - record: armada:grpc:server:histogram95
-          expr: histogram_quantile(0.95, sum(rate(grpc_server_handling_seconds_bucket{grpc_type!="server_stream"}[30s])) by (grpc_method,grpc_service, le))
+          expr: histogram_quantile(0.95, sum(rate(grpc_server_handling_seconds_bucket{grpc_type!="server_stream"}[2m])) by (grpc_method,grpc_service, le))
 
         - record: armada:grpc:server:requestrate
-          expr: sum(rate(grpc_server_handled_total[30s])) by (grpc_method,grpc_service)
+          expr: sum(rate(grpc_server_handled_total[2m])) by (grpc_method,grpc_service)
 
         - record: armada:log:rate
-          expr: sum(rate(log_messages[30s])) by (level)
+          expr: sum(rate(log_messages[2m])) by (level)
 
         - record: armada:resource:available_capacity
           expr: avg(armada_cluster_available_capacity) by (cluster, resourceType)

--- a/deployment/executor/templates/prometheusrule.yaml
+++ b/deployment/executor/templates/prometheusrule.yaml
@@ -15,8 +15,8 @@ spec:
       interval: {{ .Values.prometheus.scrapeInterval }}
       rules:
         - record: armada:executor:rest:request:histogram95
-          expr: histogram_quantile(0.95, sum(rate(rest_client_request_duration_seconds_bucket{service="{{ include "executor.name" . }}"}[30s])) by (endpoint, verb, url, le))
+          expr: histogram_quantile(0.95, sum(rate(rest_client_request_duration_seconds_bucket{service="{{ include "executor.name" . }}"}[2m])) by (endpoint, verb, url, le))
 
         - record: armada:executor:log:rate
-          expr: sum(rate(log_messages[30s])) by (level)
+          expr: sum(rate(log_messages[2m])) by (level)
 {{- end }}


### PR DESCRIPTION
The scrape interval is 10s, meaning at 30s we only get 3 datapoints which susceptible to fluctuations and at 10s we often get none (no data) which is unusable.

This makes the metrics less stable and want these as steadystate metrics.

Increasing to 2m, means we should get 12 datapoints, which will give us a much more steady metric.