### PR TITLE
Implement reconnecting for NATS Streaming lost connection.

### DIFF
--- a/internal/armada/repository/event_nats.go
+++ b/internal/armada/repository/event_nats.go
@@ -6,15 +6,16 @@ import (
 	stanPb "github.com/nats-io/stan.go/pb"
 	log "github.com/sirupsen/logrus"
 
+	stanUtil "github.com/G-Research/armada/internal/common/stan-util"
 	"github.com/G-Research/armada/pkg/api"
 )
 
 type NatsEventStore struct {
-	connection stan.Conn
+	connection *stanUtil.DurableConnection
 	subject    string
 }
 
-func NewNatsEventStore(connection stan.Conn, subject string) *NatsEventStore {
+func NewNatsEventStore(connection *stanUtil.DurableConnection, subject string) *NatsEventStore {
 	return &NatsEventStore{connection: connection, subject: subject}
 }
 
@@ -55,18 +56,18 @@ func (n *NatsEventStore) ReportEvents(messages []*api.EventMessage) error {
 }
 
 type NatsEventRedisProcessor struct {
-	connection stan.Conn
+	connection *stanUtil.DurableConnection
 	repository EventStore
 	subject    string
 	group      string
 }
 
-func NewNatsEventRedisProcessor(connection stan.Conn, repository EventStore, subject string, group string) *NatsEventRedisProcessor {
+func NewNatsEventRedisProcessor(connection *stanUtil.DurableConnection, repository EventStore, subject string, group string) *NatsEventRedisProcessor {
 	return &NatsEventRedisProcessor{connection: connection, repository: repository, subject: subject, group: group}
 }
 
 func (p *NatsEventRedisProcessor) Start() {
-	_, err := p.connection.QueueSubscribe(p.subject, p.group,
+	err := p.connection.QueueSubscribe(p.subject, p.group,
 		p.handleMessage,
 		stan.SetManualAckMode(),
 		stan.StartAt(stanPb.StartPosition_LastReceived),
@@ -84,7 +85,11 @@ func (p *NatsEventRedisProcessor) handleMessage(msg *stan.Msg) {
 	if err != nil {
 		log.Errorf("Error while unmarshaling nats message: %v", err)
 	} else {
-		p.repository.ReportEvents([]*api.EventMessage{eventMessage})
+		err := p.repository.ReportEvents([]*api.EventMessage{eventMessage})
+		if err != nil {
+			log.Errorf("Error while reporting event from nats: %v", err)
+			return
+		}
 	}
 	err = msg.Ack()
 	if err != nil {

--- a/internal/armada/server.go
+++ b/internal/armada/server.go
@@ -12,7 +12,6 @@ import (
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
-	"github.com/nats-io/stan.go"
 	"github.com/segmentio/kafka-go"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
@@ -24,6 +23,7 @@ import (
 	"github.com/G-Research/armada/internal/armada/repository"
 	"github.com/G-Research/armada/internal/armada/scheduling"
 	"github.com/G-Research/armada/internal/armada/server"
+	stan_util "github.com/G-Research/armada/internal/common/stan-util"
 	"github.com/G-Research/armada/internal/common/task"
 	"github.com/G-Research/armada/internal/common/util"
 	"github.com/G-Research/armada/pkg/api"
@@ -72,10 +72,10 @@ func Serve(config *configuration.ArmadaConfig) (func(), *sync.WaitGroup) {
 
 	} else if len(config.EventsNats.Servers) > 0 {
 
-		conn, err := stan.Connect(
+		conn, err := stan_util.DurableConnect(
 			config.EventsNats.ClusterID,
 			"armada-server-"+util.NewULID(),
-			stan.NatsURL(strings.Join(config.EventsNats.Servers, ",")),
+			strings.Join(config.EventsNats.Servers, ","),
 		)
 		if err != nil {
 			panic(err)

--- a/internal/common/stan-util/durable_connection.go
+++ b/internal/common/stan-util/durable_connection.go
@@ -1,0 +1,124 @@
+package stan_util
+
+import (
+	"sync"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/stan.go"
+	log "github.com/sirupsen/logrus"
+)
+
+type DurableConnection struct {
+	sync.RWMutex
+
+	options       []stan.Option
+	clientID      string
+	stanClusterID string
+
+	subscriptions []func(conn stan.Conn) error
+
+	currentConn stan.Conn
+	nc          *nats.Conn
+}
+
+func DurableConnect(stanClusterID, clientID, urls string, options ...stan.Option) (*DurableConnection, error) {
+	// as underlying NATS connection reconnects automatically, there is no need to renew it
+	// keeping one NATS connection around will make message ack work better during STAN connection lost event
+	nc, err := nats.Connect(urls,
+		nats.Name(clientID),
+		nats.MaxReconnects(-1),
+		nats.ReconnectBufSize(-1))
+
+	if err != nil {
+		return nil, err
+	}
+
+	conn := &DurableConnection{
+		stanClusterID: stanClusterID,
+		clientID:      clientID,
+		nc:            nc,
+	}
+	conn.options = append(options, stan.SetConnectionLostHandler(conn.onConnectionLost), stan.NatsConn(nc))
+	err = conn.reconnect()
+	return conn, err
+}
+
+func (c *DurableConnection) PublishAsync(subject string, data []byte, ah stan.AckHandler) (string, error) {
+	c.RLock()
+	defer c.RUnlock()
+
+	return c.currentConn.PublishAsync(subject, data, ah)
+}
+
+func (c *DurableConnection) QueueSubscribe(subject, qgroup string, cb stan.MsgHandler, opts ...stan.SubscriptionOption) error {
+	c.Lock()
+	defer c.Unlock()
+
+	s := func(conn stan.Conn) error {
+		_, err := conn.QueueSubscribe(subject, qgroup, cb, opts...)
+		return err
+	}
+	c.subscriptions = append(c.subscriptions, s)
+
+	return s(c.currentConn)
+}
+
+func (c *DurableConnection) Close() error {
+	c.Lock()
+	defer c.Unlock()
+
+	err := c.currentConn.Close()
+	c.nc.Close()
+	return err
+}
+
+func (c *DurableConnection) onConnectionLost(_ stan.Conn, e error) {
+	// this callback is started in new go routine, it can take all the time needed
+	for {
+		err := c.reconnect()
+		if err == nil {
+			return
+		}
+		log.Errorf("Error while reconnecting to STAN: %v", err)
+		time.Sleep(1 * time.Second)
+	}
+}
+
+func (c *DurableConnection) reconnect() error {
+	c.Lock()
+	defer c.Unlock()
+
+	// close any previous connection, just in case it was still open
+	if c.currentConn != nil {
+		c.closeConnection()
+	}
+
+	// reconnect
+	newConnection, err := stan.Connect(c.stanClusterID, c.clientID, c.options...)
+	c.currentConn = newConnection
+	if err != nil {
+		log.Errorf("Error while connecting to STAN: %v", err)
+		return err
+	}
+
+	// resubscribe
+	for _, s := range c.subscriptions {
+		err := s(c.currentConn)
+		if err != nil {
+			// on any subscription error consider connection unsuccessful
+			log.Errorf("Error while resubscribing to STAN: %v", err)
+			c.closeConnection()
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *DurableConnection) closeConnection() {
+	err := c.currentConn.Close()
+	if err != nil {
+		log.Errorf("Error while closing STAN connection: %v", err)
+	}
+}


### PR DESCRIPTION
NATS Streaming go library unfortunately does not reestablish connection if server side ping times out. In this case all subscriptions needs to be renewed as well. This PR implements more robust connection with ability to recreate the connection and resubscribe.

https://github.com/nats-io/stan.go#connection-status