### PR TITLE
Improve handling of watch in the case of out of order events

### DIFF
--- a/cmd/armadactl/cmd/watch.go
+++ b/cmd/armadactl/cmd/watch.go
@@ -59,8 +59,10 @@ var watchCmd = &cobra.Command{
 						log.Errorf("Failure reason:\n%s\n", event.Reason)
 
 						jobInfo := state.GetJobInfo(event.JobId)
-						log.Errorf("You might be able to get the pod logs by running (logs are available for limited time):\n%s --tail=50\n",
-							client.GetKubectlCommand(jobInfo.ClusterId, jobInfo.Job.Namespace, event.JobId, "logs"))
+						if jobInfo != nil && jobInfo.ClusterId != "" && jobInfo.Job != nil {
+							log.Errorf("You might be able to get the pod logs by running (logs are available for limited time):\n%s --tail=50\n",
+								client.GetKubectlCommand(jobInfo.ClusterId, jobInfo.Job.Namespace, event.JobId, "logs"))
+						}
 					}
 				}
 				if exit_on_inactive && state.GetNumberOfJobs() == state.GetNumberOfFinishedJobs() {

--- a/pkg/client/domain/watch.go
+++ b/pkg/client/domain/watch.go
@@ -157,6 +157,9 @@ func (context *WatchContext) AreJobsFinished(ids []string) bool {
 
 func updateJobInfo(info *JobInfo, event api.Event) {
 	if info.LastUpdate.After(event.GetCreated()) {
+		if submitEvent, ok := event.(*api.JobSubmittedEvent); ok {
+			info.Job = &submitEvent.Job
+		}
 		// skipping event as it is out of time order
 		return
 	}


### PR DESCRIPTION
 - Handling JobInfo.Job details being set even when submitEvent is out of the expected order
 - Making watch handle when information is not present when logging FailEvent information
   - Currently if information isn't present, it'll panic. Meaning you cannot monitor the jobset anymore
   - Now if some information it wants to provide the user is missing, it just continues on allowing the user to see the whole jobset