### PR TITLE
Making client + loadtest more user friendly and flexible

### DIFF
--- a/cmd/armada-load-tester/cmd/loadtest.go
+++ b/cmd/armada-load-tester/cmd/loadtest.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"os"
 
 	log "github.com/sirupsen/logrus"
@@ -65,7 +66,6 @@ var loadtestCmd = &cobra.Command{
 		watchEvents := viper.GetBool("watch")
 		apiConnectionDetails := client.ExtractCommandlineArmadaApiConnectionDetails()
 		loadTester := client.NewArmadaLoadTester(apiConnectionDetails)
-
-		loadTester.RunSubmissionTest(*loadTestSpec, watchEvents)
+		loadTester.RunSubmissionTest(context.Background(), *loadTestSpec, watchEvents)
 	},
 }

--- a/cmd/armadactl/cmd/submit.go
+++ b/cmd/armadactl/cmd/submit.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/G-Research/armada/pkg/api"
 	"github.com/G-Research/armada/pkg/client"
+	"github.com/G-Research/armada/pkg/client/domain"
 	"github.com/G-Research/armada/pkg/client/util"
 	"github.com/G-Research/armada/pkg/client/validation"
 )
@@ -16,12 +17,6 @@ import (
 func init() {
 	rootCmd.AddCommand(submitCmd)
 	submitCmd.Flags().Bool("dry-run", false, "Performs basic validation on the submitted file. Does no actual submission of jobs to the server.")
-}
-
-type JobSubmitFile struct {
-	Queue    string
-	JobSetId string
-	Jobs     []*api.JobSubmitRequestItem `json:"jobs"`
 }
 
 var submitCmd = &cobra.Command{
@@ -50,7 +45,7 @@ var submitCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		submitFile := &JobSubmitFile{}
+		submitFile := &domain.JobSubmitFile{}
 		err = util.BindJsonOrYaml(filePath, submitFile)
 
 		if err != nil {

--- a/pkg/client/domain/types.go
+++ b/pkg/client/domain/types.go
@@ -4,6 +4,8 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+
+	"github.com/G-Research/armada/pkg/api"
 )
 
 type LoadTestSpecification struct {
@@ -29,4 +31,10 @@ type JobSubmissionDescription struct {
 	DelaySubmit        time.Duration
 	Priority           float64
 	Spec               *v1.PodSpec
+}
+
+type JobSubmitFile struct {
+	Queue    string
+	JobSetId string
+	Jobs     []*api.JobSubmitRequestItem `json:"jobs"`
 }


### PR DESCRIPTION
- Moving JobSubmitFile to pkg/client. This is very useful for users who want to submit from file, which we do quite a bit. This just means they can use the "supported" type
- Making loadtest watch respect context deadline.
  - This is handy when programmatically running a loadtest that you want to have a timeout. Currently you just have to wait until it ends or kill the program
- Making loadtest return aggregated current state at the end. If you don't use set watchEvents = true, it'll return nil.
  - This is handy when running a load test. As it allows you to evaluate the state at the end (i.e did all my jobs complete successfully).