### PR TITLE
Making Unix SPNEGOCredential not look up user unnecessarily

### DIFF
--- a/pkg/client/auth/kerberos/spnego_unix.go
+++ b/pkg/client/auth/kerberos/spnego_unix.go
@@ -43,12 +43,12 @@ func NewSPNEGOCredentials(serverUrl string, spnegoConfig ClientConfig) (grpc_cre
 		return nil, err
 	}
 
-	currentUser, err := user.Current()
-	if err != nil {
-		return nil, err
-	}
 	credentialsCachePath := os.Getenv("KRB5CCNAME")
 	if credentialsCachePath == "" {
+		currentUser, err := user.Current()
+		if err != nil {
+			return nil, err
+		}
 		credentialsCachePath = "/tmp/krb5cc_" + currentUser.Uid
 	}
 


### PR DESCRIPTION
This is a minor optimisation

This also helps when you are running a container without a user specified inside it (or only root but you may not be running as root)
 - It will error when doing user.Current(), however it shouldn't be needed if you specify KRB5CCNAME explicitly