### PR TITLE
Adding flags --timeout and --checkSuccess to loadtester

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,9 @@ jobs:
             docker tag armadactl gresearchdev/armada-armadactl-dev:${TAG}
             docker push gresearchdev/armada-armadactl-dev:${TAG}
 
+            docker tag armadactl gresearchdev/armada-load-tester-dev:${TAG}
+            docker push gresearchdev/armada-load-tester-dev:${TAG}
+
             docker tag armada-fakeexecutor gresearchdev/armada-fakeexecutor-dev:${TAG}
             docker push gresearchdev/armada-fakeexecutor-dev:${TAG}
   deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
             docker tag armadactl gresearchdev/armada-armadactl-dev:${TAG}
             docker push gresearchdev/armada-armadactl-dev:${TAG}
 
-            docker tag armadactl gresearchdev/armada-load-tester-dev:${TAG}
+            docker tag armada-load-tester gresearchdev/armada-load-tester-dev:${TAG}
             docker push gresearchdev/armada-load-tester-dev:${TAG}
 
             docker tag armada-fakeexecutor gresearchdev/armada-fakeexecutor-dev:${TAG}

--- a/build/armada-load-tester/Dockerfile
+++ b/build/armada-load-tester/Dockerfile
@@ -1,0 +1,13 @@
+FROM alpine:3.10
+
+RUN apk update && apk add --no-cache ca-certificates
+
+RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
+
+USER armada
+
+COPY ./bin/linux/armada-load-tester /app/
+
+WORKDIR /app
+
+ENTRYPOINT ["./armada-load-tester"]

--- a/cmd/armada-load-tester/cmd/loadtest.go
+++ b/cmd/armada-load-tester/cmd/loadtest.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"context"
 	"os"
+	"strings"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -13,10 +15,16 @@ import (
 	"github.com/G-Research/armada/pkg/client/util"
 )
 
+const defaultTimeout = time.Second * -1
+
 func init() {
 	rootCmd.AddCommand(loadtestCmd)
 	loadtestCmd.Flags().Bool("watch", false, "If enabled, the program will watch the events of all submitted jobs before exiting")
+	loadtestCmd.Flags().Duration("timeout", defaultTimeout, "The duration the test will last for, before cancelling all remaining jobs")
+	loadtestCmd.Flags().Bool("checkSuccess", false, "If enabled, the program will exit with -1 if any jobs submitted do not succeed")
 	viper.BindPFlag("watch", loadtestCmd.Flags().Lookup("watch"))
+	viper.BindPFlag("timeout", loadtestCmd.Flags().Lookup("timeout"))
+	viper.BindPFlag("checkSuccess", loadtestCmd.Flags().Lookup("checkSuccess"))
 }
 
 var loadtestCmd = &cobra.Command{
@@ -64,8 +72,42 @@ var loadtestCmd = &cobra.Command{
 		}
 
 		watchEvents := viper.GetBool("watch")
+		timeout := viper.GetDuration("timeout")
+		checkSuccess := viper.GetBool("checkSuccess")
+
+		loadTestTimeout := context.Background()
+		if timeout != defaultTimeout {
+			loadTestTimeout, _ = context.WithTimeout(context.Background(), timeout)
+		}
 		apiConnectionDetails := client.ExtractCommandlineArmadaApiConnectionDetails()
 		loadTester := client.NewArmadaLoadTester(apiConnectionDetails)
-		loadTester.RunSubmissionTest(context.Background(), *loadTestSpec, watchEvents)
+		result := loadTester.RunSubmissionTest(loadTestTimeout, *loadTestSpec, watchEvents)
+
+		if watchEvents && checkSuccess {
+			checkLoadTestSuccess(loadTestTimeout, result, loadTestSpec)
+		}
 	},
+}
+
+func checkLoadTestSuccess(loadTestDeadline context.Context, result domain.LoadTestSummary, loadTestSpec *domain.LoadTestSpecification) {
+	if loadTestDeadline.Err() != nil {
+		log.Error("Fail: Test timed out")
+		os.Exit(1)
+	}
+
+	if len(result.SubmittedJobs) != loadTestSpec.NumberOfJobsInSpecification() {
+		log.Error("Fail: Did not submit as many jobs as were in the test specification")
+		os.Exit(1)
+	}
+
+	nonSuccessfulJobs := make([]string, 0, 10)
+	for _, jobId := range result.SubmittedJobs {
+		if result.CurrentState.GetJobInfo(jobId).Status != domain.Succeeded {
+			nonSuccessfulJobs = append(nonSuccessfulJobs, jobId)
+		}
+	}
+	if len(nonSuccessfulJobs) > 0 {
+		log.Error("Fail: The following jobs have not completed successfully %s", strings.Join(nonSuccessfulJobs, ","))
+		os.Exit(1)
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/nats-io/nats-server/v2 v2.1.6 // indirect
 	github.com/nats-io/nats-streaming-server v0.17.0 // indirect
+	github.com/nats-io/nats.go v1.9.2
 	github.com/nats-io/stan.go v0.6.0
 	github.com/oklog/ulid v1.3.1
 	github.com/prometheus/client_golang v1.2.1

--- a/makefile
+++ b/makefile
@@ -43,6 +43,10 @@ build-docker-executor:
 	$(gobuildlinux) -o ./bin/linux/executor cmd/executor/main.go
 	docker build $(dockerFlags) -t armada-executor -f ./build/executor/Dockerfile .
 
+build-docker-armada-load-tester:
+	$(gobuildlinux) -o ./bin/linux/armada-load-tester cmd/armada-load-tester/main.go
+	docker build $(dockerFlags) -t armada-load-tester -f ./build/armada-load-tester/Dockerfile .
+
 build-docker-armadactl:
 	$(gobuildlinux) -o ./bin/linux/armadactl cmd/armadactl/main.go
 	docker build $(dockerFlags) -t armadactl -f ./build/armadactl/Dockerfile .
@@ -51,7 +55,7 @@ build-docker-fakeexecutor:
 	$(gobuildlinux) -o ./bin/linux/fakeexecutor cmd/fakeexecutor/main.go
 	docker build $(dockerFlags) -t armada-fakeexecutor -f ./build/fakeexecutor/Dockerfile .
 
-build-docker: build-docker-server build-docker-executor build-docker-armadactl build-docker-fakeexecutor
+build-docker: build-docker-server build-docker-executor build-docker-armadactl build-docker-armada-load-tester build-docker-fakeexecutor
 
 build-ci: gobuild=$(gobuildlinux)
 build-ci: build-docker build-armadactl build-load-tester

--- a/pkg/client/domain/types.go
+++ b/pkg/client/domain/types.go
@@ -38,3 +38,18 @@ type JobSubmitFile struct {
 	JobSetId string
 	Jobs     []*api.JobSubmitRequestItem `json:"jobs"`
 }
+
+type LoadTestSummary struct {
+	SubmittedJobs []string
+	CurrentState  *WatchContext
+}
+
+func (loadTest LoadTestSpecification) NumberOfJobsInSpecification() int {
+	numberOfJobs := 0
+	for _, submission := range loadTest.Submissions {
+		for _, jobDescription := range submission.Jobs {
+			numberOfJobs += jobDescription.Count * submission.Count
+		}
+	}
+	return numberOfJobs
+}


### PR DESCRIPTION
--timeout - If the test exceeds this time, it'll stop and cancel all jobs in the run
--checkSuccess - Once all jobs have finished, it'll check all jobs finished with success, otherwise it'll end with exit code 1

Submit also now adheres to context timeout