### PR TITLE
Not marking pods as done if the ReportDone api call fails

### DIFF
--- a/internal/executor/service/job_lease.go
+++ b/internal/executor/service/job_lease.go
@@ -142,8 +142,10 @@ func (jobLeaseService *JobLeaseService) ReportDone(pods []*v1.Pod) error {
 	defer cancel()
 	log.Infof("Reporting done for jobs %s", strings.Join(jobIds, ","))
 	_, err := jobLeaseService.queueClient.ReportDone(ctx, &api.IdList{Ids: jobIds})
+	if err == nil {
+		jobLeaseService.markAsDone(pods)
+	}
 
-	jobLeaseService.markAsDone(pods)
 	return err
 }
 


### PR DESCRIPTION
Currently the API call can fail, but the pods are still marked and done and deleted.

This causes the lease of these jobs to expire (as they weren't properly closed off) and the jobs to be resubmitted.

Now we only mark the pods as done, if the API call succeeds.