### PR TITLE
Create a branch when updating charts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,10 +94,11 @@ commands:
         name: Commit and push updated charts
         command: |
           cd charts
+          git checkout -b circlci-armada_$RELEASE_TAG
           git -c user.name='GR OSS' -c user.email=github@gr-oss.io commit -qam "Pushing new helm charts at version $RELEASE_TAG"
           eval "$(ssh-agent -s)"
           echo -e "$ARMADA_CHART_UPDATE_KEY" | ssh-add - > /dev/null
-          git push -q origin master
+          git push -q origin HEAD
 
 jobs:
   build:


### PR DESCRIPTION
Because of branch protection on https://github.com/G-Research/charts, we can't simply push the Armada chart to master over in that repository.

For the moment, we will:
* Create and push a new branch named `circleci-armada_VERSION` to the charts repo
* Have a GH Action that triggers whenever a new branch matching `circleci-armada_*` is pushed and creates a new PR
* Have a human push the button to merge that new PR into the charts repo.

This PR should wait until https://github.com/G-Research/charts/pull/22 is merged before it will work correctly.

This at least gets us close to a fully automated deployment of a new version of Armada and unblocks us from a failing release job.