### PR TITLE
Adding locking on delete in UtilisationEventReporter

### DIFF
--- a/internal/executor/service/job_utilisation_reporter.go
+++ b/internal/executor/service/job_utilisation_reporter.go
@@ -123,6 +123,8 @@ func (r *UtilisationEventReporter) deletePod(pod *v1.Pod) {
 	if !util.IsManagedPod(pod) {
 		return
 	}
+	r.dataAccessMutex.Lock()
+	defer r.dataAccessMutex.Unlock()
 	delete(r.podInfo, pod.Name)
 }
 


### PR DESCRIPTION
We have been seeing a fatal error occasionally on concurrent map access we believe is coming from UtilisationEventReporter.

It looks like the lack of locking on delete is the most likely candidate (We can be iterating and deleting at the same time due to lack of the lock).