### PR TITLE
Small fixes to charts.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,8 +93,10 @@ commands:
     - run:
         name: Commit and push updated charts
         command: |
+          RELEASE_TAG=${CIRCLE_TAG}
           cd charts
           git checkout -b circlci-armada_$RELEASE_TAG
+          git add ./armada
           git -c user.name='GR OSS' -c user.email=github@gr-oss.io commit -qam "Pushing new helm charts at version $RELEASE_TAG"
           eval "$(ssh-agent -s)"
           echo -e "$ARMADA_CHART_UPDATE_KEY" | ssh-add - > /dev/null

--- a/deployment/armada/templates/deployment.yaml
+++ b/deployment/armada/templates/deployment.yaml
@@ -17,6 +17,8 @@ spec:
   template:
     metadata:
       name: {{ include "armada.name" . }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       labels:
         {{- include "armada.labels.all" . | nindent 8 }}
     spec:

--- a/deployment/executor/templates/deployment.yaml
+++ b/deployment/executor/templates/deployment.yaml
@@ -13,6 +13,8 @@ spec:
   template:
     metadata:
       name: {{ include "executor.name" . }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       labels:
         {{- include "executor.labels.all" . | nindent 8 }}
     spec:

--- a/deployment/executor/templates/serviceaccount.yaml
+++ b/deployment/executor/templates/serviceaccount.yaml
@@ -6,5 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "executor.labels.all" . | nindent 4 }}
+{{ if .Values.serviceAccount }}
 {{ toYaml .Values.serviceAccount }}
+{{ end} }
 {{ end }}

--- a/deployment/executor/values.yaml
+++ b/deployment/executor/values.yaml
@@ -17,7 +17,7 @@ tolerations:
     key: node-role.kubernetes.io/master
     operator: Exists
 customServiceAccount: null
-serviceAccount: {}
+serviceAccount: null
 
 prometheus:
   enabled: false


### PR DESCRIPTION
- Missing service account in executor chart won't cause problems anymore.
- Changing config will redeploy pods, thanks to checksum in annotation.
- Fix circleci release pipeline to push charts into charts repository.