### PR TITLE
Checking jobs meet the minimumJobSize when scheduling them

### DIFF
--- a/internal/armada/scheduling/lease.go
+++ b/internal/armada/scheduling/lease.go
@@ -254,7 +254,7 @@ func (c *leaseContext) leaseJobs(queue *api.Queue, slice common.ComputeResources
 			requirement := common.TotalResourceRequest(job.PodSpec).AsFloat()
 			remainder = slice.DeepCopy()
 			remainder.Sub(requirement)
-			if remainder.IsValid() {
+			if isLargeEnough(job, c.minimumJobSize) && remainder.IsValid() {
 				nodeType, ok := matchAnyNodeTypeAllocation(job, c.nodeResources, consumedNodeResources)
 				if ok {
 					slice = remainder

--- a/internal/armada/scheduling/lease_test.go
+++ b/internal/armada/scheduling/lease_test.go
@@ -22,15 +22,11 @@ func Test_minimumJobSize(t *testing.T) {
 	}
 	job := &api.Job{PodSpec: &v1.PodSpec{Containers: []v1.Container{{Resources: resourceRequirement}}}}
 
-	assert.True(t, isLargeEnough(job, &api.ClusterSchedulingInfoReport{
-		MinimumJobSize: common.ComputeResources{"cpu": resource.MustParse("2")}}))
-	assert.True(t, isLargeEnough(job, &api.ClusterSchedulingInfoReport{
-		MinimumJobSize: common.ComputeResources{}}))
+	assert.True(t, isLargeEnough(job, common.ComputeResources{"cpu": resource.MustParse("2")}))
+	assert.True(t, isLargeEnough(job, common.ComputeResources{}))
 
-	assert.False(t, isLargeEnough(job, &api.ClusterSchedulingInfoReport{
-		MinimumJobSize: common.ComputeResources{"cpu": resource.MustParse("5")}}))
-	assert.False(t, isLargeEnough(job, &api.ClusterSchedulingInfoReport{
-		MinimumJobSize: common.ComputeResources{"gpu": resource.MustParse("1")}}))
+	assert.False(t, isLargeEnough(job, common.ComputeResources{"cpu": resource.MustParse("5")}))
+	assert.False(t, isLargeEnough(job, common.ComputeResources{"gpu": resource.MustParse("1")}))
 }
 
 func Test_distributeRemainder_highPriorityUserDoesNotBlockOthers(t *testing.T) {

--- a/internal/armada/scheduling/node_matching.go
+++ b/internal/armada/scheduling/node_matching.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/G-Research/armada/internal/common"
 	"github.com/G-Research/armada/pkg/api"
@@ -38,10 +37,9 @@ func MatchSchedulingRequirements(job *api.Job, schedulingInfo *api.ClusterSchedu
 		matchAnyNodeType(job, schedulingInfo.NodeTypes)
 }
 
-func isLargeEnough(job *api.Job, minimumJobSize map[string]resource.Quantity) bool {
+func isLargeEnough(job *api.Job, minimumJobSize common.ComputeResources) bool {
 	resourceRequest := common.TotalResourceRequest(job.PodSpec)
-	minimum := common.ComputeResources(minimumJobSize)
-	resourceRequest.Sub(minimum)
+	resourceRequest.Sub(minimumJobSize)
 	return resourceRequest.IsValid()
 }
 

--- a/internal/armada/scheduling/node_matching.go
+++ b/internal/armada/scheduling/node_matching.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/G-Research/armada/internal/common"
 	"github.com/G-Research/armada/pkg/api"
@@ -33,13 +34,13 @@ func extractNodeTypes(allocations []*nodeTypeAllocation) []*api.NodeType {
 }
 
 func MatchSchedulingRequirements(job *api.Job, schedulingInfo *api.ClusterSchedulingInfoReport) bool {
-	return isLargeEnough(job, schedulingInfo) &&
+	return isLargeEnough(job, schedulingInfo.MinimumJobSize) &&
 		matchAnyNodeType(job, schedulingInfo.NodeTypes)
 }
 
-func isLargeEnough(job *api.Job, schedulingInfo *api.ClusterSchedulingInfoReport) bool {
+func isLargeEnough(job *api.Job, minimumJobSize map[string]resource.Quantity) bool {
 	resourceRequest := common.TotalResourceRequest(job.PodSpec)
-	minimum := common.ComputeResources(schedulingInfo.MinimumJobSize)
+	minimum := common.ComputeResources(minimumJobSize)
 	resourceRequest.Sub(minimum)
 	return resourceRequest.IsValid()
 }


### PR DESCRIPTION
Jobs should be at least as big as minimumJobSize requirements of the cluster to be allowed to be scheduled on that cluster.

Currently we use this feature to make sure only GPU jobs go to GPU clusters. However as we aren't filtering jobs on job size when scheduling, we are seeing CPU jobs be sent to GPU clusters.