### PR TITLE
Update cert-manager annotations for Ingress resources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,8 +93,10 @@ commands:
     - run:
         name: Commit and push updated charts
         command: |
+          RELEASE_TAG=${CIRCLE_TAG}
           cd charts
           git checkout -b circlci-armada_$RELEASE_TAG
+          git add ./armada
           git -c user.name='GR OSS' -c user.email=github@gr-oss.io commit -qam "Pushing new helm charts at version $RELEASE_TAG"
           eval "$(ssh-agent -s)"
           echo -e "$ARMADA_CHART_UPDATE_KEY" | ssh-add - > /dev/null

--- a/deployment/armada/templates/deployment.yaml
+++ b/deployment/armada/templates/deployment.yaml
@@ -17,6 +17,8 @@ spec:
   template:
     metadata:
       name: {{ include "armada.name" . }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       labels:
         {{- include "armada.labels.all" . | nindent 8 }}
     spec:

--- a/deployment/armada/templates/ingress.yaml
+++ b/deployment/armada/templates/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
     kubernetes.io/ingress.class: {{ required "A value is required for .Values.ingressClass" .Values.ingressClass }}
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
-    certmanager.k8s.io/cluster-issuer: {{ required "A value is required for .Values.clusterIssuer" .Values.clusterIssuer }}
+    cert-manager.io/cluster-issuer: {{ required "A value is required for .Values.clusterIssuer" .Values.clusterIssuer }}
     {{- if .Values.ingress.annotations }}
     {{- toYaml .Values.ingress.annotations | nindent 4 }}
     {{- end }}

--- a/deployment/armada/templates/ingressrest.yaml
+++ b/deployment/armada/templates/ingressrest.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: {{ required "A value is required for .Values.ingressClass" .Values.ingressClass }}
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    certmanager.k8s.io/cluster-issuer: {{ required "A value is required for .Values.clusterIssuer" .Values.clusterIssuer }}
+    cert-manager.io/cluster-issuer: {{ required "A value is required for .Values.clusterIssuer" .Values.clusterIssuer }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     {{- if .Values.ingress.annotations }}
     {{- toYaml .Values.ingress.annotations | nindent 4 -}}

--- a/deployment/armada/templates/serviceaccount.yaml
+++ b/deployment/armada/templates/serviceaccount.yaml
@@ -6,5 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "armada.labels.all" . | nindent 4 }}
+{{ if .Values.serviceAccount }}
 {{ toYaml .Values.serviceAccount }}
+{{ end }}
 {{ end }}

--- a/deployment/armada/values.yaml
+++ b/deployment/armada/values.yaml
@@ -23,7 +23,7 @@ prometheus:
   labels: {}
   scrapeInterval: 10s
 customServiceAccount: null
-serviceAccount: {}
+serviceAccount: null
 
 applicationConfig:
   grpcPort: 50051

--- a/deployment/executor/templates/deployment.yaml
+++ b/deployment/executor/templates/deployment.yaml
@@ -13,6 +13,8 @@ spec:
   template:
     metadata:
       name: {{ include "executor.name" . }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       labels:
         {{- include "executor.labels.all" . | nindent 8 }}
     spec:

--- a/deployment/executor/templates/serviceaccount.yaml
+++ b/deployment/executor/templates/serviceaccount.yaml
@@ -8,5 +8,5 @@ metadata:
     {{- include "executor.labels.all" . | nindent 4 }}
 {{ if .Values.serviceAccount }}
 {{ toYaml .Values.serviceAccount }}
-{{ end} }
+{{ end }}
 {{ end }}

--- a/deployment/executor/templates/serviceaccount.yaml
+++ b/deployment/executor/templates/serviceaccount.yaml
@@ -6,5 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "executor.labels.all" . | nindent 4 }}
+{{ if .Values.serviceAccount }}
 {{ toYaml .Values.serviceAccount }}
+{{ end} }
 {{ end }}

--- a/deployment/executor/values.yaml
+++ b/deployment/executor/values.yaml
@@ -17,7 +17,7 @@ tolerations:
     key: node-role.kubernetes.io/master
     operator: Exists
 customServiceAccount: null
-serviceAccount: {}
+serviceAccount: null
 
 prometheus:
   enabled: false

--- a/docs/production-install.md
+++ b/docs/production-install.md
@@ -13,7 +13,7 @@ The below sections will cover how to install the component into Kubernetes.
 #### Recommended pre-requisites
 
 * Cert manager installed (https://hub.helm.sh/charts/jetstack/cert-manager)
-* gRPC compatible ingress controller installed for gRPC ingress (such as https://github.com/helm/charts/tree/master/stable/nginx-ingress)
+* gRPC compatible ingress controller installed for gRPC ingress (such as https://github.com/kubernetes/ingress-nginx)
 * Redis installed (https://github.com/helm/charts/tree/master/stable/redis-ha)
 
 Set `ARMADA_VERSION` environment variable and clone this repository repository with the same version tag as you are installing. For example to install version `v1.2.3`:
@@ -31,7 +31,8 @@ You'll need to provide custom config via the values file, below is a minimal tem
 ```yaml
 ingressClass: "nginx"
 clusterIssuer: "letsencrypt-prod"
-hostname: "server.component.url.com"
+hostnames: 
+  - "server.component.url.com"
 replicas: 3
 
 applicationConfig:
@@ -107,7 +108,7 @@ For authentication please create a config file described below.
 
 #### Config file
 
-By default config is loaded from `$HOME/.armadactl`.
+By default config is loaded from `$HOME/.armadactl.yaml`.
 
 You can also set location of the config file  using command line argument:
 

--- a/internal/armada/scheduling/lease.go
+++ b/internal/armada/scheduling/lease.go
@@ -254,7 +254,7 @@ func (c *leaseContext) leaseJobs(queue *api.Queue, slice common.ComputeResources
 			requirement := common.TotalResourceRequest(job.PodSpec).AsFloat()
 			remainder = slice.DeepCopy()
 			remainder.Sub(requirement)
-			if remainder.IsValid() {
+			if isLargeEnough(job, c.minimumJobSize) && remainder.IsValid() {
 				nodeType, ok := matchAnyNodeTypeAllocation(job, c.nodeResources, consumedNodeResources)
 				if ok {
 					slice = remainder

--- a/internal/armada/scheduling/lease_test.go
+++ b/internal/armada/scheduling/lease_test.go
@@ -22,15 +22,11 @@ func Test_minimumJobSize(t *testing.T) {
 	}
 	job := &api.Job{PodSpec: &v1.PodSpec{Containers: []v1.Container{{Resources: resourceRequirement}}}}
 
-	assert.True(t, isLargeEnough(job, &api.ClusterSchedulingInfoReport{
-		MinimumJobSize: common.ComputeResources{"cpu": resource.MustParse("2")}}))
-	assert.True(t, isLargeEnough(job, &api.ClusterSchedulingInfoReport{
-		MinimumJobSize: common.ComputeResources{}}))
+	assert.True(t, isLargeEnough(job, common.ComputeResources{"cpu": resource.MustParse("2")}))
+	assert.True(t, isLargeEnough(job, common.ComputeResources{}))
 
-	assert.False(t, isLargeEnough(job, &api.ClusterSchedulingInfoReport{
-		MinimumJobSize: common.ComputeResources{"cpu": resource.MustParse("5")}}))
-	assert.False(t, isLargeEnough(job, &api.ClusterSchedulingInfoReport{
-		MinimumJobSize: common.ComputeResources{"gpu": resource.MustParse("1")}}))
+	assert.False(t, isLargeEnough(job, common.ComputeResources{"cpu": resource.MustParse("5")}))
+	assert.False(t, isLargeEnough(job, common.ComputeResources{"gpu": resource.MustParse("1")}))
 }
 
 func Test_distributeRemainder_highPriorityUserDoesNotBlockOthers(t *testing.T) {

--- a/internal/armada/scheduling/node_matching.go
+++ b/internal/armada/scheduling/node_matching.go
@@ -33,14 +33,13 @@ func extractNodeTypes(allocations []*nodeTypeAllocation) []*api.NodeType {
 }
 
 func MatchSchedulingRequirements(job *api.Job, schedulingInfo *api.ClusterSchedulingInfoReport) bool {
-	return isLargeEnough(job, schedulingInfo) &&
+	return isLargeEnough(job, schedulingInfo.MinimumJobSize) &&
 		matchAnyNodeType(job, schedulingInfo.NodeTypes)
 }
 
-func isLargeEnough(job *api.Job, schedulingInfo *api.ClusterSchedulingInfoReport) bool {
+func isLargeEnough(job *api.Job, minimumJobSize common.ComputeResources) bool {
 	resourceRequest := common.TotalResourceRequest(job.PodSpec)
-	minimum := common.ComputeResources(schedulingInfo.MinimumJobSize)
-	resourceRequest.Sub(minimum)
+	resourceRequest.Sub(minimumJobSize)
 	return resourceRequest.IsValid()
 }
 


### PR DESCRIPTION
Cert-manager has updated the annotation key for Ingress resources from `certmanager.k8s.io/cluster-issuer` to ` cert-manager.io/cluster-issue`. 

