### PR TITLE
Update cert-manager Ingress annotations

### DIFF
--- a/deployment/armada/templates/ingress.yaml
+++ b/deployment/armada/templates/ingress.yaml
@@ -7,6 +7,7 @@ metadata:
     kubernetes.io/ingress.class: {{ required "A value is required for .Values.ingressClass" .Values.ingressClass }}
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+    certmanager.k8s.io/cluster-issuer: {{ required "A value is required for .Values.clusterIssuer" .Values.clusterIssuer }}
     cert-manager.io/cluster-issuer: {{ required "A value is required for .Values.clusterIssuer" .Values.clusterIssuer }}
     {{- if .Values.ingress.annotations }}
     {{- toYaml .Values.ingress.annotations | nindent 4 }}

--- a/deployment/armada/templates/ingress.yaml
+++ b/deployment/armada/templates/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
     kubernetes.io/ingress.class: {{ required "A value is required for .Values.ingressClass" .Values.ingressClass }}
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
-    certmanager.k8s.io/cluster-issuer: {{ required "A value is required for .Values.clusterIssuer" .Values.clusterIssuer }}
+    cert-manager.io/cluster-issuer: {{ required "A value is required for .Values.clusterIssuer" .Values.clusterIssuer }}
     {{- if .Values.ingress.annotations }}
     {{- toYaml .Values.ingress.annotations | nindent 4 }}
     {{- end }}

--- a/deployment/armada/templates/ingressrest.yaml
+++ b/deployment/armada/templates/ingressrest.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: {{ required "A value is required for .Values.ingressClass" .Values.ingressClass }}
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    certmanager.k8s.io/cluster-issuer: {{ required "A value is required for .Values.clusterIssuer" .Values.clusterIssuer }}
+    cert-manager.io/cluster-issuer: {{ required "A value is required for .Values.clusterIssuer" .Values.clusterIssuer }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     {{- if .Values.ingress.annotations }}
     {{- toYaml .Values.ingress.annotations | nindent 4 -}}

--- a/deployment/armada/templates/ingressrest.yaml
+++ b/deployment/armada/templates/ingressrest.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: {{ required "A value is required for .Values.ingressClass" .Values.ingressClass }}
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    certmanager.k8s.io/cluster-issuer: {{ required "A value is required for .Values.clusterIssuer" .Values.clusterIssuer }}
     cert-manager.io/cluster-issuer: {{ required "A value is required for .Values.clusterIssuer" .Values.clusterIssuer }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     {{- if .Values.ingress.annotations }}


### PR DESCRIPTION
cert-manager has changed the key it expects Ingresses to request a TLS certificate to `cert-manager.io/cluster-issuer`. 

This PR updates the Helm templates for the two Ingress resources in Armada to reflect this change.