### PR TITLE
Improve error codes for armadactl.

### DIFF
--- a/cmd/armadactl/cmd/cancel.go
+++ b/cmd/armadactl/cmd/cancel.go
@@ -45,8 +45,7 @@ var cancelCmd = &cobra.Command{
 				Queue:    queue,
 			})
 			if e != nil {
-				log.Error(e)
-				return
+				exitWithError(e)
 			}
 			log.Infof("Cancellation request submitted for jobs: %s", strings.Join(result.CancelledIds, ", "))
 		})

--- a/cmd/armadactl/cmd/createQueue.go
+++ b/cmd/armadactl/cmd/createQueue.go
@@ -43,8 +43,7 @@ Job priority is evaluated inside queue, queue has its own priority.`,
 		resourceLimits, _ := cmd.Flags().GetStringToString("resourceLimits")
 		resourceLimitsFloat, err := convertResourceLimitsToFloat64(resourceLimits)
 		if err != nil {
-			log.Error(err)
-			return
+			exitWithError(err)
 		}
 
 		apiConnectionDetails := client.ExtractCommandlineArmadaApiConnectionDetails()
@@ -59,8 +58,7 @@ Job priority is evaluated inside queue, queue has its own priority.`,
 				ResourceLimits: resourceLimitsFloat})
 
 			if e != nil {
-				log.Error(e)
-				return
+				exitWithError(e)
 			}
 			log.Infof("Queue %s created.", queue)
 		})

--- a/cmd/armadactl/cmd/deleteQueue.go
+++ b/cmd/armadactl/cmd/deleteQueue.go
@@ -28,8 +28,7 @@ var deleteQueueCmd = &cobra.Command{
 			submissionClient := api.NewSubmitClient(conn)
 			e := client.DeleteQueue(submissionClient, queue)
 			if e != nil {
-				log.Error(e)
-				return
+				exitWithError(e)
 			}
 			log.Infof("Queue %s deleted or did not exist.", queue)
 		})

--- a/cmd/armadactl/cmd/info.go
+++ b/cmd/armadactl/cmd/info.go
@@ -34,8 +34,7 @@ var infoCmd = &cobra.Command{
 			defer cancel()
 			queueInfo, e := submitClient.GetQueueInfo(ctx, &api.QueueInfoRequest{queue})
 			if e != nil {
-				log.Error(e)
-				return
+				exitWithError(e)
 			}
 
 			jobSets := queueInfo.ActiveJobSets

--- a/cmd/armadactl/cmd/root.go
+++ b/cmd/armadactl/cmd/root.go
@@ -47,3 +47,8 @@ var cfgFile string
 func initConfig() {
 	client.LoadCommandlineArgsFromConfigFile(cfgFile)
 }
+
+func exitWithError(e error) {
+	log.Error(e)
+	os.Exit(1)
+}

--- a/cmd/armadactl/cmd/submit.go
+++ b/cmd/armadactl/cmd/submit.go
@@ -49,8 +49,7 @@ var submitCmd = &cobra.Command{
 		err = util.BindJsonOrYaml(filePath, submitFile)
 
 		if err != nil {
-			log.Error(err)
-			os.Exit(1)
+			exitWithError(err)
 		}
 
 		if dryRun {
@@ -67,8 +66,7 @@ var submitCmd = &cobra.Command{
 				response, e := client.SubmitJobs(submissionClient, request)
 
 				if e != nil {
-					log.Error(e)
-					os.Exit(1)
+					exitWithError(e)
 				}
 
 				summariseResponse(response, request.JobSetId)


### PR DESCRIPTION
Always use exit code 1 for errors in armadactl.