### PR TITLE
Fixing circleci builds

### DIFF
--- a/e2e/setup/setup_cluster_ci.sh
+++ b/e2e/setup/setup_cluster_ci.sh
@@ -1,4 +1,4 @@
 if curl -s --fail http://127.0.0.1:10080/kubernetes-ready; then
     exit 0
 fi
-docker run -d --name kube --privileged -p 8443:8443 -p 10080:10080 bsycorp/kind:v1.15.1 || true
+docker run -d --name kube --privileged -p 8443:8443 -p 10080:10080 bsycorp/kind:v1.17.9 || true

--- a/internal/armada/scheduling/node_matching_test.go
+++ b/internal/armada/scheduling/node_matching_test.go
@@ -66,8 +66,8 @@ func Test_AggregateNodeTypesAllocations(t *testing.T) {
 		},
 		{
 			Name:                 "n3-special",
-			AllocatableResources: common.ComputeResources{"cpu": resource.MustParse("4"), "memory": resource.MustParse("1Gi")},
-			AvailableResources:   common.ComputeResources{"cpu": resource.MustParse("2"), "memory": resource.MustParse("3Gi")},
+			AllocatableResources: common.ComputeResources{"cpu": resource.MustParse("5"), "memory": resource.MustParse("5Gi")},
+			AvailableResources:   common.ComputeResources{"cpu": resource.MustParse("6"), "memory": resource.MustParse("6Gi")},
 		},
 	}
 
@@ -82,8 +82,8 @@ func Test_AggregateNodeTypesAllocations(t *testing.T) {
 		{
 			taints:             nil,
 			labels:             nil,
-			nodeSize:           common.ComputeResources{"cpu": resource.MustParse("4"), "memory": resource.MustParse("1Gi")},
-			availableResources: common.ComputeResourcesFloat{"cpu": 2, "memory": 3 * 1024 * 1024 * 1024},
+			nodeSize:           common.ComputeResources{"cpu": resource.MustParse("5"), "memory": resource.MustParse("5Gi")},
+			availableResources: common.ComputeResourcesFloat{"cpu": 6, "memory": 6 * 1024 * 1024 * 1024},
 		},
 	}, aggregated)
 }


### PR DESCRIPTION
Fixing e2e tests hanging
 - It seems to be failing on starting up bsycorp/kind to run the e2e tests
- Updated bsycorp/kind version

Fixing flaky test
 - The size of the clusters used as examples in this test meant they didn't have a deterministic sort order
 - The sorting is fine for our purposes, so changing the test data give a deterministic result order