### PR TITLE
Add support for default job limits.

### DIFF
--- a/internal/armada/configuration/types.go
+++ b/internal/armada/configuration/types.go
@@ -58,6 +58,7 @@ type SchedulingConfig struct {
 	MaximalResourceFractionToSchedulePerQueue map[string]float64
 	MaximalResourceFractionPerQueue           map[string]float64
 	Lease                                     LeaseSettings
+	DefaultJobLimits                          common.ComputeResources
 }
 
 type EventRetentionPolicy struct {

--- a/internal/armada/server.go
+++ b/internal/armada/server.go
@@ -39,7 +39,7 @@ func Serve(config *configuration.ArmadaConfig) (func(), *sync.WaitGroup) {
 	db := createRedisClient(&config.Redis)
 	eventsDb := createRedisClient(&config.EventsRedis)
 
-	jobRepository := repository.NewRedisJobRepository(db)
+	jobRepository := repository.NewRedisJobRepository(db, config.Scheduling.DefaultJobLimits)
 	usageRepository := repository.NewRedisUsageRepository(db)
 	queueRepository := repository.NewRedisQueueRepository(db)
 	schedulingInfoRepository := repository.NewRedisSchedulingInfoRepository(db)

--- a/internal/armada/server/submit_test.go
+++ b/internal/armada/server/submit_test.go
@@ -156,7 +156,7 @@ func withSubmitServer(action func(s *SubmitServer, events repository.EventReposi
 	// using real redis instance as miniredis does not support streams
 	client := redis.NewClient(&redis.Options{Addr: "localhost:6379", DB: 10})
 
-	jobRepo := repository.NewRedisJobRepository(client)
+	jobRepo := repository.NewRedisJobRepository(client, nil)
 	queueRepo := repository.NewRedisQueueRepository(client)
 	eventRepo := repository.NewRedisEventRepository(client, configuration.EventRetentionPolicy{ExpiryEnabled: false})
 	schedulingInfoRepository := repository.NewRedisSchedulingInfoRepository(client)


### PR DESCRIPTION
This change allows specifying resource request and limit defaults. If containers of job does not specify any of the resources in defaults, default is applied when job as submitted to the api.