### PR TITLE
Limit maximum number of retries for stuck jobs

### DIFF
--- a/internal/executor/application.go
+++ b/internal/executor/application.go
@@ -70,9 +70,12 @@ func StartUpWithContext(config configuration.ExecutorConfiguration, clusterConte
 		clusterContext,
 		eventClient)
 
+	inMemoryRetryCache := service.NewInMemoryRetryCache()
+
 	jobLeaseService := service.NewJobLeaseService(
 		clusterContext,
 		queueClient,
+		inMemoryRetryCache,
 		config.Kubernetes.MinimumPodAge,
 		config.Kubernetes.FailedPodExpiry,
 		config.Kubernetes.MinimumJobSize)
@@ -92,6 +95,7 @@ func StartUpWithContext(config configuration.ExecutorConfiguration, clusterConte
 		clusterContext,
 		eventReporter,
 		jobLeaseService,
+		inMemoryRetryCache,
 		config.Kubernetes.StuckPodExpiry)
 
 	clusterAllocationService := service.NewClusterAllocationService(

--- a/internal/executor/service/job_lease_test.go
+++ b/internal/executor/service/job_lease_test.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"github.com/G-Research/armada/internal/executor/domain"
 	"testing"
 	"time"
 
@@ -13,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/G-Research/armada/internal/common"
+	"github.com/G-Research/armada/internal/executor/domain"
 	context2 "github.com/G-Research/armada/internal/executor/fake/context"
 	"github.com/G-Research/armada/pkg/api"
 )

--- a/internal/executor/service/job_utilisation_reporter_test.go
+++ b/internal/executor/service/job_utilisation_reporter_test.go
@@ -23,7 +23,7 @@ var testPodResources = common.ComputeResources{
 func TestUtilisationEventReporter_ReportUtilisationEvents(t *testing.T) {
 	reportingPeriod := 100 * time.Millisecond
 	clusterContext := fakeContext.NewFakeClusterContext("test", nil)
-	fakeEventReporter := &fakeEventReporter{}
+	fakeEventReporter := &FakeEventReporter{}
 	reporter := NewUtilisationEventReporter(clusterContext, &fakePodUtilisation{}, fakeEventReporter, reportingPeriod)
 
 	podResources := map[v1.ResourceName]resource.Quantity{
@@ -74,16 +74,16 @@ func (f *fakePodUtilisation) GetPodUtilisation(pod *v1.Pod) common.ComputeResour
 	return testPodResources
 }
 
-type fakeEventReporter struct {
+type FakeEventReporter struct {
 	receivedEvents []api.Event
 }
 
-func (f *fakeEventReporter) Report(event api.Event) error {
+func (f *FakeEventReporter) Report(event api.Event) error {
 	f.receivedEvents = append(f.receivedEvents, event)
 	return nil
 }
 
-func (f *fakeEventReporter) QueueEvent(event api.Event, callback func(error)) {
+func (f *FakeEventReporter) QueueEvent(event api.Event, callback func(error)) {
 	e := f.Report(event)
 	callback(e)
 }

--- a/internal/executor/service/retry_cache.go
+++ b/internal/executor/service/retry_cache.go
@@ -1,0 +1,39 @@
+package service
+
+import "sync"
+
+type RetryCache interface {
+	AddRetryAttempt(jobId string)
+	GetNumberOfRetryAttempts(jobId string) int
+	Evict(jobId string)
+}
+
+type InMemoryRetryCache struct {
+	mutex *sync.RWMutex
+	cache map[string]int
+}
+
+func NewInMemoryRetryCache() RetryCache {
+	return &InMemoryRetryCache{
+		mutex: &sync.RWMutex{},
+		cache: make(map[string]int),
+	}
+}
+
+func (rc *InMemoryRetryCache) AddRetryAttempt(jobId string) {
+	rc.mutex.Lock()
+	defer rc.mutex.Unlock()
+	rc.cache[jobId]++
+}
+
+func (rc *InMemoryRetryCache) GetNumberOfRetryAttempts(jobId string) int {
+	rc.mutex.RLock()
+	defer rc.mutex.RUnlock()
+	return rc.cache[jobId]
+}
+
+func (rc *InMemoryRetryCache) Evict(jobId string) {
+	rc.mutex.Lock()
+	defer rc.mutex.Unlock()
+	delete(rc.cache, jobId)
+}

--- a/internal/executor/service/retry_cache_test.go
+++ b/internal/executor/service/retry_cache_test.go
@@ -1,0 +1,79 @@
+package service
+
+import (
+	"github.com/stretchr/testify/assert"
+
+	"sync"
+	"testing"
+)
+
+func TestInMemoryRetryCache_NewJobShouldHaveZeroRetries(t *testing.T) {
+	retryCache := NewInMemoryRetryCache()
+
+	assert.Zero(t, retryCache.GetNumberOfRetryAttempts("job-1"))
+}
+
+func TestInMemoryRetryCache_RetryAttemptsShouldBeRecorded(t *testing.T) {
+	retryCache := NewInMemoryRetryCache()
+
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+
+	go func() {
+		for i := 0; i < 10; i++ {
+			retryCache.AddRetryAttempt("job-1")
+		}
+		wg.Done()
+	}()
+
+	go func() {
+		for i := 0; i < 15; i++ {
+			retryCache.AddRetryAttempt("job-2")
+		}
+		wg.Done()
+	}()
+
+	wg.Wait()
+
+	assert.Equal(t, 10, retryCache.GetNumberOfRetryAttempts("job-1"))
+	assert.Equal(t, 15, retryCache.GetNumberOfRetryAttempts("job-2"))
+}
+
+func TestInMemoryRetryCache_JobRetriesAreEvicted(t *testing.T) {
+	retryCache := NewInMemoryRetryCache()
+
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+
+	go func() {
+		for i := 0; i < 7; i++ {
+			retryCache.AddRetryAttempt("job-1")
+		}
+		wg.Done()
+	}()
+
+	go func() {
+		for i := 0; i < 10; i++ {
+			retryCache.AddRetryAttempt("job-2")
+		}
+		wg.Done()
+	}()
+
+	wg.Wait()
+	wg.Add(2)
+
+	go func() {
+		retryCache.Evict("job-1")
+		wg.Done()
+	}()
+
+	go func() {
+		retryCache.Evict("job-2")
+		wg.Done()
+	}()
+
+	wg.Wait()
+
+	assert.Zero(t, retryCache.GetNumberOfRetryAttempts("job-1"))
+	assert.Zero(t, retryCache.GetNumberOfRetryAttempts("job-2"))
+}

--- a/internal/executor/service/retry_cache_test.go
+++ b/internal/executor/service/retry_cache_test.go
@@ -1,10 +1,10 @@
 package service
 
 import (
-	"github.com/stretchr/testify/assert"
-
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestInMemoryRetryCache_NewJobShouldHaveZeroRetries(t *testing.T) {

--- a/internal/executor/service/stuck_pod_detector_test.go
+++ b/internal/executor/service/stuck_pod_detector_test.go
@@ -5,9 +5,10 @@ import (
 	"time"
 
 	"github.com/G-Research/armada/internal/common"
-	clusterContext "github.com/G-Research/armada/internal/executor/context"
+	"github.com/G-Research/armada/internal/executor/context"
 	"github.com/G-Research/armada/internal/executor/domain"
 	"github.com/G-Research/armada/pkg/api"
+
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -123,7 +124,7 @@ func TestStuckPodDetector_RetriesMaxFiveTimes(t *testing.T) {
 	assert.Equal(t, 5, mockLeaseService.returnLeaseCalls)
 }
 
-func getActivePods(t *testing.T, clusterContext clusterContext.ClusterContext) []*v1.Pod {
+func getActivePods(t *testing.T, clusterContext context.ClusterContext) []*v1.Pod {
 	t.Helper()
 	remainingActivePods, err := clusterContext.GetActiveBatchPods()
 	if err != nil {
@@ -184,7 +185,7 @@ func makeTestPod(status v1.PodStatus) *v1.Pod {
 	}
 }
 
-func addPod(t *testing.T, fakeClusterContext clusterContext.ClusterContext, runningPod *v1.Pod) {
+func addPod(t *testing.T, fakeClusterContext context.ClusterContext, runningPod *v1.Pod) {
 	t.Helper()
 	_, err := fakeClusterContext.SubmitPod(runningPod, "owner-1")
 	if err != nil {
@@ -192,7 +193,7 @@ func addPod(t *testing.T, fakeClusterContext clusterContext.ClusterContext, runn
 	}
 }
 
-func makeStuckPodDetectorWithTestDoubles() (clusterContext.ClusterContext, *mockLeaseService, *StuckPodDetector) {
+func makeStuckPodDetectorWithTestDoubles() (context.ClusterContext, *mockLeaseService, *StuckPodDetector) {
 	fakeClusterContext := newSyncFakeClusterContext()
 	mockLeaseService := NewMockLeaseService()
 

--- a/internal/executor/service/stuck_pod_detector_test.go
+++ b/internal/executor/service/stuck_pod_detector_test.go
@@ -1,0 +1,302 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/G-Research/armada/internal/common"
+	clusterContext "github.com/G-Research/armada/internal/executor/context"
+	"github.com/G-Research/armada/internal/executor/domain"
+	"github.com/G-Research/armada/pkg/api"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestStuckPodDetector_DoesNothingIfNoPodsAreFound(t *testing.T) {
+	_, mockLeaseService, stuckPodDetector := makeStuckPodDetectorWithTestDoubles()
+
+	stuckPodDetector.HandleStuckPods()
+
+	assert.Zero(t, mockLeaseService.returnLeaseCalls)
+
+	mockLeaseService.assertReportDoneCalledOnceWith(t, emptyPodSlice())
+}
+
+func TestStuckPodDetector_DoesNothingIfNoStuckPodsAreFound(t *testing.T) {
+	runningPod := makeRunningPod()
+
+	fakeClusterContext, mockLeaseService, stuckPodDetector := makeStuckPodDetectorWithTestDoubles()
+
+	addPod(t, fakeClusterContext, runningPod)
+
+	stuckPodDetector.HandleStuckPods()
+
+	assert.Zero(t, mockLeaseService.returnLeaseCalls)
+
+	mockLeaseService.assertReportDoneCalledOnceWith(t, emptyPodSlice())
+}
+
+func TestStuckPodDetector_DeletesPodAndReportsDoneIfStuckAndUnretryable(t *testing.T) {
+	unretryableStuckPod := makeUnretryableStuckPod()
+
+	fakeClusterContext, mockLeaseService, stuckPodDetector := makeStuckPodDetectorWithTestDoubles()
+
+	addPod(t, fakeClusterContext, unretryableStuckPod)
+
+	stuckPodDetector.HandleStuckPods()
+
+	remainingActivePods := getActivePods(t, fakeClusterContext)
+	assert.Equal(t, emptyPodSlice(), remainingActivePods)
+
+	assert.Zero(t, mockLeaseService.returnLeaseCalls)
+
+	mockLeaseService.assertReportDoneCalledOnceWith(t, []*v1.Pod{unretryableStuckPod})
+}
+
+func TestStuckPodDetector_ReturnsLeaseAndDeletesRetryableStuckPod(t *testing.T) {
+	retryableStuckPod := makeRetryableStuckPod()
+
+	fakeClusterContext, mockLeaseService, stuckPodDetector := makeStuckPodDetectorWithTestDoubles()
+
+	addPod(t, fakeClusterContext, retryableStuckPod)
+
+	stuckPodDetector.HandleStuckPods()
+
+	// Not done as can be retried
+	assert.Equal(t, 1, mockLeaseService.reportDoneCalls)
+	assert.Equal(t, emptyPodSlice(), mockLeaseService.reportDoneArg)
+
+	// Not returning lease yet
+	assert.Equal(t, 0, mockLeaseService.returnLeaseCalls)
+
+	// Still deletes pod
+	remainingActivePods := getActivePods(t, fakeClusterContext)
+	assert.Equal(t, emptyPodSlice(), remainingActivePods)
+
+	stuckPodDetector.HandleStuckPods()
+
+	// Not done as can be retried
+	assert.Equal(t, 2, mockLeaseService.reportDoneCalls)
+	assert.Equal(t, emptyPodSlice(), mockLeaseService.reportDoneArg)
+
+	// Return lease for retry
+	assert.Equal(t, 1, mockLeaseService.returnLeaseCalls)
+	assert.Equal(t, retryableStuckPod, mockLeaseService.returnLeaseArg)
+}
+
+func TestStuckPodDetector_RetriesMaxFiveTimes(t *testing.T) {
+	retryableStuckPod := makeRetryableStuckPod()
+
+	fakeClusterContext, mockLeaseService, stuckPodDetector := makeStuckPodDetectorWithTestDoubles()
+
+	for i := 0; i < 5; i++ {
+		addPod(t, fakeClusterContext, retryableStuckPod)
+
+		stuckPodDetector.HandleStuckPods()
+
+		assert.Equal(t, emptyPodSlice(), mockLeaseService.reportDoneArg)
+
+		remainingActivePods := getActivePods(t, fakeClusterContext)
+		assert.Equal(t, emptyPodSlice(), remainingActivePods)
+
+		stuckPodDetector.HandleStuckPods()
+
+		assert.Equal(t, emptyPodSlice(), mockLeaseService.reportDoneArg)
+
+		assert.Equal(t, retryableStuckPod, mockLeaseService.returnLeaseArg)
+	}
+
+	addPod(t, fakeClusterContext, retryableStuckPod)
+
+	stuckPodDetector.HandleStuckPods()
+
+	// Don't retry anymore
+	assert.Equal(t, []*v1.Pod{retryableStuckPod}, mockLeaseService.reportDoneArg)
+
+	remainingActivePods := getActivePods(t, fakeClusterContext)
+	assert.Equal(t, emptyPodSlice(), remainingActivePods)
+
+	stuckPodDetector.HandleStuckPods()
+
+	assert.Equal(t, 5, mockLeaseService.returnLeaseCalls)
+}
+
+func getActivePods(t *testing.T, clusterContext clusterContext.ClusterContext) []*v1.Pod {
+	t.Helper()
+	remainingActivePods, err := clusterContext.GetActiveBatchPods()
+	if err != nil {
+		t.Error(err)
+	}
+	return remainingActivePods
+}
+
+func makeRunningPod() *v1.Pod {
+	return makeTestPod(v1.PodStatus{Phase: "Running"})
+}
+
+func makeUnretryableStuckPod() *v1.Pod {
+	return makeTestPod(v1.PodStatus{
+		Phase: "Pending",
+		ContainerStatuses: []v1.ContainerStatus{
+			{
+				State: v1.ContainerState{
+					Waiting: &v1.ContainerStateWaiting{
+						Reason:  "ImagePullBackOff",
+						Message: "Some message",
+					},
+				},
+			},
+		},
+	})
+}
+
+func makeRetryableStuckPod() *v1.Pod {
+	return makeTestPod(v1.PodStatus{
+		Phase: "Pending",
+		ContainerStatuses: []v1.ContainerStatus{
+			{
+				State: v1.ContainerState{
+					Waiting: &v1.ContainerStateWaiting{
+						Reason:  "Some reason",
+						Message: "Some message",
+					},
+				},
+			},
+		},
+	})
+}
+
+func makeTestPod(status v1.PodStatus) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				domain.JobId: "job-id-1",
+				domain.Queue: "queue-id-1",
+			},
+			Annotations: map[string]string{
+				domain.JobSetId: "job-set-id-1",
+			},
+			CreationTimestamp: metav1.Time{time.Now().Add(-10 * time.Minute)},
+		},
+		Status: status,
+	}
+}
+
+func addPod(t *testing.T, fakeClusterContext clusterContext.ClusterContext, runningPod *v1.Pod) {
+	t.Helper()
+	_, err := fakeClusterContext.SubmitPod(runningPod, "owner-1")
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func makeStuckPodDetectorWithTestDoubles() (clusterContext.ClusterContext, *mockLeaseService, *StuckPodDetector) {
+	fakeClusterContext := newSyncFakeClusterContext()
+	mockLeaseService := NewMockLeaseService()
+
+	stuckPodDetector := NewPodProgressMonitorService(
+		fakeClusterContext,
+		&FakeEventReporter{nil},
+		mockLeaseService,
+		NewInMemoryRetryCache(),
+		time.Second)
+
+	return fakeClusterContext, mockLeaseService, stuckPodDetector
+}
+
+func emptyPodSlice() []*v1.Pod {
+	return make([]*v1.Pod, 0)
+}
+
+type mockLeaseService struct {
+	returnLeaseCalls      int
+	requestJobLeasesCalls int
+	reportDoneCalls       int
+
+	returnLeaseArg *v1.Pod
+	reportDoneArg  []*v1.Pod
+}
+
+func NewMockLeaseService() *mockLeaseService {
+	return &mockLeaseService{0, 0, 0, nil, nil}
+}
+
+func (ls *mockLeaseService) ReturnLease(pod *v1.Pod) error {
+	ls.returnLeaseArg = pod
+	ls.returnLeaseCalls++
+	return nil
+}
+
+func (ls *mockLeaseService) RequestJobLeases(availableResource *common.ComputeResources, nodes []api.NodeInfo, leasedResourceByQueue map[string]common.ComputeResources) ([]*api.Job, error) {
+	ls.requestJobLeasesCalls++
+	return make([]*api.Job, 0), nil
+}
+
+func (ls *mockLeaseService) ReportDone(pods []*v1.Pod) error {
+	ls.reportDoneArg = pods
+	ls.reportDoneCalls++
+	return nil
+}
+
+func (ls *mockLeaseService) assertReportDoneCalledOnceWith(t *testing.T, expected []*v1.Pod) {
+	assert.Equal(t, 1, ls.reportDoneCalls)
+	assert.Equal(t, expected, ls.reportDoneArg)
+}
+
+type syncFakeClusterContext struct {
+	pods map[string]*v1.Pod
+}
+
+func newSyncFakeClusterContext() *syncFakeClusterContext {
+	c := &syncFakeClusterContext{pods: map[string]*v1.Pod{}}
+	return c
+}
+
+func (*syncFakeClusterContext) Stop() {}
+
+func (c *syncFakeClusterContext) AddPodEventHandler(handler cache.ResourceEventHandlerFuncs) {}
+
+func (c *syncFakeClusterContext) GetBatchPods() ([]*v1.Pod, error) {
+	pods := make([]*v1.Pod, 0, len(c.pods))
+	for _, p := range c.pods {
+		pods = append(pods, p.DeepCopy())
+	}
+	return pods, nil
+}
+
+func (c *syncFakeClusterContext) GetAllPods() ([]*v1.Pod, error) {
+	return c.GetBatchPods()
+}
+
+func (c *syncFakeClusterContext) GetActiveBatchPods() ([]*v1.Pod, error) {
+	return c.GetBatchPods()
+}
+
+func (c *syncFakeClusterContext) GetNodes() ([]*v1.Node, error) {
+	return make([]*v1.Node, 0), nil
+}
+
+func (c *syncFakeClusterContext) GetPodEvents(pod *v1.Pod) ([]*v1.Event, error) {
+	return []*v1.Event{}, nil
+}
+
+func (c *syncFakeClusterContext) SubmitPod(pod *v1.Pod, owner string) (*v1.Pod, error) {
+	c.pods[pod.Labels[domain.JobId]] = pod
+	return pod, nil
+}
+
+func (c *syncFakeClusterContext) AddAnnotation(pod *v1.Pod, annotations map[string]string) error {
+	return nil
+}
+
+func (c *syncFakeClusterContext) DeletePods(pods []*v1.Pod) {
+	for _, p := range pods {
+		delete(c.pods, p.Labels[domain.JobId])
+	}
+}
+
+func (c *syncFakeClusterContext) GetClusterId() string {
+	return "cluster-id-1"
+}


### PR DESCRIPTION
Currently, if a retryable stuck job is found, the executor will schedule the job again.

There have been situations in which pods identified as retryable are rescheduled and get stuck again. This cycle continues indefinitely.

These changes limit the number of times a job get retried to a maximum of five times per Armada executor, as job retries are persisted in an in-memory cache.