### PR TITLE
Add temporary fix for python sspi with kerberos auth.

### DIFF
--- a/internal/armada/authorization/kerberos.go
+++ b/internal/armada/authorization/kerberos.go
@@ -105,7 +105,9 @@ func (authService *KerberosAuthService) Authenticate(ctx context.Context) (Princ
 			user := adCredentials.EffectiveName + authService.userNameSuffix
 			groups := adCredentials.GroupMembershipSIDs
 
-			_ = grpc.SetHeader(ctx, metadata.Pairs(spnego.HTTPHeaderAuthResponse, spnegoNegTokenRespKRBAcceptCompleted))
+			// Original library sets ticket accepted header here, but this breaks python request-negotiate-sspi module
+			// removing the header as workaround before moving away from kerberos
+			// _ = grpc.SetHeader(ctx, metadata.Pairs(spnego.HTTPHeaderAuthResponse, spnegoNegTokenRespKRBAcceptCompleted))
 			return NewStaticPrincipal(user, groups), nil
 		}
 		log.Error("Failed to read ad credentials")


### PR DESCRIPTION
Python request-negotiate-sspi module is failing when used with armada api when passing 
"toke accepted" response header to windows, until there is a fix available in the module or other workaround found, removing the header fixes the issue.