### PR TITLE
Ignore gh-pages branch since it will never build correctly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -310,6 +310,9 @@ workflows:
   build_and_deploy:
     jobs:
       - build
+          filters:
+            branches:
+              ignore: gh-pages
       - deploy:
           requires:
             - build


### PR DESCRIPTION
So that CircleCI doesn't run unnecessarily on a branch that will never build, I'd like to ignore the gh-pages branch from the build job.