### PR TITLE
Use Context in Lookout API

### DIFF
--- a/internal/lookout/repository/query_test.go
+++ b/internal/lookout/repository/query_test.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -22,6 +23,7 @@ var (
 	k8sId4  = util.NewULID()
 	k8sId5  = util.NewULID()
 	node    = "node"
+	ctx     = context.Background()
 )
 
 func Test_QueueStats(t *testing.T) {
@@ -40,7 +42,7 @@ func Test_QueueStats(t *testing.T) {
 		newJobSimulator(t, jobStore, &defaultClock{}).
 			createJob(queue)
 
-		stats, err := jobRepo.GetQueueStats()
+		stats, err := jobRepo.GetQueueStats(ctx)
 		assert.NoError(t, err)
 		assert.Equal(t, []*lookout.QueueInfo{{
 			Queue:       queue,
@@ -69,7 +71,7 @@ func Test_GetNoJobsIfQueueDoesNotExist(t *testing.T) {
 
 		jobRepo := NewSQLJobRepository(db)
 
-		jobInfos, err := jobRepo.GetJobsInQueue(&lookout.GetJobsInQueueRequest{
+		jobInfos, err := jobRepo.GetJobsInQueue(ctx, &lookout.GetJobsInQueueRequest{
 			Queue: "queue",
 			Take:  10,
 		})
@@ -91,7 +93,7 @@ func Test_GetSucceededJobFromQueue(t *testing.T) {
 			running(cluster, k8sId1, node).
 			succeeded(cluster, k8sId1, node)
 
-		jobInfos, err := jobRepo.GetJobsInQueue(&lookout.GetJobsInQueueRequest{
+		jobInfos, err := jobRepo.GetJobsInQueue(ctx, &lookout.GetJobsInQueueRequest{
 			Queue: queue,
 			Take:  10,
 		})
@@ -133,7 +135,7 @@ func Test_GetFailedJobFromQueue(t *testing.T) {
 			running(cluster, k8sId1, node).
 			failed(cluster, k8sId1, node, failureReason)
 
-		jobInfos, err := jobRepo.GetJobsInQueue(&lookout.GetJobsInQueueRequest{
+		jobInfos, err := jobRepo.GetJobsInQueue(ctx, &lookout.GetJobsInQueueRequest{
 			Queue: queue,
 			Take:  10,
 		})
@@ -174,7 +176,7 @@ func Test_GetCancelledJobFromQueue(t *testing.T) {
 			running(cluster, k8sId1, node).
 			cancelled()
 
-		jobInfos, err := jobRepo.GetJobsInQueue(&lookout.GetJobsInQueueRequest{
+		jobInfos, err := jobRepo.GetJobsInQueue(ctx, &lookout.GetJobsInQueueRequest{
 			Queue: queue,
 			Take:  10,
 		})
@@ -214,7 +216,7 @@ func Test_GetMultipleRunJobFromQueue(t *testing.T) {
 			running(cluster, k8sId2, node).
 			succeeded(cluster, k8sId2, node)
 
-		jobInfos, err := jobRepo.GetJobsInQueue(&lookout.GetJobsInQueueRequest{
+		jobInfos, err := jobRepo.GetJobsInQueue(ctx, &lookout.GetJobsInQueueRequest{
 			Queue: queue,
 			Take:  10,
 		})
@@ -271,7 +273,7 @@ func Test_GetJobsOrderedFromOldestToNewest(t *testing.T) {
 			pending(cluster, util.NewULID()).
 			running(cluster, util.NewULID(), node)
 
-		jobInfos, err := jobRepo.GetJobsInQueue(&lookout.GetJobsInQueueRequest{
+		jobInfos, err := jobRepo.GetJobsInQueue(ctx, &lookout.GetJobsInQueueRequest{
 			Queue: queue,
 			Take:  10,
 		})
@@ -309,7 +311,7 @@ func Test_GetJobsOrderedFromNewestToOldest(t *testing.T) {
 			pending(cluster, util.NewULID()).
 			running(cluster, util.NewULID(), node)
 
-		jobInfos, err := jobRepo.GetJobsInQueue(&lookout.GetJobsInQueueRequest{
+		jobInfos, err := jobRepo.GetJobsInQueue(ctx, &lookout.GetJobsInQueueRequest{
 			Queue:       queue,
 			Take:        10,
 			NewestFirst: true,
@@ -355,7 +357,7 @@ func Test_FilterQueuedJobs(t *testing.T) {
 			createJob(queue).
 			cancelled()
 
-		jobInfos, err := jobRepo.GetJobsInQueue(&lookout.GetJobsInQueueRequest{
+		jobInfos, err := jobRepo.GetJobsInQueue(ctx, &lookout.GetJobsInQueueRequest{
 			Queue:     queue,
 			Take:      10,
 			JobStates: []string{JobStates.Queued},
@@ -401,7 +403,7 @@ func Test_FilterPendingJobs(t *testing.T) {
 			createJob(queue).
 			cancelled()
 
-		jobInfos, err := jobRepo.GetJobsInQueue(&lookout.GetJobsInQueueRequest{
+		jobInfos, err := jobRepo.GetJobsInQueue(ctx, &lookout.GetJobsInQueueRequest{
 			Queue:     queue,
 			Take:      10,
 			JobStates: []string{JobStates.Pending},
@@ -447,7 +449,7 @@ func Test_FilterRunningJobs(t *testing.T) {
 			createJob(queue).
 			cancelled()
 
-		jobInfos, err := jobRepo.GetJobsInQueue(&lookout.GetJobsInQueueRequest{
+		jobInfos, err := jobRepo.GetJobsInQueue(ctx, &lookout.GetJobsInQueueRequest{
 			Queue:     queue,
 			Take:      10,
 			JobStates: []string{JobStates.Running},
@@ -493,7 +495,7 @@ func Test_FilterSucceededJobs(t *testing.T) {
 			createJob(queue).
 			cancelled()
 
-		jobInfos, err := jobRepo.GetJobsInQueue(&lookout.GetJobsInQueueRequest{
+		jobInfos, err := jobRepo.GetJobsInQueue(ctx, &lookout.GetJobsInQueueRequest{
 			Queue:     queue,
 			Take:      10,
 			JobStates: []string{JobStates.Succeeded},
@@ -539,7 +541,7 @@ func Test_FilterFailedJobs(t *testing.T) {
 			createJob(queue).
 			cancelled()
 
-		jobInfos, err := jobRepo.GetJobsInQueue(&lookout.GetJobsInQueueRequest{
+		jobInfos, err := jobRepo.GetJobsInQueue(ctx, &lookout.GetJobsInQueueRequest{
 			Queue:     queue,
 			Take:      10,
 			JobStates: []string{JobStates.Failed},
@@ -585,7 +587,7 @@ func Test_FilterCancelledJobs(t *testing.T) {
 			createJob(queue).
 			cancelled()
 
-		jobInfos, err := jobRepo.GetJobsInQueue(&lookout.GetJobsInQueueRequest{
+		jobInfos, err := jobRepo.GetJobsInQueue(ctx, &lookout.GetJobsInQueueRequest{
 			Queue:     queue,
 			Take:      10,
 			JobStates: []string{JobStates.Cancelled},
@@ -603,7 +605,7 @@ func Test_ErrorsIfUnknownStateIsGiven(t *testing.T) {
 	withDatabase(t, func(db *goqu.Database) {
 		jobRepo := NewSQLJobRepository(db)
 
-		_, err := jobRepo.GetJobsInQueue(&lookout.GetJobsInQueueRequest{
+		_, err := jobRepo.GetJobsInQueue(ctx, &lookout.GetJobsInQueueRequest{
 			Queue:     queue,
 			Take:      10,
 			JobStates: []string{"Unknown"},
@@ -645,7 +647,7 @@ func Test_FilterMultipleStates(t *testing.T) {
 			createJob(queue).
 			cancelled()
 
-		jobInfos, err := jobRepo.GetJobsInQueue(&lookout.GetJobsInQueueRequest{
+		jobInfos, err := jobRepo.GetJobsInQueue(ctx, &lookout.GetJobsInQueueRequest{
 			Queue:     queue,
 			Take:      10,
 			JobStates: []string{JobStates.Queued, JobStates.Running, JobStates.Failed},
@@ -656,7 +658,7 @@ func Test_FilterMultipleStates(t *testing.T) {
 		assertJobsAreEquivalent(t, running.job, jobInfos[1].Job)
 		assertJobsAreEquivalent(t, failed.job, jobInfos[2].Job)
 
-		jobInfos, err = jobRepo.GetJobsInQueue(&lookout.GetJobsInQueueRequest{
+		jobInfos, err = jobRepo.GetJobsInQueue(ctx, &lookout.GetJobsInQueueRequest{
 			Queue:     queue,
 			Take:      10,
 			JobStates: []string{JobStates.Pending, JobStates.Succeeded, JobStates.Cancelled},
@@ -705,7 +707,7 @@ func Test_FilterBySingleJobSet(t *testing.T) {
 			createJobWithJobSet(queue, jobSet3).
 			cancelled()
 
-		jobInfos, err := jobRepo.GetJobsInQueue(&lookout.GetJobsInQueueRequest{
+		jobInfos, err := jobRepo.GetJobsInQueue(ctx, &lookout.GetJobsInQueueRequest{
 			Queue:     queue,
 			Take:      10,
 			JobSetIds: []string{jobSet1},
@@ -715,7 +717,7 @@ func Test_FilterBySingleJobSet(t *testing.T) {
 		assertJobsAreEquivalent(t, job1.job, jobInfos[0].Job)
 		assertJobsAreEquivalent(t, job2.job, jobInfos[1].Job)
 
-		jobInfos, err = jobRepo.GetJobsInQueue(&lookout.GetJobsInQueueRequest{
+		jobInfos, err = jobRepo.GetJobsInQueue(ctx, &lookout.GetJobsInQueueRequest{
 			Queue:     queue,
 			Take:      10,
 			JobSetIds: []string{jobSet2},
@@ -725,7 +727,7 @@ func Test_FilterBySingleJobSet(t *testing.T) {
 		assertJobsAreEquivalent(t, job3.job, jobInfos[0].Job)
 		assertJobsAreEquivalent(t, job4.job, jobInfos[1].Job)
 
-		jobInfos, err = jobRepo.GetJobsInQueue(&lookout.GetJobsInQueueRequest{
+		jobInfos, err = jobRepo.GetJobsInQueue(ctx, &lookout.GetJobsInQueueRequest{
 			Queue:     queue,
 			Take:      10,
 			JobSetIds: []string{jobSet3},
@@ -773,7 +775,7 @@ func Test_FilterByMultipleJobSets(t *testing.T) {
 			createJobWithJobSet(queue, jobSet3).
 			cancelled()
 
-		jobInfos, err := jobRepo.GetJobsInQueue(&lookout.GetJobsInQueueRequest{
+		jobInfos, err := jobRepo.GetJobsInQueue(ctx, &lookout.GetJobsInQueueRequest{
 			Queue:     queue,
 			Take:      10,
 			JobSetIds: []string{jobSet1, jobSet2},
@@ -823,7 +825,7 @@ func Test_FilterByJobSetStartingWith(t *testing.T) {
 			createJobWithJobSet(queue, jobSet3).
 			cancelled()
 
-		jobInfos, err := jobRepo.GetJobsInQueue(&lookout.GetJobsInQueueRequest{
+		jobInfos, err := jobRepo.GetJobsInQueue(ctx, &lookout.GetJobsInQueueRequest{
 			Queue:     queue,
 			Take:      10,
 			JobSetIds: []string{"job-se"},
@@ -876,7 +878,7 @@ func Test_FilterByMultipleJobSetStartingWith(t *testing.T) {
 			createJobWithJobSet(queue, jobSet4).
 			cancelled()
 
-		jobInfos, err := jobRepo.GetJobsInQueue(&lookout.GetJobsInQueueRequest{
+		jobInfos, err := jobRepo.GetJobsInQueue(ctx, &lookout.GetJobsInQueueRequest{
 			Queue:     queue,
 			Take:      10,
 			JobSetIds: []string{"hello", "world"},
@@ -910,7 +912,7 @@ func Test_TakeOldestJobsFirst(t *testing.T) {
 				running(cluster, k8sId, node)
 		}
 
-		jobInfos, err := jobRepo.GetJobsInQueue(&lookout.GetJobsInQueueRequest{
+		jobInfos, err := jobRepo.GetJobsInQueue(ctx, &lookout.GetJobsInQueueRequest{
 			Queue: queue,
 			Take:  uint32(take),
 		})
@@ -941,7 +943,7 @@ func Test_TakeNewestJobsFirst(t *testing.T) {
 				running(cluster, k8sId, node)
 		}
 
-		jobInfos, err := jobRepo.GetJobsInQueue(&lookout.GetJobsInQueueRequest{
+		jobInfos, err := jobRepo.GetJobsInQueue(ctx, &lookout.GetJobsInQueueRequest{
 			NewestFirst: true,
 			Queue:       queue,
 			Take:        uint32(take),
@@ -974,7 +976,7 @@ func Test_SkipFirstOldestJobs(t *testing.T) {
 				running(cluster, k8sId, node)
 		}
 
-		jobInfos, err := jobRepo.GetJobsInQueue(&lookout.GetJobsInQueueRequest{
+		jobInfos, err := jobRepo.GetJobsInQueue(ctx, &lookout.GetJobsInQueueRequest{
 			Queue: queue,
 			Take:  uint32(take),
 			Skip:  uint32(skip),
@@ -1007,7 +1009,7 @@ func Test_SkipFirstNewestJobs(t *testing.T) {
 				running(cluster, k8sId, node)
 		}
 
-		jobInfos, err := jobRepo.GetJobsInQueue(&lookout.GetJobsInQueueRequest{
+		jobInfos, err := jobRepo.GetJobsInQueue(ctx, &lookout.GetJobsInQueueRequest{
 			NewestFirst: true,
 			Queue:       queue,
 			Take:        uint32(take),

--- a/internal/lookout/server/lookout.go
+++ b/internal/lookout/server/lookout.go
@@ -20,7 +20,7 @@ func NewLookoutServer(jobRepository repository.JobRepository) *LookoutServer {
 }
 
 func (s *LookoutServer) Overview(ctx context.Context, _ *types.Empty) (*lookout.SystemOverview, error) {
-	queues, err := s.jobRepository.GetQueueStats()
+	queues, err := s.jobRepository.GetQueueStats(ctx)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Failed to query queue stats: %s", err)
 	}
@@ -28,7 +28,7 @@ func (s *LookoutServer) Overview(ctx context.Context, _ *types.Empty) (*lookout.
 }
 
 func (s *LookoutServer) GetJobsInQueue(ctx context.Context, opts *lookout.GetJobsInQueueRequest) (*lookout.GetJobsInQueueResponse, error) {
-	jobInfos, err := s.jobRepository.GetJobsInQueue(opts)
+	jobInfos, err := s.jobRepository.GetJobsInQueue(ctx, opts)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Failed to query jobs in queue: %s", err)
 	}


### PR DESCRIPTION
Correctly pass the context in db calls in the Lookout API, previously unused