### PR TITLE
Fix website description

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 ---
 title: Home
 layout: default
-description: Use the Argon Jekyll theme to build a landing page, blog or complete website.
+description: Armada is an application to achieve high throughput of run-to-completion jobs on multiple Kubernetes clusters.
 featured_image: /assets/img/social.jpg
 ---
 


### PR DESCRIPTION
The Argon template's default description was still in index.html.  Just fixing that to be the description of Armada, instead.