### PR TITLE
Lookout API make time-based tests deterministic

### DIFF
--- a/internal/lookout/repository/job_sets_test.go
+++ b/internal/lookout/repository/job_sets_test.go
@@ -13,10 +13,10 @@ func TestGetJobSetInfos_GetNoJobSetsIfQueueDoesNotExist(t *testing.T) {
 	withDatabase(t, func(db *goqu.Database) {
 		jobStore := NewSQLJobStore(db)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob("queue-1")
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob("queue-2").
 			Pending(cluster, k8sId1)
 
@@ -32,10 +32,10 @@ func TestGetJobSetInfos_GetsJobSetWithNoFinishedJobs(t *testing.T) {
 	withDatabase(t, func(db *goqu.Database) {
 		jobStore := NewSQLJobStore(db)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, "job-set")
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, "job-set").
 			Pending(cluster, k8sId1)
 
@@ -59,12 +59,12 @@ func TestGetJobSetInfos_GetsJobSetWithOnlyFinishedJobs(t *testing.T) {
 	withDatabase(t, func(db *goqu.Database) {
 		jobStore := NewSQLJobStore(db)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, "job-set").
 			Running(cluster, k8sId1, node).
 			Succeeded(cluster, k8sId1, node)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, "job-set").
 			Pending(cluster, k8sId2).
 			Failed(cluster, k8sId2, node, "some error")
@@ -90,36 +90,36 @@ func TestGetJobSetInfos_JobSetsCounts(t *testing.T) {
 		jobStore := NewSQLJobStore(db)
 		jobRepo := NewSQLJobRepository(db, &DefaultClock{})
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, "job-set-1").
 			Pending(cluster, "a1").
 			UnableToSchedule(cluster, "a1", node).
 			Pending(cluster, "a2")
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, "job-set-1").
 			Pending(cluster, "b1").
 			UnableToSchedule(cluster, "b1", node).
 			Running(cluster, "b2", node)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, "job-set-1")
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, "job-set-1").
 			Pending(cluster, "c1").
 			UnableToSchedule(cluster, "c1", node).
 			Running(cluster, "c2", node).
 			Succeeded(cluster, "c2", node)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, "job-set-1").
 			Pending(cluster, "d1").
 			UnableToSchedule(cluster, "d1", node).
 			Running(cluster, "d2", node).
 			Failed(cluster, "d2", node, "something bad")
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, "job-set-1").
 			Pending(cluster, "e1").
 			UnableToSchedule(cluster, "e1", node).
@@ -147,32 +147,32 @@ func TestGetJobSetInfos_MultipleJobSetsCounts(t *testing.T) {
 		jobRepo := NewSQLJobRepository(db, &DefaultClock{})
 
 		// Job set 1
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, "job-set-1")
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, "job-set-1")
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, "job-set-1").
 			Pending(cluster, "a1").
 			UnableToSchedule(cluster, "a1", node).
 			Pending(cluster, "a2")
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, "job-set-1").
 			Pending(cluster, "b1").
 			UnableToSchedule(cluster, "b1", node).
 			Running(cluster, "b2", node)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, "job-set-1").
 			Pending(cluster, "c1").
 			UnableToSchedule(cluster, "c1", node).
 			Running(cluster, "c2", node).
 			Succeeded(cluster, "c2", node)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, "job-set-1").
 			Pending(cluster, "d1").
 			UnableToSchedule(cluster, "d1", node).
@@ -180,21 +180,21 @@ func TestGetJobSetInfos_MultipleJobSetsCounts(t *testing.T) {
 			Failed(cluster, "d2", node, "something bad")
 
 		// Job set 2
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, "job-set-2")
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, "job-set-2").
 			Pending(cluster, "e1")
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, "job-set-2").
 			Pending(cluster, "f1").
 			UnableToSchedule(cluster, "f1", node).
 			Running(cluster, "f2", node).
 			Succeeded(cluster, "f2", node)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, "job-set-2").
 			Pending(cluster, "h1").
 			UnableToSchedule(cluster, "h1", node).

--- a/internal/lookout/repository/jobs_test.go
+++ b/internal/lookout/repository/jobs_test.go
@@ -44,8 +44,8 @@ func TestGetJobs_GetSucceededJobFromQueue(t *testing.T) {
 		jobRepo := NewSQLJobRepository(db, &DefaultClock{})
 
 		pendingTime := someTime.Add(time.Second)
-		runningTime := someTime.Add(2*time.Second)
-		succeededTime := someTime.Add(3*time.Second)
+		runningTime := someTime.Add(2 * time.Second)
+		succeededTime := someTime.Add(3 * time.Second)
 
 		succeeded := NewJobSimulator(t, jobStore).
 			CreateJobAtTime(queue, someTime).
@@ -87,8 +87,8 @@ func TestGetJobs_GetFailedJobFromQueue(t *testing.T) {
 		jobRepo := NewSQLJobRepository(db, &DefaultClock{})
 
 		pendingTime := someTime.Add(time.Second)
-		runningTime := someTime.Add(2*time.Second)
-		failedTime := someTime.Add(3*time.Second)
+		runningTime := someTime.Add(2 * time.Second)
+		failedTime := someTime.Add(3 * time.Second)
 		failureReason := "Something bad happened"
 
 		failed := NewJobSimulator(t, jobStore).
@@ -131,8 +131,8 @@ func TestGetJobs_GetCancelledJobFromQueue(t *testing.T) {
 		jobRepo := NewSQLJobRepository(db, &DefaultClock{})
 
 		pendingTime := someTime.Add(time.Second)
-		runningTime := someTime.Add(2*time.Second)
-		cancelledTime := someTime.Add(3*time.Second)
+		runningTime := someTime.Add(2 * time.Second)
+		cancelledTime := someTime.Add(3 * time.Second)
 
 		cancelled := NewJobSimulator(t, jobStore).
 			CreateJobAtTime(queue, someTime).
@@ -172,10 +172,10 @@ func TestGetJobs_GetMultipleRunJobFromQueue(t *testing.T) {
 		jobRepo := NewSQLJobRepository(db, &DefaultClock{})
 
 		pendingTime1 := someTime.Add(time.Second)
-		unableToScheduleTime := someTime.Add(2*time.Second)
-		pendingTime2 := someTime.Add(3*time.Second)
-		runningTime := someTime.Add(4*time.Second)
-		succeededTime := someTime.Add(5*time.Second)
+		unableToScheduleTime := someTime.Add(2 * time.Second)
+		pendingTime2 := someTime.Add(3 * time.Second)
+		runningTime := someTime.Add(4 * time.Second)
+		succeededTime := someTime.Add(5 * time.Second)
 
 		retried := NewJobSimulator(t, jobStore).
 			CreateJobAtTime(queue, someTime).

--- a/internal/lookout/repository/jobs_test.go
+++ b/internal/lookout/repository/jobs_test.go
@@ -2,7 +2,6 @@ package repository
 
 import (
 	"testing"
-	"time"
 
 	"github.com/doug-martin/goqu/v9"
 	"github.com/stretchr/testify/assert"
@@ -15,14 +14,14 @@ func TestGetJobs_GetNoJobsIfQueueDoesNotExist(t *testing.T) {
 	withDatabase(t, func(db *goqu.Database) {
 		jobStore := NewSQLJobStore(db)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob("queue-1")
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob("queue-2").
 			Pending(cluster, k8sId1)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob("queue-2").
 			Pending(cluster, k8sId2).
 			Running(cluster, k8sId2, node)
@@ -43,13 +42,11 @@ func TestGetJobs_GetSucceededJobFromQueue(t *testing.T) {
 		jobStore := NewSQLJobStore(db)
 		jobRepo := NewSQLJobRepository(db, &DefaultClock{})
 
-		startTime := time.Now()
-
-		succeeded := NewJobSimulator(t, jobStore, NewIncrementClock(startTime)).
-			CreateJob(queue).
-			Pending(cluster, k8sId1).
-			Running(cluster, k8sId1, node).
-			Succeeded(cluster, k8sId1, node)
+		succeeded := NewJobSimulator(t, jobStore).
+			CreateJobAtTime(queue, someTime).
+			PendingAtTime(cluster, k8sId1, *Increment(someTime, 1)).
+			RunningAtTime(cluster, k8sId1, node, *Increment(someTime, 2)).
+			SucceededAtTime(cluster, k8sId1, node, *Increment(someTime, 3))
 
 		jobInfos, err := jobRepo.GetJobs(ctx, &lookout.GetJobsRequest{
 			Queue: queue,
@@ -72,9 +69,9 @@ func TestGetJobs_GetSucceededJobFromQueue(t *testing.T) {
 			Cluster:   cluster,
 			Node:      node,
 			Succeeded: true,
-			Created:   Increment(startTime, 1),
-			Started:   Increment(startTime, 2),
-			Finished:  Increment(startTime, 3),
+			Created:   Increment(someTime, 1),
+			Started:   Increment(someTime, 2),
+			Finished:  Increment(someTime, 3),
 		}, runInfo)
 	})
 }
@@ -84,14 +81,13 @@ func TestGetJobs_GetFailedJobFromQueue(t *testing.T) {
 		jobStore := NewSQLJobStore(db)
 		jobRepo := NewSQLJobRepository(db, &DefaultClock{})
 
-		startTime := time.Now()
 		failureReason := "Something bad happened"
 
-		failed := NewJobSimulator(t, jobStore, NewIncrementClock(startTime)).
-			CreateJob(queue).
-			Pending(cluster, k8sId1).
-			Running(cluster, k8sId1, node).
-			Failed(cluster, k8sId1, node, failureReason)
+		failed := NewJobSimulator(t, jobStore).
+			CreateJobAtTime(queue, someTime).
+			PendingAtTime(cluster, k8sId1, *Increment(someTime, 1)).
+			RunningAtTime(cluster, k8sId1, node, *Increment(someTime, 2)).
+			FailedAtTime(cluster, k8sId1, node, failureReason, *Increment(someTime, 3))
 
 		jobInfos, err := jobRepo.GetJobs(ctx, &lookout.GetJobsRequest{
 			Queue: queue,
@@ -113,9 +109,9 @@ func TestGetJobs_GetFailedJobFromQueue(t *testing.T) {
 			Cluster:   cluster,
 			Node:      node,
 			Succeeded: false,
-			Created:   Increment(startTime, 1),
-			Started:   Increment(startTime, 2),
-			Finished:  Increment(startTime, 3),
+			Created:   Increment(someTime, 1),
+			Started:   Increment(someTime, 2),
+			Finished:  Increment(someTime, 3),
 			Error:     failureReason,
 		}, jobInfo.Runs[0])
 	})
@@ -126,13 +122,11 @@ func TestGetJobs_GetCancelledJobFromQueue(t *testing.T) {
 		jobStore := NewSQLJobStore(db)
 		jobRepo := NewSQLJobRepository(db, &DefaultClock{})
 
-		startTime := time.Now()
-
-		cancelled := NewJobSimulator(t, jobStore, NewIncrementClock(startTime)).
-			CreateJob(queue).
-			Pending(cluster, k8sId1).
-			Running(cluster, k8sId1, node).
-			Cancelled()
+		cancelled := NewJobSimulator(t, jobStore).
+			CreateJobAtTime(queue, someTime).
+			PendingAtTime(cluster, k8sId1, *Increment(someTime, 1)).
+			RunningAtTime(cluster, k8sId1, node, *Increment(someTime, 2)).
+			CancelledAtTime(*Increment(someTime, 3))
 
 		jobInfos, err := jobRepo.GetJobs(ctx, &lookout.GetJobsRequest{
 			Queue: queue,
@@ -144,7 +138,7 @@ func TestGetJobs_GetCancelledJobFromQueue(t *testing.T) {
 		jobInfo := jobInfos[0]
 		AssertJobsAreEquivalent(t, cancelled.job, jobInfo.Job)
 
-		AssertTimesApproxEqual(t, Increment(startTime, 3), jobInfo.Cancelled)
+		AssertTimesApproxEqual(t, Increment(someTime, 3), jobInfo.Cancelled)
 
 		assert.Equal(t, string(JobCancelled), jobInfo.JobState)
 
@@ -154,8 +148,8 @@ func TestGetJobs_GetCancelledJobFromQueue(t *testing.T) {
 			Cluster:   cluster,
 			Node:      node,
 			Succeeded: false,
-			Created:   Increment(startTime, 1),
-			Started:   Increment(startTime, 2),
+			Created:   Increment(someTime, 1),
+			Started:   Increment(someTime, 2),
 		}, jobInfo.Runs[0])
 	})
 }
@@ -165,15 +159,13 @@ func TestGetJobs_GetMultipleRunJobFromQueue(t *testing.T) {
 		jobStore := NewSQLJobStore(db)
 		jobRepo := NewSQLJobRepository(db, &DefaultClock{})
 
-		startTime := time.Now()
-
-		retried := NewJobSimulator(t, jobStore, NewIncrementClock(startTime)).
-			CreateJob(queue).
-			Pending(cluster, k8sId1).
-			UnableToSchedule(cluster, k8sId1, node).
-			Pending(cluster, k8sId2).
-			Running(cluster, k8sId2, node).
-			Succeeded(cluster, k8sId2, node)
+		retried := NewJobSimulator(t, jobStore).
+			CreateJobAtTime(queue, someTime).
+			PendingAtTime(cluster, k8sId1, *Increment(someTime, 1)).
+			UnableToScheduleAtTime(cluster, k8sId1, node, *Increment(someTime, 2)).
+			PendingAtTime(cluster, k8sId2, *Increment(someTime, 3)).
+			RunningAtTime(cluster, k8sId2, node, *Increment(someTime, 4)).
+			SucceededAtTime(cluster, k8sId2, node, *Increment(someTime, 5))
 
 		jobInfos, err := jobRepo.GetJobs(ctx, &lookout.GetJobsRequest{
 			Queue: queue,
@@ -193,17 +185,17 @@ func TestGetJobs_GetMultipleRunJobFromQueue(t *testing.T) {
 			Cluster:   cluster,
 			Node:      node,
 			Succeeded: false,
-			Created:   Increment(startTime, 1),
-			Finished:  Increment(startTime, 2),
+			Created:   Increment(someTime, 1),
+			Finished:  Increment(someTime, 2),
 		}, jobInfo.Runs[0])
 		AssertRunInfosEquivalent(t, &lookout.RunInfo{
 			K8SId:     k8sId2,
 			Cluster:   cluster,
 			Node:      node,
 			Succeeded: true,
-			Created:   Increment(startTime, 3),
-			Started:   Increment(startTime, 4),
-			Finished:  Increment(startTime, 5),
+			Created:   Increment(someTime, 3),
+			Started:   Increment(someTime, 4),
+			Finished:  Increment(someTime, 5),
 		}, jobInfo.Runs[1])
 	})
 }
@@ -218,17 +210,17 @@ func TestGetJobs_GetJobsOrderedFromOldestToNewest(t *testing.T) {
 		jobId2 := "b"
 		jobId3 := "c"
 
-		third := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		third := NewJobSimulator(t, jobStore).
 			CreateJobWithId(queue, jobId3).
 			Pending(cluster, k8sId1).
 			Running(cluster, k8sId1, node)
 
-		second := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		second := NewJobSimulator(t, jobStore).
 			CreateJobWithId(queue, jobId2).
 			Pending(cluster, k8sId2).
 			Running(cluster, k8sId2, node)
 
-		first := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		first := NewJobSimulator(t, jobStore).
 			CreateJobWithId(queue, jobId1).
 			Pending(cluster, k8sId3).
 			Running(cluster, k8sId3, node)
@@ -256,17 +248,17 @@ func TestGetJobs_GetJobsOrderedFromNewestToOldest(t *testing.T) {
 		jobId2 := "b"
 		jobId3 := "c"
 
-		first := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		first := NewJobSimulator(t, jobStore).
 			CreateJobWithId(queue, jobId1).
 			Pending(cluster, k8sId1).
 			Running(cluster, k8sId1, node)
 
-		second := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		second := NewJobSimulator(t, jobStore).
 			CreateJobWithId(queue, jobId2).
 			Pending(cluster, k8sId2).
 			Running(cluster, k8sId2, node)
 
-		third := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		third := NewJobSimulator(t, jobStore).
 			CreateJobWithId(queue, jobId3).
 			Pending(cluster, k8sId3).
 			Running(cluster, k8sId3, node)
@@ -290,31 +282,31 @@ func TestGetJobs_FilterQueuedJobs(t *testing.T) {
 		jobStore := NewSQLJobStore(db)
 		jobRepo := NewSQLJobRepository(db, &DefaultClock{})
 
-		queued := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		queued := NewJobSimulator(t, jobStore).
 			CreateJob(queue)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Pending(cluster, k8sId1)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Pending(cluster, k8sId2).
 			UnableToSchedule(cluster, k8sId2, node).
 			Pending(cluster, k8sId3).
 			Running(cluster, k8sId3, node)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Pending(cluster, k8sId4).
 			Running(cluster, k8sId4, node).
 			Succeeded(cluster, k8sId4, node)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Failed(cluster, k8sId5, node, "Something bad")
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Cancelled()
 
@@ -337,31 +329,31 @@ func TestGetJobs_FilterPendingJobs(t *testing.T) {
 		jobStore := NewSQLJobStore(db)
 		jobRepo := NewSQLJobRepository(db, &DefaultClock{})
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue)
 
-		pending := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		pending := NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Pending(cluster, k8sId1)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Pending(cluster, k8sId2).
 			UnableToSchedule(cluster, k8sId2, node).
 			Pending(cluster, k8sId3).
 			Running(cluster, k8sId3, node)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Pending(cluster, k8sId4).
 			Running(cluster, k8sId4, node).
 			Succeeded(cluster, k8sId4, node)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Failed(cluster, k8sId5, node, "Something bad")
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Cancelled()
 
@@ -384,31 +376,31 @@ func TestGetJobs_FilterRunningJobs(t *testing.T) {
 		jobStore := NewSQLJobStore(db)
 		jobRepo := NewSQLJobRepository(db, &DefaultClock{})
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Pending(cluster, k8sId1)
 
-		running := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		running := NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Pending(cluster, k8sId2).
 			UnableToSchedule(cluster, k8sId2, node).
 			Pending(cluster, k8sId3).
 			Running(cluster, k8sId3, node)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Pending(cluster, k8sId4).
 			Running(cluster, k8sId4, node).
 			Succeeded(cluster, k8sId4, node)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Failed(cluster, k8sId5, node, "Something bad")
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Cancelled()
 
@@ -431,31 +423,31 @@ func TestGetJobs_FilterSucceededJobs(t *testing.T) {
 		jobStore := NewSQLJobStore(db)
 		jobRepo := NewSQLJobRepository(db, &DefaultClock{})
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Pending(cluster, k8sId1)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Pending(cluster, k8sId2).
 			UnableToSchedule(cluster, k8sId2, node).
 			Pending(cluster, k8sId3).
 			Running(cluster, k8sId3, node)
 
-		succeeded := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		succeeded := NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Pending(cluster, k8sId4).
 			Running(cluster, k8sId4, node).
 			Succeeded(cluster, k8sId4, node)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Failed(cluster, k8sId5, node, "Something bad")
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Cancelled()
 
@@ -478,31 +470,31 @@ func TestGetJobs_FilterFailedJobs(t *testing.T) {
 		jobStore := NewSQLJobStore(db)
 		jobRepo := NewSQLJobRepository(db, &DefaultClock{})
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Pending(cluster, k8sId1)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Pending(cluster, k8sId2).
 			UnableToSchedule(cluster, k8sId2, node).
 			Pending(cluster, k8sId3).
 			Running(cluster, k8sId3, node)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Pending(cluster, k8sId4).
 			Running(cluster, k8sId4, node).
 			Succeeded(cluster, k8sId4, node)
 
-		failed := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		failed := NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Failed(cluster, k8sId5, node, "Something bad")
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Cancelled()
 
@@ -525,31 +517,31 @@ func TestGetJobs_FilterCancelledJobs(t *testing.T) {
 		jobStore := NewSQLJobStore(db)
 		jobRepo := NewSQLJobRepository(db, &DefaultClock{})
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Pending(cluster, k8sId1)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Pending(cluster, k8sId2).
 			UnableToSchedule(cluster, k8sId2, node).
 			Pending(cluster, k8sId3).
 			Running(cluster, k8sId3, node)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Pending(cluster, k8sId4).
 			Running(cluster, k8sId4, node).
 			Succeeded(cluster, k8sId4, node)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Failed(cluster, k8sId5, node, "Something bad")
 
-		cancelled := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		cancelled := NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Cancelled()
 
@@ -586,31 +578,31 @@ func TestGetJobs_FilterMultipleStates(t *testing.T) {
 		jobStore := NewSQLJobStore(db)
 		jobRepo := NewSQLJobRepository(db, &DefaultClock{})
 
-		queued := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		queued := NewJobSimulator(t, jobStore).
 			CreateJob(queue)
 
-		pending := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		pending := NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Pending(cluster, k8sId1)
 
-		running := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		running := NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Pending(cluster, k8sId2).
 			UnableToSchedule(cluster, k8sId2, node).
 			Pending(cluster, k8sId3).
 			Running(cluster, k8sId3, node)
 
-		succeeded := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		succeeded := NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Pending(cluster, k8sId4).
 			Running(cluster, k8sId4, node).
 			Succeeded(cluster, k8sId4, node)
 
-		failed := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		failed := NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Failed(cluster, k8sId5, node, "Something bad")
 
-		cancelled := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		cancelled := NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Cancelled()
 
@@ -647,31 +639,31 @@ func TestGetJobs_FilterBySingleJobSet(t *testing.T) {
 		jobSet2 := "job-set-2"
 		jobSet3 := "job-set-3"
 
-		job1 := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		job1 := NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, jobSet1)
 
-		job2 := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		job2 := NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, jobSet1).
 			Pending(cluster, k8sId1)
 
-		job3 := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		job3 := NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, jobSet2).
 			Pending(cluster, k8sId2).
 			UnableToSchedule(cluster, k8sId2, node).
 			Pending(cluster, k8sId3).
 			Running(cluster, k8sId3, node)
 
-		job4 := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		job4 := NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, jobSet2).
 			Pending(cluster, k8sId4).
 			Running(cluster, k8sId4, node).
 			Succeeded(cluster, k8sId4, node)
 
-		job5 := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		job5 := NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, jobSet3).
 			Failed(cluster, k8sId5, node, "Something bad")
 
-		job6 := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		job6 := NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, jobSet3).
 			Cancelled()
 
@@ -716,31 +708,31 @@ func TestGetJobs_FilterByMultipleJobSets(t *testing.T) {
 		jobSet2 := "job-set-2"
 		jobSet3 := "job-set-3"
 
-		job1 := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		job1 := NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, jobSet1)
 
-		job2 := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		job2 := NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, jobSet1).
 			Pending(cluster, k8sId1)
 
-		job3 := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		job3 := NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, jobSet2).
 			Pending(cluster, k8sId2).
 			UnableToSchedule(cluster, k8sId2, node).
 			Pending(cluster, k8sId3).
 			Running(cluster, k8sId3, node)
 
-		job4 := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		job4 := NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, jobSet2).
 			Pending(cluster, k8sId4).
 			Running(cluster, k8sId4, node).
 			Succeeded(cluster, k8sId4, node)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, jobSet3).
 			Failed(cluster, k8sId5, node, "Something bad")
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, jobSet3).
 			Cancelled()
 
@@ -767,31 +759,31 @@ func TestGetJobs_FilterByJobSetStartingWith(t *testing.T) {
 		jobSet2 := "job-set-2"
 		jobSet3 := "job-set-3"
 
-		job1 := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		job1 := NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, jobSet1)
 
-		job2 := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		job2 := NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, jobSet1).
 			Pending(cluster, k8sId1)
 
-		job3 := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		job3 := NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, jobSet2).
 			Pending(cluster, k8sId2).
 			UnableToSchedule(cluster, k8sId2, node).
 			Pending(cluster, k8sId3).
 			Running(cluster, k8sId3, node)
 
-		job4 := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		job4 := NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, jobSet2).
 			Pending(cluster, k8sId4).
 			Running(cluster, k8sId4, node).
 			Succeeded(cluster, k8sId4, node)
 
-		job5 := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		job5 := NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, jobSet3).
 			Failed(cluster, k8sId5, node, "Something bad")
 
-		job6 := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		job6 := NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, jobSet3).
 			Cancelled()
 
@@ -821,31 +813,31 @@ func TestGetJobs_FilterByMultipleJobSetStartingWith(t *testing.T) {
 		jobSet3 := "world-3"
 		jobSet4 := "other-job-set"
 
-		job1 := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		job1 := NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, jobSet1)
 
-		job2 := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		job2 := NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, jobSet1).
 			Pending(cluster, k8sId1)
 
-		job3 := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		job3 := NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, jobSet2).
 			Pending(cluster, k8sId2).
 			UnableToSchedule(cluster, k8sId2, node).
 			Pending(cluster, k8sId3).
 			Running(cluster, k8sId3, node)
 
-		job4 := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		job4 := NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, jobSet2).
 			Pending(cluster, k8sId4).
 			Running(cluster, k8sId4, node).
 			Succeeded(cluster, k8sId4, node)
 
-		job5 := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		job5 := NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, jobSet3).
 			Failed(cluster, k8sId5, node, "Something bad")
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, jobSet4).
 			Cancelled()
 
@@ -869,31 +861,31 @@ func TestGetJobs_FilterByJobIdIfNoQueueIsSpecified(t *testing.T) {
 		jobStore := NewSQLJobStore(db)
 		jobRepo := NewSQLJobRepository(db, &DefaultClock{})
 
-		job := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		job := NewJobSimulator(t, jobStore).
 			CreateJob(queue)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Pending(cluster, k8sId1)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Pending(cluster, k8sId2).
 			UnableToSchedule(cluster, k8sId2, node).
 			Pending(cluster, k8sId3).
 			Running(cluster, k8sId3, node)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Pending(cluster, k8sId4).
 			Running(cluster, k8sId4, node).
 			Succeeded(cluster, k8sId4, node)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Failed(cluster, k8sId5, node, "Something bad")
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Cancelled()
 
@@ -912,31 +904,31 @@ func TestGetJobs_FilterByJobIdIfQueueIsSpecified(t *testing.T) {
 		jobStore := NewSQLJobStore(db)
 		jobRepo := NewSQLJobRepository(db, &DefaultClock{})
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Pending(cluster, k8sId1)
 
-		job := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		job := NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Pending(cluster, k8sId2).
 			UnableToSchedule(cluster, k8sId2, node).
 			Pending(cluster, k8sId3).
 			Running(cluster, k8sId3, node)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Pending(cluster, k8sId4).
 			Running(cluster, k8sId4, node).
 			Succeeded(cluster, k8sId4, node)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Failed(cluster, k8sId5, node, "Something bad")
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Cancelled()
 
@@ -956,31 +948,31 @@ func TestGetJobs_FilterByJobIdWithWrongQueue(t *testing.T) {
 		jobStore := NewSQLJobStore(db)
 		jobRepo := NewSQLJobRepository(db, &DefaultClock{})
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Pending(cluster, k8sId1)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Pending(cluster, k8sId2).
 			UnableToSchedule(cluster, k8sId2, node).
 			Pending(cluster, k8sId3).
 			Running(cluster, k8sId3, node)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Pending(cluster, k8sId4).
 			Running(cluster, k8sId4, node).
 			Succeeded(cluster, k8sId4, node)
 
-		job := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		job := NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Failed(cluster, k8sId5, node, "Something bad")
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Cancelled()
 
@@ -999,31 +991,31 @@ func TestGetJobs_FilterByJobIdWithWrongJobSet(t *testing.T) {
 		jobStore := NewSQLJobStore(db)
 		jobRepo := NewSQLJobRepository(db, &DefaultClock{})
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Pending(cluster, k8sId1)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Pending(cluster, k8sId2).
 			UnableToSchedule(cluster, k8sId2, node).
 			Pending(cluster, k8sId3).
 			Running(cluster, k8sId3, node)
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Pending(cluster, k8sId4).
 			Running(cluster, k8sId4, node).
 			Succeeded(cluster, k8sId4, node)
 
-		job := NewJobSimulator(t, jobStore, &DefaultClock{}).
+		job := NewJobSimulator(t, jobStore).
 			CreateJobWithJobSet(queue, "job-set").
 			Failed(cluster, k8sId5, node, "Something bad")
 
-		NewJobSimulator(t, jobStore, &DefaultClock{}).
+		NewJobSimulator(t, jobStore).
 			CreateJob(queue).
 			Cancelled()
 
@@ -1050,7 +1042,7 @@ func TestGetJobs_TakeOldestJobsFirst(t *testing.T) {
 		for i := 0; i < nJobs; i++ {
 			k8sId := util.NewULID()
 			otherK8sId := util.NewULID()
-			allJobs[i] = NewJobSimulator(t, jobStore, &DefaultClock{}).
+			allJobs[i] = NewJobSimulator(t, jobStore).
 				CreateJob(queue).
 				Pending(cluster, k8sId).
 				UnableToSchedule(cluster, k8sId, node).
@@ -1083,7 +1075,7 @@ func TestGetJobs_TakeNewestJobsFirst(t *testing.T) {
 		for i := 0; i < nJobs; i++ {
 			k8sId := util.NewULID()
 			otherK8sId := util.NewULID()
-			allJobs[i] = NewJobSimulator(t, jobStore, &DefaultClock{}).
+			allJobs[i] = NewJobSimulator(t, jobStore).
 				CreateJob(queue).
 				Pending(cluster, k8sId).
 				UnableToSchedule(cluster, k8sId, node).
@@ -1118,7 +1110,7 @@ func TestGetJobs_SkipFirstOldestJobs(t *testing.T) {
 		for i := 0; i < nJobs; i++ {
 			k8sId := util.NewULID()
 			otherK8sId := util.NewULID()
-			allJobs[i] = NewJobSimulator(t, jobStore, &DefaultClock{}).
+			allJobs[i] = NewJobSimulator(t, jobStore).
 				CreateJob(queue).
 				Pending(cluster, k8sId).
 				UnableToSchedule(cluster, k8sId, node).
@@ -1153,7 +1145,7 @@ func TestGetJobs_SkipFirstNewestJobs(t *testing.T) {
 		for i := 0; i < nJobs; i++ {
 			k8sId := util.NewULID()
 			otherK8sId := util.NewULID()
-			allJobs[i] = NewJobSimulator(t, jobStore, &DefaultClock{}).
+			allJobs[i] = NewJobSimulator(t, jobStore).
 				CreateJob(queue).
 				UnableToSchedule(cluster, k8sId, node).
 				Pending(cluster, otherK8sId).

--- a/internal/lookout/repository/queues.go
+++ b/internal/lookout/repository/queues.go
@@ -27,8 +27,6 @@ func (r *SQLJobRepository) GetQueueInfos(ctx context.Context) ([]*lookout.QueueI
 		return nil, err
 	}
 
-	fmt.Println(queries)
-
 	rows, err := r.goquDb.Db.QueryContext(ctx, queries)
 	if err != nil {
 		return nil, err

--- a/internal/lookout/repository/queues_test.go
+++ b/internal/lookout/repository/queues_test.go
@@ -134,12 +134,12 @@ func TestGetQueueInfos_IncludeOldestQueuedJob(t *testing.T) {
 
 		NewJobSimulator(t, jobStore).
 			CreateJobAtTime(queue, someTime).
-			PendingAtTime(cluster, "f",*Increment(someTime, 1))
+			PendingAtTime(cluster, "f", *Increment(someTime, 1))
 
 		NewJobSimulator(t, jobStore).
 			CreateJobAtTime(queue, *Increment(someTime, 10)).
 			PendingAtTime(cluster, "a", *Increment(someTime, 11)).
-			RunningAtTime(cluster, "a", node,*Increment(someTime, 12))
+			RunningAtTime(cluster, "a", node, *Increment(someTime, 12))
 
 		NewJobSimulator(t, jobStore).
 			CreateJobAtTime(queue, *Increment(someTime, 5)).

--- a/internal/lookout/repository/queues_test.go
+++ b/internal/lookout/repository/queues_test.go
@@ -73,36 +73,36 @@ func TestGetQueueInfos_OldestQueuedJobIsNilIfNoJobsAreQueued(t *testing.T) {
 		jobRepo := NewSQLJobRepository(db, &DefaultClock{})
 
 		NewJobSimulator(t, jobStore).
-			CreateJobAtTime(queue, *Increment(someTime, 5)).
-			PendingAtTime(cluster, "c", *Increment(someTime, 6))
+			CreateJobAtTime(queue, someTime.Add(5*time.Second)).
+			PendingAtTime(cluster, "c", someTime.Add(6*time.Second))
 
 		NewJobSimulator(t, jobStore).
 			CreateJobAtTime(queue, someTime).
-			PendingAtTime(cluster, "f", *Increment(someTime, 1))
+			PendingAtTime(cluster, "f", someTime.Add(time.Second))
 
 		NewJobSimulator(t, jobStore).
-			CreateJobAtTime(queue, *Increment(someTime, 10)).
-			PendingAtTime(cluster, "a", *Increment(someTime, 11)).
-			RunningAtTime(cluster, "a", node, *Increment(someTime, 12))
+			CreateJobAtTime(queue, someTime.Add(10*time.Second)).
+			PendingAtTime(cluster, "a", someTime.Add(11*time.Second)).
+			RunningAtTime(cluster, "a", node, someTime.Add(12*time.Second))
 
 		NewJobSimulator(t, jobStore).
-			CreateJobAtTime(queue, *Increment(someTime, 5)).
-			PendingAtTime(cluster, "b", *Increment(someTime, 6)).
-			RunningAtTime(cluster, "b", node, *Increment(someTime, 7))
+			CreateJobAtTime(queue, someTime.Add(5*time.Second)).
+			PendingAtTime(cluster, "b", someTime.Add(6*time.Second)).
+			RunningAtTime(cluster, "b", node, someTime.Add(7*time.Second))
 
 		NewJobSimulator(t, jobStore).
-			CreateJobAtTime(queue, *Increment(someTime, 1)).
-			RunningAtTime(cluster, "d", node, *Increment(someTime, 2))
-
-		NewJobSimulator(t, jobStore).
-			CreateJobAtTime(queue, someTime).
-			RunningAtTime(cluster, "e", node, *Increment(someTime, 1)).
-			SucceededAtTime(cluster, "e", node, *Increment(someTime, 2))
+			CreateJobAtTime(queue, someTime.Add(time.Second)).
+			RunningAtTime(cluster, "d", node, someTime.Add(2*time.Second))
 
 		NewJobSimulator(t, jobStore).
 			CreateJobAtTime(queue, someTime).
-			RunningAtTime(cluster, "g", node, *Increment(someTime, 1)).
-			CancelledAtTime(*Increment(someTime, 2))
+			RunningAtTime(cluster, "e", node, someTime.Add(time.Second)).
+			SucceededAtTime(cluster, "e", node, someTime.Add(2*time.Second))
+
+		NewJobSimulator(t, jobStore).
+			CreateJobAtTime(queue, someTime).
+			RunningAtTime(cluster, "g", node, someTime.Add(time.Second)).
+			CancelledAtTime(someTime.Add(2*time.Second))
 
 		queueInfos, err := jobRepo.GetQueueInfos(ctx)
 		assert.NoError(t, err)
@@ -119,46 +119,48 @@ func TestGetQueueInfos_IncludeOldestQueuedJob(t *testing.T) {
 		jobStore := NewSQLJobStore(db)
 		jobRepo := NewSQLJobRepository(db, &DummyClock{someTime2})
 
+		submissionTime := someTime.Add(time.Second)
+
 		NewJobSimulator(t, jobStore).
-			CreateJobAtTime(queue, *Increment(someTime, 5))
+			CreateJobAtTime(queue, someTime.Add(5*time.Second))
 
 		oldestQueued := NewJobSimulator(t, jobStore).
-			CreateJobAtTime(queue, *Increment(someTime, 1))
+			CreateJobAtTime(queue, submissionTime)
 
 		NewJobSimulator(t, jobStore).
-			CreateJobAtTime(queue, *Increment(someTime, 10))
+			CreateJobAtTime(queue, someTime.Add(10*time.Second))
 
 		NewJobSimulator(t, jobStore).
-			CreateJobAtTime(queue, *Increment(someTime, 5)).
-			PendingAtTime(cluster, "c", *Increment(someTime, 6))
-
-		NewJobSimulator(t, jobStore).
-			CreateJobAtTime(queue, someTime).
-			PendingAtTime(cluster, "f", *Increment(someTime, 1))
-
-		NewJobSimulator(t, jobStore).
-			CreateJobAtTime(queue, *Increment(someTime, 10)).
-			PendingAtTime(cluster, "a", *Increment(someTime, 11)).
-			RunningAtTime(cluster, "a", node, *Increment(someTime, 12))
-
-		NewJobSimulator(t, jobStore).
-			CreateJobAtTime(queue, *Increment(someTime, 5)).
-			PendingAtTime(cluster, "b", *Increment(someTime, 6)).
-			RunningAtTime(cluster, "b", node, *Increment(someTime, 7))
+			CreateJobAtTime(queue, someTime.Add(5*time.Second)).
+			PendingAtTime(cluster, "c", someTime.Add(6*time.Second))
 
 		NewJobSimulator(t, jobStore).
 			CreateJobAtTime(queue, someTime).
-			RunningAtTime(cluster, "d", node, *Increment(someTime, 1))
+			PendingAtTime(cluster, "f", someTime.Add(1*time.Second))
+
+		NewJobSimulator(t, jobStore).
+			CreateJobAtTime(queue, someTime.Add(10*time.Second)).
+			PendingAtTime(cluster, "a", someTime.Add(11*time.Second)).
+			RunningAtTime(cluster, "a", node, someTime.Add(12*time.Second))
+
+		NewJobSimulator(t, jobStore).
+			CreateJobAtTime(queue, someTime.Add(5*time.Second)).
+			PendingAtTime(cluster, "b", someTime.Add(6*time.Second)).
+			RunningAtTime(cluster, "b", node, someTime.Add(7*time.Second))
 
 		NewJobSimulator(t, jobStore).
 			CreateJobAtTime(queue, someTime).
-			RunningAtTime(cluster, "e", node, *Increment(someTime, 1)).
-			SucceededAtTime(cluster, "e", node, *Increment(someTime, 2))
+			RunningAtTime(cluster, "d", node, someTime.Add(time.Second))
 
 		NewJobSimulator(t, jobStore).
 			CreateJobAtTime(queue, someTime).
-			RunningAtTime(cluster, "g", node, *Increment(someTime, 1)).
-			CancelledAtTime(*Increment(someTime, 2))
+			RunningAtTime(cluster, "e", node, someTime.Add(time.Second)).
+			SucceededAtTime(cluster, "e", node, someTime.Add(2*time.Second))
+
+		NewJobSimulator(t, jobStore).
+			CreateJobAtTime(queue, someTime).
+			RunningAtTime(cluster, "g", node, someTime.Add(time.Second)).
+			CancelledAtTime(someTime.Add(2*time.Second))
 
 		queueInfos, err := jobRepo.GetQueueInfos(ctx)
 		assert.NoError(t, err)
@@ -170,7 +172,6 @@ func TestGetQueueInfos_IncludeOldestQueuedJob(t *testing.T) {
 
 		assert.Equal(t, 0, len(queueInfos[0].OldestQueuedJob.Runs))
 
-		submissionTime := *Increment(someTime, 1)
 		assert.Equal(t, types.DurationProto(someTime2.Sub(submissionTime).Round(time.Second)), queueInfos[0].OldestQueuedDuration)
 	})
 }
@@ -185,16 +186,16 @@ func TestGetQueueInfos_LongestRunningJobIsNilIfNoJobsAreRunning(t *testing.T) {
 
 		NewJobSimulator(t, jobStore).
 			CreateJobAtTime(queue, someTime).
-			PendingAtTime(cluster, "f", *Increment(someTime, 1))
+			PendingAtTime(cluster, "f", someTime.Add(time.Second))
 
 		NewJobSimulator(t, jobStore).
-			CreateJobAtTime(queue, *Increment(someTime, 5)).
-			PendingAtTime(cluster, "c", *Increment(someTime, 6))
+			CreateJobAtTime(queue, someTime.Add(5*time.Second)).
+			PendingAtTime(cluster, "c", someTime.Add(6*time.Second))
 
 		NewJobSimulator(t, jobStore).
 			CreateJobAtTime(queue, someTime).
-			RunningAtTime(cluster, "e", node, *Increment(someTime, 1)).
-			SucceededAtTime(cluster, "e", node, *Increment(someTime, 2))
+			RunningAtTime(cluster, "e", node, someTime.Add(time.Second)).
+			SucceededAtTime(cluster, "e", node, someTime.Add(2*time.Second))
 
 		queueInfos, err := jobRepo.GetQueueInfos(ctx)
 		assert.NoError(t, err)
@@ -211,45 +212,49 @@ func TestGetQueueInfos_IncludeLongestRunningJob(t *testing.T) {
 		jobStore := NewSQLJobStore(db)
 		jobRepo := NewSQLJobRepository(db, &DummyClock{someTime2})
 
+		pendingTime := someTime.Add(2*time.Second)
+		unableToScheduleTime := someTime.Add(3*time.Second)
+		runningTime := someTime.Add(4*time.Second)
+
 		NewJobSimulator(t, jobStore).
 			CreateJobAtTime(queue, someTime)
 
 		NewJobSimulator(t, jobStore).
-			CreateJobAtTime(queue, *Increment(someTime, 5)).
-			PendingAtTime(cluster, "c", *Increment(someTime, 6))
+			CreateJobAtTime(queue, someTime.Add(5*time.Second)).
+			PendingAtTime(cluster, "c", someTime.Add(6*time.Second))
 
 		NewJobSimulator(t, jobStore).
 			CreateJobAtTime(queue, someTime).
-			PendingAtTime(cluster, "f", *Increment(someTime, 1))
+			PendingAtTime(cluster, "f", someTime.Add(time.Second))
 
 		NewJobSimulator(t, jobStore).
-			CreateJobAtTime(queue, *Increment(someTime, 10)).
-			PendingAtTime(cluster, "a1", *Increment(someTime, 11)).
-			UnableToScheduleAtTime(cluster, "a1", node, *Increment(someTime, 12)).
-			RunningAtTime(cluster, "a2", node, *Increment(someTime, 13))
+			CreateJobAtTime(queue, someTime.Add(10*time.Second)).
+			PendingAtTime(cluster, "a1", someTime.Add(11*time.Second)).
+			UnableToScheduleAtTime(cluster, "a1", node, someTime.Add(12*time.Second)).
+			RunningAtTime(cluster, "a2", node, someTime.Add(13*time.Second))
 
 		NewJobSimulator(t, jobStore).
-			CreateJobAtTime(queue, *Increment(someTime, 5)).
-			PendingAtTime(cluster, "b1", *Increment(someTime, 6)).
-			UnableToScheduleAtTime(cluster, "b1", node, *Increment(someTime, 7)).
-			RunningAtTime(cluster, "b2", node, *Increment(someTime, 8))
+			CreateJobAtTime(queue, someTime.Add(5*time.Second)).
+			PendingAtTime(cluster, "b1", someTime.Add(6*time.Second)).
+			UnableToScheduleAtTime(cluster, "b1", node, someTime.Add(7*time.Second)).
+			RunningAtTime(cluster, "b2", node, someTime.Add(8*time.Second))
 
 		longestRunning := NewJobSimulator(t, jobStore).
-			CreateJobAtTime(queue, *Increment(someTime, 1)).
-			PendingAtTime(cluster, "d1", *Increment(someTime, 2)).
-			UnableToScheduleAtTime(cluster, "d1", node, *Increment(someTime, 3)).
-			RunningAtTime(cluster, "d2", node, *Increment(someTime, 4))
+			CreateJobAtTime(queue, someTime.Add(time.Second)).
+			PendingAtTime(cluster, "d1", pendingTime).
+			UnableToScheduleAtTime(cluster, "d1", node, unableToScheduleTime).
+			RunningAtTime(cluster, "d2", node, runningTime)
 
 		NewJobSimulator(t, jobStore).
 			CreateJobAtTime(queue, someTime).
-			RunningAtTime(cluster, "e1", node, *Increment(someTime, 1)).
-			UnableToScheduleAtTime(cluster, "e1", node, *Increment(someTime, 2)).
-			SucceededAtTime(cluster, "e2", node, *Increment(someTime, 3))
+			RunningAtTime(cluster, "e1", node, someTime.Add(time.Second)).
+			UnableToScheduleAtTime(cluster, "e1", node, someTime.Add(2*time.Second)).
+			SucceededAtTime(cluster, "e2", node, someTime.Add(3*time.Second))
 
 		NewJobSimulator(t, jobStore).
 			CreateJobAtTime(queue, someTime).
-			RunningAtTime(cluster, "g", node, *Increment(someTime, 1)).
-			CancelledAtTime(*Increment(someTime, 2))
+			RunningAtTime(cluster, "g", node, someTime.Add(time.Second)).
+			CancelledAtTime(someTime.Add(2*time.Second))
 
 		queueInfos, err := jobRepo.GetQueueInfos(ctx)
 		assert.NoError(t, err)
@@ -265,25 +270,24 @@ func TestGetQueueInfos_IncludeLongestRunningJob(t *testing.T) {
 			Cluster:   cluster,
 			Node:      node,
 			Succeeded: false,
-			Created:   Increment(someTime, 2),
+			Created:   &pendingTime,
 			Started:   nil,
-			Finished:  Increment(someTime, 3),
+			Finished:  &unableToScheduleTime,
 			Error:     "",
 		}, queueInfos[0].LongestRunningJob.Runs[0])
 
-		startRunningTime := *Increment(someTime, 4)
 		AssertRunInfosEquivalent(t, &lookout.RunInfo{
 			K8SId:     "d2",
 			Cluster:   cluster,
 			Node:      node,
 			Succeeded: false,
 			Created:   nil,
-			Started:   &startRunningTime,
+			Started:   &runningTime,
 			Finished:  nil,
 			Error:     "",
 		}, queueInfos[0].LongestRunningJob.Runs[1])
 
-		assert.Equal(t, types.DurationProto(someTime2.Sub(startRunningTime).Round(time.Second)), queueInfos[0].LongestRunningDuration)
+		assert.Equal(t, types.DurationProto(someTime2.Sub(runningTime).Round(time.Second)), queueInfos[0].LongestRunningDuration)
 	})
 }
 
@@ -292,64 +296,70 @@ func TestGetQueueInfos_MultipleQueues(t *testing.T) {
 		jobStore := NewSQLJobStore(db)
 		jobRepo := NewSQLJobRepository(db, &DefaultClock{})
 
+		queue1PendingTime := someTime.Add(time.Second)
+		queue1UnableToScheduleTime := someTime.Add(2*time.Second)
+		queue1RunningTime := someTime.Add(3*time.Second)
+
+		queue2RunningTime := someTime.Add(time.Second)
+
 		// Queue 1
 		NewJobSimulator(t, jobStore).
-			CreateJobAtTime(queue, *Increment(someTime, 5))
+			CreateJobAtTime(queue, someTime.Add(5*time.Second))
 
 		oldestQueued1 := NewJobSimulator(t, jobStore).
 			CreateJobAtTime(queue, someTime)
 
 		NewJobSimulator(t, jobStore).
 			CreateJobAtTime(queue, someTime).
-			PendingAtTime(cluster, "a", *Increment(someTime, 1))
+			PendingAtTime(cluster, "a", someTime.Add(time.Second))
 
 		NewJobSimulator(t, jobStore).
-			CreateJobAtTime(queue, *Increment(someTime, 5)).
-			PendingAtTime(cluster, "b1", *Increment(someTime, 6)).
-			UnableToScheduleAtTime(cluster, "b1", node, *Increment(someTime, 7)).
-			RunningAtTime(cluster, "b2", node, *Increment(someTime, 8))
+			CreateJobAtTime(queue, someTime.Add(5*time.Second)).
+			PendingAtTime(cluster, "b1", someTime.Add(6*time.Second)).
+			UnableToScheduleAtTime(cluster, "b1", node, someTime.Add(7*time.Second)).
+			RunningAtTime(cluster, "b2", node, someTime.Add(8*time.Second))
 
 		longestRunning1 := NewJobSimulator(t, jobStore).
 			CreateJobAtTime(queue, someTime).
-			PendingAtTime(cluster, "c1", *Increment(someTime, 1)).
-			UnableToScheduleAtTime(cluster, "c1", node, *Increment(someTime, 2)).
-			RunningAtTime(cluster, "c2", node, *Increment(someTime, 3))
+			PendingAtTime(cluster, "c1", queue1PendingTime).
+			UnableToScheduleAtTime(cluster, "c1", node, queue1UnableToScheduleTime).
+			RunningAtTime(cluster, "c2", node, queue1RunningTime)
 
 		NewJobSimulator(t, jobStore).
 			CreateJobAtTime(queue, someTime).
-			PendingAtTime(cluster, "d1", *Increment(someTime, 1)).
-			UnableToScheduleAtTime(cluster, "d1", node, *Increment(someTime, 2)).
-			RunningAtTime(cluster, "d2", node, *Increment(someTime, 3)).
-			SucceededAtTime(cluster, "d2", node, *Increment(someTime, 4))
+			PendingAtTime(cluster, "d1", someTime.Add(time.Second)).
+			UnableToScheduleAtTime(cluster, "d1", node, someTime.Add(2*time.Second)).
+			RunningAtTime(cluster, "d2", node, someTime.Add(3*time.Second)).
+			SucceededAtTime(cluster, "d2", node, someTime.Add(4*time.Second))
 
 		NewJobSimulator(t, jobStore).
 			CreateJobAtTime(queue, someTime).
-			CancelledAtTime(*Increment(someTime, 1))
+			CancelledAtTime(someTime.Add(time.Second))
 
 		// Queue 2
 		NewJobSimulator(t, jobStore).
-			CreateJobAtTime(queue2, *Increment(someTime, 5))
+			CreateJobAtTime(queue2, someTime.Add(5*time.Second))
 
 		oldestQueued2 := NewJobSimulator(t, jobStore).
 			CreateJobAtTime(queue2, someTime)
 
 		NewJobSimulator(t, jobStore).
 			CreateJobAtTime(queue2, someTime).
-			PendingAtTime(cluster, "e", *Increment(someTime, 1))
+			PendingAtTime(cluster, "e", someTime.Add(1*time.Second))
 
 		NewJobSimulator(t, jobStore).
-			CreateJobAtTime(queue2, *Increment(someTime, 5)).
-			RunningAtTime(cluster, "f", node, *Increment(someTime, 6))
+			CreateJobAtTime(queue2, someTime.Add(5*time.Second)).
+			RunningAtTime(cluster, "f", node, someTime.Add(6*time.Second))
 
 		longestRunning2 := NewJobSimulator(t, jobStore).
 			CreateJobAtTime(queue2, someTime).
-			RunningAtTime(cluster, "g", node, *Increment(someTime, 1))
+			RunningAtTime(cluster, "g", node, queue2RunningTime)
 
 		NewJobSimulator(t, jobStore).
-			CreateJobAtTime(queue2, *Increment(someTime, 1)).
-			PendingAtTime(cluster, "h1", *Increment(someTime, 2)).
-			UnableToScheduleAtTime(cluster, "h1", node, *Increment(someTime, 3)).
-			RunningAtTime(cluster, "h2", node, *Increment(someTime, 4))
+			CreateJobAtTime(queue2, someTime.Add(time.Second)).
+			PendingAtTime(cluster, "h1", someTime.Add(2*time.Second)).
+			UnableToScheduleAtTime(cluster, "h1", node, someTime.Add(3*time.Second)).
+			RunningAtTime(cluster, "h2", node, someTime.Add(4*time.Second))
 
 		queueInfos, err := jobRepo.GetQueueInfos(ctx)
 		assert.NoError(t, err)
@@ -380,21 +390,14 @@ func TestGetQueueInfos_MultipleQueues(t *testing.T) {
 			K8SId:     "c1",
 			Cluster:   cluster,
 			Node:      node,
-			Succeeded: false,
-			Created:   Increment(someTime, 1),
-			Started:   nil,
-			Finished:  Increment(someTime, 2),
-			Error:     "",
+			Created:   &queue1PendingTime,
+			Finished:  &queue1UnableToScheduleTime,
 		}, queueInfos[0].LongestRunningJob.Runs[0])
 		AssertRunInfosEquivalent(t, &lookout.RunInfo{
 			K8SId:     "c2",
 			Cluster:   cluster,
 			Node:      node,
-			Succeeded: false,
-			Created:   nil,
-			Started:   Increment(someTime, 3),
-			Finished:  nil,
-			Error:     "",
+			Started:   &queue1RunningTime,
 		}, queueInfos[0].LongestRunningJob.Runs[1])
 
 		AssertJobsAreEquivalent(t, oldestQueued2.job, queueInfos[1].OldestQueuedJob.Job)
@@ -410,11 +413,7 @@ func TestGetQueueInfos_MultipleQueues(t *testing.T) {
 			K8SId:     "g",
 			Cluster:   cluster,
 			Node:      node,
-			Succeeded: false,
-			Created:   nil,
-			Started:   Increment(someTime, 1),
-			Finished:  nil,
-			Error:     "",
+			Started:   &queue2RunningTime,
 		}, queueInfos[1].LongestRunningJob.Runs[0])
 	})
 }

--- a/internal/lookout/repository/queues_test.go
+++ b/internal/lookout/repository/queues_test.go
@@ -102,7 +102,7 @@ func TestGetQueueInfos_OldestQueuedJobIsNilIfNoJobsAreQueued(t *testing.T) {
 		NewJobSimulator(t, jobStore).
 			CreateJobAtTime(queue, someTime).
 			RunningAtTime(cluster, "g", node, someTime.Add(time.Second)).
-			CancelledAtTime(someTime.Add(2*time.Second))
+			CancelledAtTime(someTime.Add(2 * time.Second))
 
 		queueInfos, err := jobRepo.GetQueueInfos(ctx)
 		assert.NoError(t, err)
@@ -160,7 +160,7 @@ func TestGetQueueInfos_IncludeOldestQueuedJob(t *testing.T) {
 		NewJobSimulator(t, jobStore).
 			CreateJobAtTime(queue, someTime).
 			RunningAtTime(cluster, "g", node, someTime.Add(time.Second)).
-			CancelledAtTime(someTime.Add(2*time.Second))
+			CancelledAtTime(someTime.Add(2 * time.Second))
 
 		queueInfos, err := jobRepo.GetQueueInfos(ctx)
 		assert.NoError(t, err)
@@ -212,9 +212,9 @@ func TestGetQueueInfos_IncludeLongestRunningJob(t *testing.T) {
 		jobStore := NewSQLJobStore(db)
 		jobRepo := NewSQLJobRepository(db, &DummyClock{someTime2})
 
-		pendingTime := someTime.Add(2*time.Second)
-		unableToScheduleTime := someTime.Add(3*time.Second)
-		runningTime := someTime.Add(4*time.Second)
+		pendingTime := someTime.Add(2 * time.Second)
+		unableToScheduleTime := someTime.Add(3 * time.Second)
+		runningTime := someTime.Add(4 * time.Second)
 
 		NewJobSimulator(t, jobStore).
 			CreateJobAtTime(queue, someTime)
@@ -254,7 +254,7 @@ func TestGetQueueInfos_IncludeLongestRunningJob(t *testing.T) {
 		NewJobSimulator(t, jobStore).
 			CreateJobAtTime(queue, someTime).
 			RunningAtTime(cluster, "g", node, someTime.Add(time.Second)).
-			CancelledAtTime(someTime.Add(2*time.Second))
+			CancelledAtTime(someTime.Add(2 * time.Second))
 
 		queueInfos, err := jobRepo.GetQueueInfos(ctx)
 		assert.NoError(t, err)
@@ -297,8 +297,8 @@ func TestGetQueueInfos_MultipleQueues(t *testing.T) {
 		jobRepo := NewSQLJobRepository(db, &DefaultClock{})
 
 		queue1PendingTime := someTime.Add(time.Second)
-		queue1UnableToScheduleTime := someTime.Add(2*time.Second)
-		queue1RunningTime := someTime.Add(3*time.Second)
+		queue1UnableToScheduleTime := someTime.Add(2 * time.Second)
+		queue1RunningTime := someTime.Add(3 * time.Second)
 
 		queue2RunningTime := someTime.Add(time.Second)
 
@@ -387,17 +387,17 @@ func TestGetQueueInfos_MultipleQueues(t *testing.T) {
 		assert.Equal(t, string(JobRunning), queueInfos[0].LongestRunningJob.JobState)
 		assert.Equal(t, 2, len(queueInfos[0].LongestRunningJob.Runs))
 		AssertRunInfosEquivalent(t, &lookout.RunInfo{
-			K8SId:     "c1",
-			Cluster:   cluster,
-			Node:      node,
-			Created:   &queue1PendingTime,
-			Finished:  &queue1UnableToScheduleTime,
+			K8SId:    "c1",
+			Cluster:  cluster,
+			Node:     node,
+			Created:  &queue1PendingTime,
+			Finished: &queue1UnableToScheduleTime,
 		}, queueInfos[0].LongestRunningJob.Runs[0])
 		AssertRunInfosEquivalent(t, &lookout.RunInfo{
-			K8SId:     "c2",
-			Cluster:   cluster,
-			Node:      node,
-			Started:   &queue1RunningTime,
+			K8SId:   "c2",
+			Cluster: cluster,
+			Node:    node,
+			Started: &queue1RunningTime,
 		}, queueInfos[0].LongestRunningJob.Runs[1])
 
 		AssertJobsAreEquivalent(t, oldestQueued2.job, queueInfos[1].OldestQueuedJob.Job)
@@ -410,10 +410,10 @@ func TestGetQueueInfos_MultipleQueues(t *testing.T) {
 		assert.Equal(t, string(JobRunning), queueInfos[1].LongestRunningJob.JobState)
 		assert.Equal(t, 1, len(queueInfos[1].LongestRunningJob.Runs))
 		AssertRunInfosEquivalent(t, &lookout.RunInfo{
-			K8SId:     "g",
-			Cluster:   cluster,
-			Node:      node,
-			Started:   &queue2RunningTime,
+			K8SId:   "g",
+			Cluster: cluster,
+			Node:    node,
+			Started: &queue2RunningTime,
 		}, queueInfos[1].LongestRunningJob.Runs[0])
 	})
 }

--- a/internal/lookout/repository/utils_test.go
+++ b/internal/lookout/repository/utils_test.go
@@ -59,12 +59,6 @@ func AssertTimesApproxEqual(t *testing.T, expected *time.Time, actual *time.Time
 	assert.Equal(t, expected.Round(time.Second).UTC(), actual.Round(time.Second).UTC())
 }
 
-// Increment given time by a number of minutes, returns pointer to new time
-func Increment(t time.Time, x int) *time.Time {
-	i := t.Add(time.Minute * time.Duration(x))
-	return &i
-}
-
 type JobSimulator struct {
 	t        *testing.T
 	jobStore JobRecorder

--- a/internal/lookout/repository/utils_test.go
+++ b/internal/lookout/repository/utils_test.go
@@ -14,16 +14,18 @@ import (
 )
 
 var (
-	queue   = "queue"
-	queue2  = "queue2"
-	cluster = "cluster"
-	k8sId1  = util.NewULID()
-	k8sId2  = util.NewULID()
-	k8sId3  = util.NewULID()
-	k8sId4  = util.NewULID()
-	k8sId5  = util.NewULID()
-	node    = "node"
-	ctx     = context.Background()
+	queue        = "queue"
+	queue2       = "queue2"
+	cluster      = "cluster"
+	k8sId1       = util.NewULID()
+	k8sId2       = util.NewULID()
+	k8sId3       = util.NewULID()
+	k8sId4       = util.NewULID()
+	k8sId5       = util.NewULID()
+	node         = "node"
+	someTimeUnix = int64(1612546858)
+	someTime     = time.Unix(someTimeUnix, 0)
+	ctx          = context.Background()
 )
 
 func AssertJobsAreEquivalent(t *testing.T, expected *api.Job, actual *api.Job) {
@@ -43,7 +45,7 @@ func AssertRunInfosEquivalent(t *testing.T, expected *lookout.RunInfo, actual *l
 	assert.Equal(t, expected.Succeeded, actual.Succeeded)
 	AssertTimesApproxEqual(t, expected.Created, actual.Created)
 	AssertTimesApproxEqual(t, expected.Started, actual.Started)
-	AssertTimesApproxEqual(t, expected.Finished, expected.Finished)
+	AssertTimesApproxEqual(t, expected.Finished, actual.Finished)
 	assert.Equal(t, expected.Error, actual.Error)
 }
 
@@ -54,7 +56,7 @@ func AssertTimesApproxEqual(t *testing.T, expected *time.Time, actual *time.Time
 		assert.Nil(t, actual)
 		return
 	}
-	assert.Equal(t, expected.Round(time.Millisecond).UTC(), actual.Round(time.Millisecond).UTC())
+	assert.Equal(t, expected.Round(time.Second).UTC(), actual.Round(time.Second).UTC())
 }
 
 // Increment given time by a number of minutes, returns pointer to new time
@@ -66,7 +68,6 @@ func Increment(t time.Time, x int) *time.Time {
 type JobSimulator struct {
 	t        *testing.T
 	jobStore JobRecorder
-	clock    Clock
 	job      *api.Job
 }
 
@@ -78,46 +79,31 @@ func (c *DummyClock) Now() time.Time {
 	return c.t
 }
 
-type incrementClock struct {
-	startTime  time.Time
-	increments int
-}
-
-func NewIncrementClock(startTime time.Time) *incrementClock {
-	return &incrementClock{
-		startTime:  startTime,
-		increments: 0,
-	}
-}
-
-func (c *incrementClock) Now() time.Time {
-	t := Increment(c.startTime, c.increments)
-	c.increments++
-	return *t
-}
-
-func NewJobSimulator(t *testing.T, jobStore JobRecorder, timeProvider Clock) *JobSimulator {
+func NewJobSimulator(t *testing.T, jobStore JobRecorder) *JobSimulator {
 	return &JobSimulator{
 		t:        t,
 		jobStore: jobStore,
-		clock:    timeProvider,
 		job:      nil,
 	}
 }
 
 func (js *JobSimulator) CreateJob(queue string) *JobSimulator {
-	return js.CreateJobWithOpts(queue, util.NewULID(), "job-set")
+	return js.CreateJobWithOpts(queue, util.NewULID(), "job-set", time.Now())
 }
 
 func (js *JobSimulator) CreateJobWithId(queue string, id string) *JobSimulator {
-	return js.CreateJobWithOpts(queue, id, "job-set")
+	return js.CreateJobWithOpts(queue, id, "job-set", time.Now())
 }
 
 func (js *JobSimulator) CreateJobWithJobSet(queue string, jobSetId string) *JobSimulator {
-	return js.CreateJobWithOpts(queue, util.NewULID(), jobSetId)
+	return js.CreateJobWithOpts(queue, util.NewULID(), jobSetId, time.Now())
 }
 
-func (js *JobSimulator) CreateJobWithOpts(queue string, jobId string, jobSetId string) *JobSimulator {
+func (js *JobSimulator) CreateJobAtTime(queue string, time time.Time) *JobSimulator {
+	return js.CreateJobWithOpts(queue, util.NewULID(), "job-set", time)
+}
+
+func (js *JobSimulator) CreateJobWithOpts(queue string, jobId string, jobSetId string, time time.Time) *JobSimulator {
 	js.job = &api.Job{
 		Id:          jobId,
 		JobSetId:    jobSetId,
@@ -128,18 +114,22 @@ func (js *JobSimulator) CreateJobWithOpts(queue string, jobId string, jobSetId s
 		Owner:       "user",
 		Priority:    10,
 		PodSpec:     &v1.PodSpec{},
-		Created:     js.clock.Now(),
+		Created:     time,
 	}
 	assert.NoError(js.t, js.jobStore.RecordJob(js.job))
 	return js
 }
 
 func (js *JobSimulator) Pending(cluster string, k8sId string) *JobSimulator {
+	return js.PendingAtTime(cluster, k8sId, time.Now())
+}
+
+func (js *JobSimulator) PendingAtTime(cluster string, k8sId string, time time.Time) *JobSimulator {
 	event := &api.JobPendingEvent{
 		JobId:        js.job.Id,
 		JobSetId:     js.job.JobSetId,
 		Queue:        js.job.Queue,
-		Created:      js.clock.Now(),
+		Created:      time,
 		ClusterId:    cluster,
 		KubernetesId: k8sId,
 	}
@@ -148,11 +138,15 @@ func (js *JobSimulator) Pending(cluster string, k8sId string) *JobSimulator {
 }
 
 func (js *JobSimulator) Running(cluster string, k8sId string, node string) *JobSimulator {
+	return js.RunningAtTime(cluster, k8sId, node, time.Now())
+}
+
+func (js *JobSimulator) RunningAtTime(cluster string, k8sId string, node string, time time.Time) *JobSimulator {
 	event := &api.JobRunningEvent{
 		JobId:        js.job.Id,
 		JobSetId:     js.job.JobSetId,
 		Queue:        js.job.Queue,
-		Created:      js.clock.Now(),
+		Created:      time,
 		ClusterId:    cluster,
 		KubernetesId: k8sId,
 		NodeName:     node,
@@ -162,11 +156,15 @@ func (js *JobSimulator) Running(cluster string, k8sId string, node string) *JobS
 }
 
 func (js *JobSimulator) Succeeded(cluster string, k8sId string, node string) *JobSimulator {
+	return js.SucceededAtTime(cluster, k8sId, node, time.Now())
+}
+
+func (js *JobSimulator) SucceededAtTime(cluster string, k8sId string, node string, time time.Time) *JobSimulator {
 	event := &api.JobSucceededEvent{
 		JobId:        js.job.Id,
 		JobSetId:     js.job.JobSetId,
 		Queue:        js.job.Queue,
-		Created:      js.clock.Now(),
+		Created:      time,
 		ClusterId:    cluster,
 		KubernetesId: k8sId,
 		NodeName:     node,
@@ -176,11 +174,15 @@ func (js *JobSimulator) Succeeded(cluster string, k8sId string, node string) *Jo
 }
 
 func (js *JobSimulator) Failed(cluster string, k8sId string, node string, error string) *JobSimulator {
+	return js.FailedAtTime(cluster, k8sId, node, error, time.Now())
+}
+
+func (js *JobSimulator) FailedAtTime(cluster string, k8sId string, node string, error string, time time.Time) *JobSimulator {
 	failedEvent := &api.JobFailedEvent{
 		JobId:        js.job.Id,
 		JobSetId:     js.job.JobSetId,
 		Queue:        js.job.Queue,
-		Created:      time.Now(),
+		Created:      time,
 		ClusterId:    cluster,
 		Reason:       error,
 		ExitCodes:    nil,
@@ -192,22 +194,30 @@ func (js *JobSimulator) Failed(cluster string, k8sId string, node string, error 
 }
 
 func (js *JobSimulator) Cancelled() *JobSimulator {
+	return js.CancelledAtTime(time.Now())
+}
+
+func (js *JobSimulator) CancelledAtTime(time time.Time) *JobSimulator {
 	cancelledEvent := &api.JobCancelledEvent{
 		JobId:    js.job.Id,
 		JobSetId: js.job.JobSetId,
 		Queue:    js.job.Queue,
-		Created:  js.clock.Now(),
+		Created:  time,
 	}
 	assert.NoError(js.t, js.jobStore.MarkCancelled(cancelledEvent))
 	return js
 }
 
 func (js *JobSimulator) UnableToSchedule(cluster string, k8sId string, node string) *JobSimulator {
+	return js.UnableToScheduleAtTime(cluster, k8sId, node, time.Now())
+}
+
+func (js *JobSimulator) UnableToScheduleAtTime(cluster string, k8sId string, node string, time time.Time) *JobSimulator {
 	unableToScheduleEvent := &api.JobUnableToScheduleEvent{
 		JobId:        js.job.Id,
 		JobSetId:     js.job.JobSetId,
 		Queue:        js.job.Queue,
-		Created:      js.clock.Now(),
+		Created:      time,
 		ClusterId:    cluster,
 		Reason:       "unable to schedule reason",
 		KubernetesId: k8sId,


### PR DESCRIPTION
Some tests could fail due to off by one errors in rounding to the nearest millisecond. To fix this, we round to the nearest second and use the same timestamp for every test run.