### PR TITLE
Update CircleCI machine image ant turn off docker layer caching.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ commands:
 jobs:
   build:
     machine:
-      docker_layer_caching: true
+      docker_layer_caching: false
       image: ubuntu-2004:202101-01
     environment:
       GO111MODULE: "on"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
   build:
     machine:
       docker_layer_caching: true
-      image: ubuntu-2004:202010-01
+      image: ubuntu-2004:202101-01
     environment:
       GO111MODULE: "on"
       GOPATH: "/home/circleci/go"


### PR DESCRIPTION
For yet unknown reason our builds started failing with circle ci docker image caching layer enabled. Temporary removal of the caching fixes the issue and surprisingly does not make the pipeline run for much longer.