### PR TITLE
Fix quickstart guide following Helm chart moves

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -46,7 +46,7 @@ Make sure Helm is configured to use the required chart repos:
 ```bash
 helm repo add stable https://charts.helm.sh/stable
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo add gresearch https://g-research.github.io/charts/
+helm repo add gresearch https://g-research.github.io/charts
 ```
 
 ## Installation

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,8 +6,8 @@ The purpose of this guide is to install a minimal local Armada deployment for te
 
 - Git
 - Docker
-- Helm v3
-- Kind
+- Helm v3.5+
+- Kind v0.10.0+
 - Kubectl
 
 ### OS specifics

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -41,15 +41,11 @@ All the commands below should be executed in Git Bash.
 
 ### Helm
 
-Make sure helm is configured to use the official Helm stable charts:
+Make sure Helm is configured to use the required chart repos:
 
 ```bash
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
-```
-
-And add the G-Research helm charts repository, too:
-
-```bash
+helm repo add stable https://charts.helm.sh/stable
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo add gresearch https://g-research.github.io/charts/
 ```
 
@@ -71,13 +67,13 @@ All commands are intended to be run from the root of the repository.
 kind create cluster --name quickstart-armada-server --config ./docs/quickstart/kind-config-server.yaml
 
 # Set cluster as current context
-export KUBECONFIG="$(kind get kubeconfig-path --name="quickstart-armada-server")"
+kind export kubeconfig --name=quickstart-armada-server
 
 # Install Redis
 helm install redis stable/redis-ha -f docs/quickstart/redis-values.yaml
 
 # Install Prometheus
-helm install prometheus-operator stable/prometheus-operator -f docs/quickstart/server-prometheus-values.yaml
+helm install kube-prometheus-stack prometheus-community/kube-prometheus-stack -f docs/quickstart/server-prometheus-values.yaml
 
 # Install Armada server
 helm install armada-server gresearch/armada -f ./docs/quickstart/server-values.yaml
@@ -94,10 +90,10 @@ First executor:
 kind create cluster --name quickstart-armada-executor-0 --config ./docs/quickstart/kind-config-executor.yaml
 
 # Set cluster as current context
-export KUBECONFIG="$(kind get kubeconfig-path --name="quickstart-armada-executor-0")"
+kind export kubeconfig --name=quickstart-armada-executor-0
 
 # Install Prometheus
-helm install prometheus-operator stable/prometheus-operator -f docs/quickstart/executor-prometheus-values.yaml
+helm install kube-prometheus-stack prometheus-community/kube-prometheus-stack -f docs/quickstart/executor-prometheus-values.yaml
 
 # Install executor
 helm install armada-executor gresearch/armada-executor --set applicationConfig.apiConnection.armadaUrl="$SERVER_IP:30000" -f docs/quickstart/executor-values.yaml
@@ -113,10 +109,10 @@ Second executor:
 kind create cluster --name quickstart-armada-executor-1 --config ./docs/quickstart/kind-config-executor.yaml
 
 # Set cluster as current context
-export KUBECONFIG="$(kind get kubeconfig-path --name="quickstart-armada-executor-1")"
+kind export kubeconfig --name=quickstart-armada-executor-1
 
 # Install Prometheus
-helm install prometheus-operator stable/prometheus-operator -f docs/quickstart/executor-prometheus-values.yaml
+helm install kube-prometheus-stack prometheus-community/kube-prometheus-stack -f docs/quickstart/executor-prometheus-values.yaml
 
 # Install executor
 helm install armada-executor gresearch/armada-executor --set applicationConfig.apiConnection.armadaUrl="$SERVER_IP:30000" -f docs/quickstart/executor-values.yaml

--- a/docs/quickstart/executor-prometheus-values.yaml
+++ b/docs/quickstart/executor-prometheus-values.yaml
@@ -15,6 +15,8 @@ prometheus:
 prometheusOperator:
   admissionWebhooks:
     enabled: false
+  tls:
+    enabled: false
   tlsProxy:
     enabled: false
   createCustomResource: false

--- a/docs/quickstart/kind-config-executor.yaml
+++ b/docs/quickstart/kind-config-executor.yaml
@@ -1,5 +1,5 @@
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
 - role: worker

--- a/docs/quickstart/kind-config-server.yaml
+++ b/docs/quickstart/kind-config-server.yaml
@@ -1,5 +1,5 @@
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
 - role: worker

--- a/docs/quickstart/server-prometheus-values.yaml
+++ b/docs/quickstart/server-prometheus-values.yaml
@@ -13,6 +13,8 @@ grafana:
 prometheusOperator:
   admissionWebhooks:
     enabled: false
+  tls:
+    enabled: false
   tlsProxy:
     enabled: false
   createCustomResource: false


### PR DESCRIPTION
- https://kubernetes-charts.storage.googleapis.com/ is now https://charts.helm.sh/stable
- Kind API upgrade
- Use new Prometheus chart, disable TLS which is now on by default