### PR TITLE
Apply queue priority factor after minimum.

### DIFF
--- a/internal/armada/scheduling/priority.go
+++ b/internal/armada/scheduling/priority.go
@@ -24,7 +24,7 @@ func CalculateQueuesPriorityInfo(clusterPriorities map[string]map[string]float64
 		priority := minPriority
 		currentPriority, ok := queuePriority[queue.Name]
 		if ok {
-			priority = math.Max(currentPriority*queue.PriorityFactor, minPriority)
+			priority = math.Max(currentPriority, minPriority) * queue.PriorityFactor
 		}
 		resultPriorityMap[queue] = QueuePriorityInfo{
 			Priority:     priority,


### PR DESCRIPTION
This will give head start to queues with lower priority factor in cases where there were no jobs running for long time.