### PR TITLE
Lookout DB - add database/sql connection pool parameters

### DIFF
--- a/cmd/lookout/main.go
+++ b/cmd/lookout/main.go
@@ -38,10 +38,12 @@ func main() {
 	common.LoadConfig(&config, "./config/lookout", userSpecifiedConfig)
 
 	if viper.GetBool(MigrateDatabase) {
-		db, err := postgres.Open(config.PostgresConnection)
+		db, err := postgres.Open(config.Postgres.Connection)
 		if err != nil {
 			panic(err)
 		}
+		lookout.ConfigurePostgresDb(db, config.Postgres)
+
 		err = schema.UpdateDatabase(db)
 		if err != nil {
 			panic(err)

--- a/config/lookout/config.yaml
+++ b/config/lookout/config.yaml
@@ -5,13 +5,17 @@ metricsPort: 9009
 uiConfig:
   armadaApiBaseUrl: "http://localhost:8080"
 
-PostgresConnection:
-  host: localhost
-  port: 5432
-  user: postgres
-  password: psw
-  dbname: postgres
-  sslmode: disable
+postgres:
+  maxOpenConns: 100
+  maxIdleConns: 25
+  connMaxLifetime: 30m
+  connection:
+    host: localhost
+    port: 5432
+    user: postgres
+    password: psw
+    dbname: postgres
+    sslmode: disable
 
 nats:
   Servers:

--- a/internal/lookout/configuration/types.go
+++ b/internal/lookout/configuration/types.go
@@ -1,5 +1,7 @@
 package configuration
 
+import "time"
+
 type NatsConfig struct {
 	Servers    []string
 	ClusterID  string
@@ -11,6 +13,13 @@ type LookoutUIConfig struct {
 	ArmadaApiBaseUrl string
 }
 
+type PostgresConfig struct {
+	MaxOpenConns    int
+	MaxIdleConns    int
+	ConnMaxLifetime time.Duration
+	Connection      map[string]string
+}
+
 type LookoutConfiguration struct {
 	HttpPort    uint16
 	GrpcPort    uint16
@@ -18,6 +27,6 @@ type LookoutConfiguration struct {
 
 	UIConfig LookoutUIConfig
 
-	Nats               NatsConfig
-	PostgresConnection map[string]string
+	Nats     NatsConfig
+	Postgres PostgresConfig
 }


### PR DESCRIPTION
Enables setting the following `database/sql` connection pool parameter values:
- MaxOpenConns
- MaxIdleConns
- ConnMaxLifetime

Probably a good idea to add metrics reporting connection stats in the future.