### PR TITLE
Add Prometheus metrics to Lookout

### DIFF
--- a/internal/lookout/application.go
+++ b/internal/lookout/application.go
@@ -61,9 +61,9 @@ func StartUp(config configuration.LookoutConfiguration) (func(), *sync.WaitGroup
 	eventProcessor.Start()
 
 	dbMetricsProvider := metrics.NewLookoutSqlDbMetricsProvider(db, config.Postgres)
-	metricsCollector := metrics.ExposeLookoutMetrics(dbMetricsProvider)
+	metrics.ExposeLookoutMetrics(dbMetricsProvider)
 
-	lookoutServer := server.NewLookoutServer(jobRepository, metricsCollector)
+	lookoutServer := server.NewLookoutServer(jobRepository)
 	lookout.RegisterLookoutServer(grpcServer, lookoutServer)
 
 	grpc_prometheus.Register(grpcServer)

--- a/internal/lookout/application.go
+++ b/internal/lookout/application.go
@@ -2,6 +2,7 @@ package lookout
 
 import (
 	"fmt"
+	"github.com/G-Research/armada/internal/lookout/metrics"
 	"net"
 	"strings"
 	"sync"
@@ -62,6 +63,7 @@ func StartUp(config configuration.LookoutConfiguration) (func(), *sync.WaitGroup
 	lookoutServer := server.NewLookoutServer(jobRepository)
 	lookout.RegisterLookoutServer(grpcServer, lookoutServer)
 
+	metrics.ExposeLookoutMetrics()
 	grpc_prometheus.Register(grpcServer)
 
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", config.GrpcPort))

--- a/internal/lookout/metrics/db_metrics_provider.go
+++ b/internal/lookout/metrics/db_metrics_provider.go
@@ -1,0 +1,5 @@
+package metrics
+
+type LookoutDbMetricsProvider interface {
+	GetOpenConnections()
+}

--- a/internal/lookout/metrics/db_metrics_provider.go
+++ b/internal/lookout/metrics/db_metrics_provider.go
@@ -1,5 +1,35 @@
 package metrics
 
+import (
+	"database/sql"
+
+	"github.com/G-Research/armada/internal/lookout/configuration"
+)
+
 type LookoutDbMetricsProvider interface {
-	GetOpenConnections()
+	GetOpenConnections() int
+	GetOpenConnectionsUtilization() float64
+}
+
+type LookoutSqlDbMetricsProvider struct {
+	db             *sql.DB
+	postgresConfig configuration.PostgresConfig
+}
+
+func NewLookoutSqlDbMetricsProvider(db *sql.DB, postgresConfig configuration.PostgresConfig) *LookoutSqlDbMetricsProvider {
+	return &LookoutSqlDbMetricsProvider{
+		db:             db,
+		postgresConfig: postgresConfig,
+	}
+}
+
+func (provider *LookoutSqlDbMetricsProvider) GetOpenConnections() int {
+	return provider.db.Stats().OpenConnections
+}
+
+func (provider *LookoutSqlDbMetricsProvider) GetOpenConnectionsUtilization() float64 {
+	if provider.postgresConfig.MaxOpenConns <= 0 {
+		return float64(provider.GetOpenConnections())
+	}
+	return float64(provider.db.Stats().OpenConnections) / float64(provider.postgresConfig.MaxOpenConns)
 }

--- a/internal/lookout/metrics/metrics.go
+++ b/internal/lookout/metrics/metrics.go
@@ -1,0 +1,41 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const MetricPrefix = "lookout_"
+
+var RequestsTotalCounter = prometheus.NewCounter(prometheus.CounterOpts{
+	Name: MetricPrefix + "requests_total",
+	Help: "Total number of incoming requests",
+})
+
+var dbOpenConnectionsDesc = prometheus.NewDesc(
+	MetricPrefix+"db_open_connections",
+	"Number of open connections to database",
+	nil,
+	nil,
+)
+
+var dbOpenConnectionsUtilizationDesc = prometheus.NewDesc(
+	MetricPrefix+"db_open_connections_utilization",
+	"Percentage of connections used over total allowed connections to database",
+	nil,
+	nil,
+)
+
+type LookoutDbCollector struct{}
+
+func ExposeLookoutMetrics() {
+	prometheus.MustRegister(RequestsTotalCounter)
+}
+
+func (c *LookoutDbCollector) Describe(desc chan<- *prometheus.Desc) {
+	desc <- dbOpenConnectionsDesc
+	desc <- dbOpenConnectionsUtilizationDesc
+}
+
+func (c *LookoutDbCollector) Collect(metrics chan<- prometheus.Metric) {
+
+}

--- a/internal/lookout/metrics/metrics.go
+++ b/internal/lookout/metrics/metrics.go
@@ -49,4 +49,3 @@ func (c *LookoutApiCollector) Collect(metrics chan<- prometheus.Metric) {
 	metrics <- prometheus.MustNewConstMetric(dbOpenConnectionsDesc, prometheus.GaugeValue, float64(nOpenConnections))
 	metrics <- prometheus.MustNewConstMetric(dbOpenConnectionsUtilizationDesc, prometheus.GaugeValue, openConnectionsUtilization)
 }
-

--- a/internal/lookout/server/lookout.go
+++ b/internal/lookout/server/lookout.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"github.com/G-Research/armada/internal/lookout/metrics"
 
 	"github.com/gogo/protobuf/types"
 	"google.golang.org/grpc/codes"
@@ -20,6 +21,7 @@ func NewLookoutServer(jobRepository repository.JobRepository) *LookoutServer {
 }
 
 func (s *LookoutServer) Overview(ctx context.Context, _ *types.Empty) (*lookout.SystemOverview, error) {
+	metrics.RequestsTotalCounter.Inc()
 	queues, err := s.jobRepository.GetQueueInfos(ctx)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to query queue stats: %s", err)

--- a/internal/lookout/server/lookout.go
+++ b/internal/lookout/server/lookout.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+
 	"github.com/gogo/protobuf/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/internal/lookout/server/lookout.go
+++ b/internal/lookout/server/lookout.go
@@ -7,18 +7,16 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/G-Research/armada/internal/lookout/metrics"
 	"github.com/G-Research/armada/internal/lookout/repository"
 	"github.com/G-Research/armada/pkg/api/lookout"
 )
 
 type LookoutServer struct {
 	jobRepository    repository.JobRepository
-	metricsCollector metrics.LookoutCollector
 }
 
-func NewLookoutServer(jobRepository repository.JobRepository, metricsCollector metrics.LookoutCollector) *LookoutServer {
-	return &LookoutServer{jobRepository: jobRepository, metricsCollector: metricsCollector}
+func NewLookoutServer(jobRepository repository.JobRepository) *LookoutServer {
+	return &LookoutServer{jobRepository: jobRepository}
 }
 
 func (s *LookoutServer) Overview(ctx context.Context, _ *types.Empty) (*lookout.SystemOverview, error) {

--- a/internal/lookout/server/lookout.go
+++ b/internal/lookout/server/lookout.go
@@ -12,7 +12,7 @@ import (
 )
 
 type LookoutServer struct {
-	jobRepository    repository.JobRepository
+	jobRepository repository.JobRepository
 }
 
 func NewLookoutServer(jobRepository repository.JobRepository) *LookoutServer {

--- a/internal/lookout/server/lookout.go
+++ b/internal/lookout/server/lookout.go
@@ -2,8 +2,6 @@ package server
 
 import (
 	"context"
-	"time"
-
 	"github.com/gogo/protobuf/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -23,40 +21,25 @@ func NewLookoutServer(jobRepository repository.JobRepository, metricsCollector m
 }
 
 func (s *LookoutServer) Overview(ctx context.Context, _ *types.Empty) (*lookout.SystemOverview, error) {
-	start := time.Now()
-	label := "Overview"
 	queues, err := s.jobRepository.GetQueueInfos(ctx)
-	elapsed := time.Since(start)
 	if err != nil {
-		s.metricsCollector.RecordRequestDuration(elapsed, label, metrics.StatusError)
 		return nil, status.Errorf(codes.Internal, "failed to query queue stats: %s", err)
 	}
-	s.metricsCollector.RecordRequestDuration(elapsed, label, metrics.StatusOk)
 	return &lookout.SystemOverview{Queues: queues}, nil
 }
 
 func (s *LookoutServer) GetJobSets(ctx context.Context, opts *lookout.GetJobSetsRequest) (*lookout.GetJobSetsResponse, error) {
-	start := time.Now()
-	label := "GetJobSets"
 	jobSets, err := s.jobRepository.GetJobSetInfos(ctx, opts)
-	elapsed := time.Since(start)
 	if err != nil {
-		s.metricsCollector.RecordRequestDuration(elapsed, label, metrics.StatusError)
 		return nil, status.Errorf(codes.Internal, "failed to query queue stats: %s", err)
 	}
-	s.metricsCollector.RecordRequestDuration(elapsed, label, metrics.StatusOk)
 	return &lookout.GetJobSetsResponse{JobSetInfos: jobSets}, nil
 }
 
 func (s *LookoutServer) GetJobs(ctx context.Context, opts *lookout.GetJobsRequest) (*lookout.GetJobsResponse, error) {
-	start := time.Now()
-	label := "GetJobs"
 	jobInfos, err := s.jobRepository.GetJobs(ctx, opts)
-	elapsed := time.Since(start)
 	if err != nil {
-		s.metricsCollector.RecordRequestDuration(elapsed, label, metrics.StatusError)
 		return nil, status.Errorf(codes.Internal, "failed to query jobs in queue: %s", err)
 	}
-	s.metricsCollector.RecordRequestDuration(elapsed, label, metrics.StatusOk)
 	return &lookout.GetJobsResponse{JobInfos: jobInfos}, nil
 }

--- a/internal/lookout/server/lookout.go
+++ b/internal/lookout/server/lookout.go
@@ -2,45 +2,61 @@ package server
 
 import (
 	"context"
-	"github.com/G-Research/armada/internal/lookout/metrics"
+	"time"
 
 	"github.com/gogo/protobuf/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/G-Research/armada/internal/lookout/metrics"
 	"github.com/G-Research/armada/internal/lookout/repository"
 	"github.com/G-Research/armada/pkg/api/lookout"
 )
 
 type LookoutServer struct {
-	jobRepository repository.JobRepository
+	jobRepository    repository.JobRepository
+	metricsCollector metrics.LookoutCollector
 }
 
-func NewLookoutServer(jobRepository repository.JobRepository) *LookoutServer {
-	return &LookoutServer{jobRepository: jobRepository}
+func NewLookoutServer(jobRepository repository.JobRepository, metricsCollector metrics.LookoutCollector) *LookoutServer {
+	return &LookoutServer{jobRepository: jobRepository, metricsCollector: metricsCollector}
 }
 
 func (s *LookoutServer) Overview(ctx context.Context, _ *types.Empty) (*lookout.SystemOverview, error) {
-	metrics.RequestsTotalCounter.Inc()
+	start := time.Now()
+	label := "Overview"
 	queues, err := s.jobRepository.GetQueueInfos(ctx)
+	elapsed := time.Since(start)
 	if err != nil {
+		s.metricsCollector.RecordRequestDuration(elapsed, label, metrics.StatusError)
 		return nil, status.Errorf(codes.Internal, "failed to query queue stats: %s", err)
 	}
+	s.metricsCollector.RecordRequestDuration(elapsed, label, metrics.StatusOk)
 	return &lookout.SystemOverview{Queues: queues}, nil
 }
 
 func (s *LookoutServer) GetJobSets(ctx context.Context, opts *lookout.GetJobSetsRequest) (*lookout.GetJobSetsResponse, error) {
+	start := time.Now()
+	label := "GetJobSets"
 	jobSets, err := s.jobRepository.GetJobSetInfos(ctx, opts)
+	elapsed := time.Since(start)
 	if err != nil {
+		s.metricsCollector.RecordRequestDuration(elapsed, label, metrics.StatusError)
 		return nil, status.Errorf(codes.Internal, "failed to query queue stats: %s", err)
 	}
+	s.metricsCollector.RecordRequestDuration(elapsed, label, metrics.StatusOk)
 	return &lookout.GetJobSetsResponse{JobSetInfos: jobSets}, nil
 }
 
 func (s *LookoutServer) GetJobs(ctx context.Context, opts *lookout.GetJobsRequest) (*lookout.GetJobsResponse, error) {
+	start := time.Now()
+	label := "GetJobs"
 	jobInfos, err := s.jobRepository.GetJobs(ctx, opts)
+	elapsed := time.Since(start)
 	if err != nil {
+		s.metricsCollector.RecordRequestDuration(elapsed, label, metrics.StatusError)
 		return nil, status.Errorf(codes.Internal, "failed to query jobs in queue: %s", err)
 	}
+	s.metricsCollector.RecordRequestDuration(elapsed, label, metrics.StatusOk)
 	return &lookout.GetJobsResponse{JobInfos: jobInfos}, nil
 }


### PR DESCRIPTION
Adds the following metrics:
* Request time and count
* Number of open database connections
* Percentage database connection utilization