### PR TITLE
Making executor resource metrics consistent with server

### DIFF
--- a/config/executor/config.yaml
+++ b/config/executor/config.yaml
@@ -7,7 +7,6 @@ task:
   jobLeaseRenewalInterval: 15s
   podDeletionInterval: 5s
   allocateSpareClusterCapacityInterval: 5s
-  podMetricsInterval: 1s
   queueUsageDataRefreshInterval: 5s
   utilisationEventProcessingInterval: 1s
   utilisationEventReportingInterval: 5m

--- a/internal/executor/application.go
+++ b/internal/executor/application.go
@@ -94,14 +94,13 @@ func StartUpWithContext(config configuration.ExecutorConfiguration, clusterConte
 		jobLeaseService,
 		clusterUtilisationService)
 
-	contextMetrics := pod_metrics.NewClusterContextMetrics(clusterContext, clusterUtilisationService, queueUtilisationService)
+	pod_metrics.ExposeClusterContextMetrics(clusterContext, clusterUtilisationService, queueUtilisationService)
 
 	taskManager.Register(clusterUtilisationService.ReportClusterUtilisation, config.Task.UtilisationReportingInterval, "utilisation_reporting")
 	taskManager.Register(clusterAllocationService.AllocateSpareClusterCapacity, config.Task.AllocateSpareClusterCapacityInterval, "job_lease_request")
 	taskManager.Register(jobLeaseService.ManageJobLeases, config.Task.JobLeaseRenewalInterval, "job_lease_renewal")
 	taskManager.Register(eventReporter.ReportMissingJobEvents, config.Task.MissingJobEventReconciliationInterval, "event_reconciliation")
 	taskManager.Register(stuckPodDetector.HandleStuckPods, config.Task.StuckPodScanInterval, "stuck_pod")
-	taskManager.Register(contextMetrics.UpdateMetrics, config.Task.PodMetricsInterval, "pod_metrics")
 
 	if config.Metric.ExposeQueueUsageMetrics {
 		taskManager.Register(queueUtilisationService.RefreshUtilisationData, config.Task.QueueUsageDataRefreshInterval, "pod_usage_data_refresh")

--- a/internal/executor/configuration/types.go
+++ b/internal/executor/configuration/types.go
@@ -29,7 +29,6 @@ type TaskConfiguration struct {
 	AllocateSpareClusterCapacityInterval  time.Duration
 	StuckPodScanInterval                  time.Duration
 	PodDeletionInterval                   time.Duration
-	PodMetricsInterval                    time.Duration
 	QueueUsageDataRefreshInterval         time.Duration
 	UtilisationEventProcessingInterval    time.Duration
 	UtilisationEventReportingInterval     time.Duration


### PR DESCRIPTION
Instead of having metrics for each resource type (cpu, memory..) will now have armada_executor_job_pod_resource_request and job_pod_resource_usage

Which contains resource per queue, with resourceType as a field on each metric

Similarly changed node resource metrics to no longer  be split by resource type but instead have a resourceType field.

This makes it:
 - Consistent with our server metrics
 - More flexible, automatically including new resources that are requested/used. Meaning we don't need to add new metrics each time a new resource type is added