### PR TITLE
Breaking update to GetJobEventsStream dotnet client

### DIFF
--- a/client/DotNet/Armada.Client.Test/Tests.cs
+++ b/client/DotNet/Armada.Client.Test/Tests.cs
@@ -15,6 +15,7 @@ namespace GResearch.Armada.Client.Test
     public class Tests
     {
         [Test]
+        [Explicit("Intended for manual testing against armada server with proxy.")]
         public async Task TestWatchingEvents()
         {
             var client = new ArmadaClient("http://localhost:8080", new HttpClient());
@@ -40,6 +41,7 @@ namespace GResearch.Armada.Client.Test
         }
         
         [Test]
+        [Explicit("Intended for manual testing against armada server with proxy.")]
         public async Task TestGetJobEvents()
         {
             var queue = "test";

--- a/client/DotNet/Armada.Client.Test/Tests.cs
+++ b/client/DotNet/Armada.Client.Test/Tests.cs
@@ -39,7 +39,7 @@ namespace GResearch.Armada.Client.Test
                 Assert.That(eventCount, Is.EqualTo(4));
             }
         }
-        
+
         [Test]
         public async Task TestSimpleJobSubmitFlow()
         {

--- a/client/DotNet/Armada.Client/Client.cs
+++ b/client/DotNet/Armada.Client/Client.cs
@@ -20,8 +20,7 @@ namespace GResearch.Armada.Client
         Task<ApiCancellationResult> CancelJobsAsync(ApiJobCancelRequest body);
         Task<ApiJobSubmitResponse> SubmitJobsAsync(ApiJobSubmitRequest body);
         Task<object> CreateQueueAsync(string name, ApiQueue body);
-        Task<IEnumerable<StreamResponse<ApiEventStreamMessage>>> GetJobEvents(string queue, string jobSetId, CancellationToken ct, string fromMessage = null);
-        Task<IEnumerable<StreamResponse<ApiEventStreamMessage>>> GetJobEventsStream(string queue, string jobSetId, string fromMessage = null, bool watch = false);
+        Task<IEnumerable<StreamResponse<ApiEventStreamMessage>>> GetJobEventsStream(string queue, string jobSetId, CancellationToken ct, string fromMessage = null);
         Task WatchEvents(
             string queue,
             string jobSetId,
@@ -71,7 +70,7 @@ namespace GResearch.Armada.Client
 
     public partial class ArmadaClient : IArmadaClient
     {       
-        public async Task<IEnumerable<StreamResponse<ApiEventStreamMessage>>> GetJobEvents(
+        public async Task<IEnumerable<StreamResponse<ApiEventStreamMessage>>> GetJobEventsStream(
             string queue, string jobSetId, CancellationToken ct, string fromMessageId = null)
         {
             var events = new List<StreamResponse<ApiEventStreamMessage>>(); 
@@ -82,31 +81,6 @@ namespace GResearch.Armada.Client
                 });           
             return events;
         }        
-        
-        public async Task<IEnumerable<StreamResponse<ApiEventStreamMessage>>> GetJobEventsStream(
-            string queue, string jobSetId, string fromMessageId = null, bool watch = false)
-        {
-            var fileResponse = await GetJobSetEventsCoreAsync(queue, jobSetId,
-                new ApiJobSetRequest {FromMessageId = fromMessageId, Watch = watch});
-            return ReadEventStream(fileResponse.Stream);
-        }
-        
-        private IEnumerable<StreamResponse<ApiEventStreamMessage>> ReadEventStream(Stream stream)
-        {
-            using (var reader = new StreamReader(stream))
-            {
-                while (!reader.EndOfStream)
-                {
-                    var line = reader.ReadLine();
-                    
-                    var (_, eventMessage) = ProcessEventLine(null, line);
-                    if (eventMessage != null)
-                    {
-                        yield return eventMessage;
-                    }
-                }
-            }
-        }
 
         public async Task WatchEvents(
             string queue,


### PR DESCRIPTION
GetJobEventsStream now: 
 - Takes a cancellation token
 -  Doesn't allow watch

Its purpose is to get just all events up until the current event and return them.

This is significantly more tolerant to network faults than the previous implementation and for general watching we advise using WatchEvents.