### PR TITLE
Fix calculateRunningJobStats

### DIFF
--- a/internal/armada/metrics/metrics_test.go
+++ b/internal/armada/metrics/metrics_test.go
@@ -1,0 +1,193 @@
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis"
+	"github.com/go-redis/redis"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/G-Research/armada/internal/armada/authorization"
+	"github.com/G-Research/armada/internal/armada/repository"
+	"github.com/G-Research/armada/pkg/api"
+)
+
+func TestCalculateRunningJobStats(t *testing.T) {
+	withRepository(func(r *repository.RedisJobRepository) {
+		sut := QueueInfoCollector{
+			jobRepository: r,
+		}
+		queue1 := &api.Queue{Name: "queue1"}
+		cluster1 := createClusterInfo("cluster1", "cpu")
+		now := time.Now()
+
+		addRunningJob(t, r, queue1.Name, cluster1.ClusterId, now)
+		addRunningJob(t, r, queue1.Name, cluster1.ClusterId, now)
+
+		clusterInfos := map[string]*api.ClusterSchedulingInfoReport{
+			cluster1.ClusterId: cluster1,
+		}
+
+		runTimeMetrics, resourceMetrics := sut.calculateRunningJobStats([]*api.Queue{queue1}, clusterInfos)
+
+		assert.Equal(t, len(runTimeMetrics), 1)
+		assert.NotNil(t, runTimeMetrics[queue1.Name])
+		assert.NotNil(t, runTimeMetrics[queue1.Name][cluster1.Pool])
+		assert.Equal(t, runTimeMetrics[queue1.Name][cluster1.Pool].GetCount(), uint64(2))
+		assert.Equal(t, len(resourceMetrics), 1)
+		assert.NotNil(t, resourceMetrics[queue1.Name])
+		assert.NotNil(t, resourceMetrics[queue1.Name][cluster1.Pool])
+		assert.NotNil(t, resourceMetrics[queue1.Name][cluster1.Pool]["cpu"])
+		assert.Equal(t, resourceMetrics[queue1.Name][cluster1.Pool]["cpu"].GetCount(), uint64(2))
+	})
+}
+
+func TestCalculateRunningJobStats_WhenMultiCluster(t *testing.T) {
+	withRepository(func(r *repository.RedisJobRepository) {
+		sut := QueueInfoCollector{
+			jobRepository: r,
+		}
+		queue1 := &api.Queue{Name: "queue1"}
+		cluster1 := createClusterInfo("cluster1", "cpu")
+		cluster2 := createClusterInfo("cluster2", "cpu")
+		now := time.Now()
+
+		addRunningJob(t, r, queue1.Name, cluster1.ClusterId, now)
+		addRunningJob(t, r, queue1.Name, cluster1.ClusterId, now)
+		addRunningJob(t, r, queue1.Name, cluster2.ClusterId, now)
+
+		clusterInfos := map[string]*api.ClusterSchedulingInfoReport{
+			cluster1.ClusterId: cluster1,
+			cluster2.ClusterId: cluster2,
+		}
+
+		runTimeMetrics, resourceMetrics := sut.calculateRunningJobStats([]*api.Queue{queue1}, clusterInfos)
+
+		assert.Equal(t, len(runTimeMetrics), 1)
+		assert.Equal(t, runTimeMetrics[queue1.Name][cluster1.Pool].GetCount(), uint64(3))
+		assert.Equal(t, len(resourceMetrics), 1)
+		assert.Equal(t, resourceMetrics[queue1.Name][cluster1.Pool]["cpu"].GetCount(), uint64(3))
+	})
+}
+
+func TestCalculateRunningJobStats_WhenMultiPool(t *testing.T) {
+	withRepository(func(r *repository.RedisJobRepository) {
+		sut := QueueInfoCollector{
+			jobRepository: r,
+		}
+		queue1 := &api.Queue{Name: "queue1"}
+		cluster1 := createClusterInfo("cluster1", "cpu")
+		cluster2 := createClusterInfo("cluster2", "gpu")
+		now := time.Now()
+
+		addRunningJob(t, r, queue1.Name, cluster1.ClusterId, now)
+		addRunningJob(t, r, queue1.Name, cluster1.ClusterId, now)
+		addRunningJob(t, r, queue1.Name, cluster2.ClusterId, now)
+
+		clusterInfos := map[string]*api.ClusterSchedulingInfoReport{
+			cluster1.ClusterId: cluster1,
+			cluster2.ClusterId: cluster2,
+		}
+
+		runTimeMetrics, resourceMetrics := sut.calculateRunningJobStats([]*api.Queue{queue1}, clusterInfos)
+
+		assert.Equal(t, len(runTimeMetrics), 1)
+		assert.Equal(t, runTimeMetrics[queue1.Name][cluster1.Pool].GetCount(), uint64(2))
+		assert.Equal(t, runTimeMetrics[queue1.Name][cluster2.Pool].GetCount(), uint64(1))
+		assert.Equal(t, len(resourceMetrics), 1)
+		assert.Equal(t, resourceMetrics[queue1.Name][cluster1.Pool]["cpu"].GetCount(), uint64(2))
+		assert.Equal(t, resourceMetrics[queue1.Name][cluster2.Pool]["cpu"].GetCount(), uint64(1))
+	})
+}
+
+func TestCalculateRunningJobStats_SkipsWhenJobOnInactivecluster(t *testing.T) {
+	withRepository(func(r *repository.RedisJobRepository) {
+		sut := QueueInfoCollector{
+			jobRepository: r,
+		}
+		queue1 := &api.Queue{Name: "queue1"}
+		cluster1 := createClusterInfo("cluster1", "cpu")
+		now := time.Now()
+
+		addRunningJob(t, r, queue1.Name, cluster1.ClusterId, now)
+
+		clusterInfos := map[string]*api.ClusterSchedulingInfoReport{}
+
+		runTimeMetrics, resourceMetrics := sut.calculateRunningJobStats([]*api.Queue{queue1}, clusterInfos)
+
+		assert.Equal(t, len(runTimeMetrics), 0)
+		assert.Equal(t, len(resourceMetrics), 0)
+	})
+}
+
+func createClusterInfo(clusterId string, pool string) *api.ClusterSchedulingInfoReport {
+	return &api.ClusterSchedulingInfoReport{
+		ClusterId: clusterId,
+		Pool:      pool,
+	}
+}
+
+func addRunningJob(t *testing.T, r *repository.RedisJobRepository, queue string, cluster string, startTime time.Time) *api.Job {
+	job := addTestJob(t, r, queue)
+	leased, e := r.TryLeaseJobs(cluster, queue, []*api.Job{job})
+	assert.NoError(t, e)
+	assert.Equal(t, 1, len(leased))
+	assert.Equal(t, job.Id, leased[0].Id)
+	e = r.UpdateStartTime(job.Id, cluster, startTime)
+	assert.NoError(t, e)
+	return job
+}
+
+func addTestJob(t *testing.T, r *repository.RedisJobRepository, queue string) *api.Job {
+	cpu := resource.MustParse("1")
+	memory := resource.MustParse("512Mi")
+
+	return addTestJobWithRequirements(t, r, queue, "", v1.ResourceRequirements{
+		Limits:   v1.ResourceList{"cpu": cpu, "memory": memory},
+		Requests: v1.ResourceList{"cpu": cpu, "memory": memory},
+	})
+}
+
+func addTestJobWithRequirements(t *testing.T, r *repository.RedisJobRepository, queue string, clientId string, requirements v1.ResourceRequirements) *api.Job {
+
+	jobs, e := r.CreateJobs(&api.JobSubmitRequest{
+		Queue:    queue,
+		JobSetId: "set1",
+		JobRequestItems: []*api.JobSubmitRequestItem{
+			{
+				Priority: 1,
+				ClientId: clientId,
+				PodSpec: &v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Resources: requirements,
+						},
+					},
+				},
+			},
+		},
+	}, authorization.NewStaticPrincipal("user", []string{}))
+	assert.NoError(t, e)
+
+	results, e := r.AddJobs(jobs)
+	assert.Nil(t, e)
+	for _, result := range results {
+		assert.Empty(t, result.Error)
+	}
+	return jobs[0]
+}
+
+func withRepository(action func(r *repository.RedisJobRepository)) {
+	db, err := miniredis.Run()
+	if err != nil {
+		panic(err)
+	}
+	defer db.Close()
+
+	redisClient := redis.NewClient(&redis.Options{Addr: db.Addr()})
+	repo := repository.NewRedisJobRepository(redisClient, nil)
+	action(repo)
+}

--- a/internal/armada/repository/job.go
+++ b/internal/armada/repository/job.go
@@ -535,7 +535,7 @@ type RunInfo struct {
 }
 
 /*
- Returns the start time of each job id for the cluster they are currently associated with (leased by)
+ Returns the run info of each job id for the cluster they are currently associated with (leased by)
  Jobs with no value will be omitted from the results, which happens in the following cases:
  - The job is not associated with a cluster
  - The job has does not have a start time for the cluster it is associated with

--- a/internal/armada/server/lease_test.go
+++ b/internal/armada/server/lease_test.go
@@ -256,8 +256,8 @@ func (repo *mockJobRepository) UpdateStartTime(jobId string, clusterId string, s
 	return nil
 }
 
-func (repo *mockJobRepository) GetStartTimes(jobIds []string) (map[string]time.Time, error) {
-	return map[string]time.Time{}, nil
+func (repo *mockJobRepository) GetJobRunInfos(jobIds []string) (map[string]*repository.RunInfo, error) {
+	return map[string]*repository.RunInfo{}, nil
 }
 
 type fakeQueueRepository struct{}


### PR DESCRIPTION
calculateRunningJobStats was incorrectly repeatedly counting the same job for each active cluster that the job could be scheduled on:
 - i.e If 5 active clusters talking to Armada that could run job "a" and job (id:"a") was running on one of them. We'd record its run duration in the metrics 5 times (1 for each active cluster)

Now we only count the metric for a running job once