### PR TITLE
Support permissioning on existence of a claim in jwt token for OIDC.

### DIFF
--- a/internal/armada/authorization/common.go
+++ b/internal/armada/authorization/common.go
@@ -26,12 +26,14 @@ type Principal interface {
 	GetName() string
 	IsInGroup(group string) bool
 	HasScope(scope string) bool
+	HasClaim(claim string) bool
 }
 
 type StaticPrincipal struct {
 	name   string
 	groups map[string]bool
 	scopes map[string]bool
+	claims map[string]bool
 }
 
 func NewStaticPrincipal(name string, groups []string) *StaticPrincipal {
@@ -39,14 +41,16 @@ func NewStaticPrincipal(name string, groups []string) *StaticPrincipal {
 		name,
 		util.StringListToSet(append(groups, EveryoneGroup)),
 		map[string]bool{},
+		map[string]bool{},
 	}
 }
 
-func NewStaticPrincipalWithScopes(name string, groups []string, scopes []string) *StaticPrincipal {
+func NewStaticPrincipalWithScopesAndClaims(name string, groups []string, scopes []string, claims []string) *StaticPrincipal {
 	return &StaticPrincipal{
 		name,
 		util.StringListToSet(append(groups, EveryoneGroup)),
 		util.StringListToSet(scopes),
+		util.StringListToSet(claims),
 	}
 }
 
@@ -56,6 +60,10 @@ func (p *StaticPrincipal) IsInGroup(group string) bool {
 
 func (p *StaticPrincipal) HasScope(scope string) bool {
 	return p.scopes[scope]
+}
+
+func (p *StaticPrincipal) HasClaim(claim string) bool {
+	return p.claims[claim]
 }
 
 func (p *StaticPrincipal) GetName() string {

--- a/internal/armada/authorization/permissions.go
+++ b/internal/armada/authorization/permissions.go
@@ -19,21 +19,25 @@ type PermissionChecker interface {
 type PrincipalPermissionChecker struct {
 	permissionGroupMap map[permissions.Permission][]string
 	permissionScopeMap map[permissions.Permission][]string
+	permissionClaimMap map[permissions.Permission][]string
 }
 
 func NewPrincipalPermissionChecker(
 	permissionGroupMap map[permissions.Permission][]string,
-	permissionScopeMap map[permissions.Permission][]string) *PrincipalPermissionChecker {
+	permissionScopeMap map[permissions.Permission][]string,
+	permissionClaimMap map[permissions.Permission][]string) *PrincipalPermissionChecker {
 
 	return &PrincipalPermissionChecker{
 		permissionGroupMap: permissionGroupMap,
-		permissionScopeMap: permissionScopeMap}
+		permissionScopeMap: permissionScopeMap,
+		permissionClaimMap: permissionClaimMap}
 }
 
 func (checker *PrincipalPermissionChecker) UserHasPermission(ctx context.Context, perm permissions.Permission) bool {
 	principal := GetPrincipal(ctx)
 	return hasPermission(perm, checker.permissionScopeMap, func(scope string) bool { return principal.HasScope(scope) }) ||
-		hasPermission(perm, checker.permissionGroupMap, func(group string) bool { return principal.IsInGroup(group) })
+		hasPermission(perm, checker.permissionGroupMap, func(group string) bool { return principal.IsInGroup(group) }) ||
+		hasPermission(perm, checker.permissionClaimMap, func(claim string) bool { return principal.HasClaim(claim) })
 }
 
 func (checker *PrincipalPermissionChecker) UserOwns(ctx context.Context, obj Owned) bool {

--- a/internal/armada/authorization/permissions_test.go
+++ b/internal/armada/authorization/permissions_test.go
@@ -11,9 +11,10 @@ import (
 
 func TestPrincipalPermissionChecker_UserHavePermission(t *testing.T) {
 
-	checker := NewPrincipalPermissionChecker(map[permissions.Permission][]string{
-		permissions.SubmitJobs: {"submitterGroup", "admin"},
-	}, map[permissions.Permission][]string{})
+	checker := NewPrincipalPermissionChecker(
+		map[permissions.Permission][]string{permissions.SubmitJobs: {"submitterGroup", "admin"}},
+		map[permissions.Permission][]string{},
+		map[permissions.Permission][]string{})
 
 	admin := NewStaticPrincipal("me", []string{"admin"})
 	submitter := NewStaticPrincipal("me", []string{"submitterGroup"})

--- a/internal/armada/configuration/types.go
+++ b/internal/armada/configuration/types.go
@@ -31,6 +31,7 @@ type ArmadaConfig struct {
 	Kerberos               KerberosAuthenticationConfig
 	PermissionGroupMapping map[permissions.Permission][]string
 	PermissionScopeMapping map[permissions.Permission][]string
+	PermissionClaimMapping map[permissions.Permission][]string
 
 	Scheduling      SchedulingConfig
 	QueueManagement QueueManagementConfig
@@ -41,6 +42,12 @@ type ArmadaConfig struct {
 type OpenIdAuthenticationConfig struct {
 	ProviderUrl string
 	GroupsClaim string
+
+	// If your OIDC provider signs token with key intended solely for this application and audience claim does not
+	// contain any clientId, you can disable client ID check.
+	// Otherwise clientId is required
+	SkipClientIDCheck bool
+	ClientId          string
 }
 
 type BasicAuthenticationConfig struct {

--- a/internal/armada/server.go
+++ b/internal/armada/server.go
@@ -109,7 +109,7 @@ func Serve(config *configuration.ArmadaConfig) (func(), *sync.WaitGroup) {
 		eventStore = redisEventRepository
 	}
 
-	permissions := authorization.NewPrincipalPermissionChecker(config.PermissionGroupMapping, config.PermissionScopeMapping)
+	permissions := authorization.NewPrincipalPermissionChecker(config.PermissionGroupMapping, config.PermissionScopeMapping, config.PermissionClaimMapping)
 
 	submitServer := server.NewSubmitServer(permissions, jobRepository, queueRepository, eventStore, schedulingInfoRepository, &config.QueueManagement)
 	usageServer := server.NewUsageServer(permissions, config.PriorityHalfTime, &config.Scheduling, usageRepository, queueRepository)


### PR DESCRIPTION
This also makes client id check configurable for OIDC Auth.