### PR TITLE
Set name on serviceports

### DIFF
--- a/internal/executor/service/cluster_allocation.go
+++ b/internal/executor/service/cluster_allocation.go
@@ -139,6 +139,7 @@ func getServicePorts(job *api.Job, podSpec *v1.PodSpec) []v1.ServicePort {
 			}
 			if shouldExposeWithNodePort(port, job) {
 				servicePort := v1.ServicePort{
+					Name:     fmt.Sprintf("%s-%d", container.Name, port.ContainerPort),
 					Port:     port.ContainerPort,
 					Protocol: port.Protocol,
 				}


### PR DESCRIPTION
Kubernetes requires there to be a name set when there is more than one serviceport in a service

Setting the name was missed on initial implementation.

So when trying to expose more than 1 port, the NodePort service created by Armada is invalid and causes the job to fail

This should allow exposing more than one port from Armada jobs