### PR TITLE
Fix PodCache handling of multi node jobs

### DIFF
--- a/internal/executor/context/cluster_context.go
+++ b/internal/executor/context/cluster_context.go
@@ -101,7 +101,7 @@ func NewClusterContext(
 				log.Errorf("Failed to process pod event due to it being an unexpected type. Failed to process %+v", obj)
 				return
 			}
-			context.submittedPods.Delete(util.ExtractJobId(pod))
+			context.submittedPods.Delete(util.ExtractPodKey(pod))
 		},
 	})
 
@@ -216,7 +216,7 @@ func (c *KubernetesClusterContext) SubmitPod(pod *v1.Pod, owner string) (*v1.Pod
 	returnedPod, err := ownerClient.CoreV1().Pods(pod.Namespace).Create(ctx.Background(), pod, metav1.CreateOptions{})
 
 	if err != nil {
-		c.submittedPods.Delete(util.ExtractJobId(pod))
+		c.submittedPods.Delete(util.ExtractPodKey(pod))
 	}
 	return returnedPod, err
 }
@@ -266,12 +266,12 @@ func (c *KubernetesClusterContext) ProcessPodsToDelete() {
 			continue
 		}
 		err := c.kubernetesClient.CoreV1().Pods(podToDelete.Namespace).Delete(ctx.Background(), podToDelete.Name, deleteOptions)
-		jobId := util.ExtractJobId(podToDelete)
+		podId := util.ExtractPodKey(podToDelete)
 		if err == nil || errors.IsNotFound(err) {
-			c.podsToDelete.Update(jobId, nil)
+			c.podsToDelete.Update(podId, nil)
 		} else {
 			log.Errorf("Failed to delete pod %s/%s because %s", podToDelete.Namespace, podToDelete.Name, err)
-			c.podsToDelete.Delete(jobId)
+			c.podsToDelete.Delete(podId)
 		}
 	}
 }

--- a/internal/executor/context/cluster_context_test.go
+++ b/internal/executor/context/cluster_context_test.go
@@ -441,7 +441,7 @@ func waitForContextSync(t *testing.T, context *KubernetesClusterContext, pods []
 				allSync = false
 				break
 			}
-			if cachedPod := context.submittedPods.Get(pod.Labels[domain.JobId]); cachedPod != nil {
+			if cachedPod := context.submittedPods.Get(util.ExtractPodKey(pod)); cachedPod != nil {
 				allSync = false
 				break
 			}

--- a/internal/executor/service/job_lease.go
+++ b/internal/executor/service/job_lease.go
@@ -216,7 +216,9 @@ func (jobLeaseService *JobLeaseService) reportTerminated(pods []*v1.Pod) {
 	for _, pod := range pods {
 		event := reporter.CreateJobTerminatedEvent(pod, "Pod terminated because lease could not be renewed.", jobLeaseService.clusterContext.GetClusterId())
 		jobLeaseService.eventReporter.QueueEvent(event, func(err error) {
-			log.Errorf("Failed to report terminated pod %s: %s", pod.Name, err)
+			if err != nil {
+				log.Errorf("Failed to report terminated pod %s: %s", pod.Name, err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
The PodCache used job id to identify a pod uniquely. The issue with this is that JobId is no longer unique to a single pod.

So when you cancelled a multi node job, it'll delete one of the pods then leave the others until the cache expired
 - We prevent repeated deletion calls by holding an empty value for that pod in the cache
 
However this means we wait for the PodExpiry between each pod being deleted of a multi node job

Similarly we have a cache of submitted pods (that may not have been reported back via the api yet). However we'd incorrectly report only 1 pod being submitted when submitting many pods as part of a multi node job.