### PR TITLE
Fix flakey test + improve redis data loading

### DIFF
--- a/internal/armada/server_test.go
+++ b/internal/armada/server_test.go
@@ -187,6 +187,10 @@ func withRunningServer(action func(client api.SubmitClient, leaseClient api.Aggr
 		},
 		Scheduling: configuration.SchedulingConfig{
 			QueueLeaseBatchSize: 100,
+			Lease: configuration.LeaseSettings{
+				ExpireAfter:        time.Minute * 15,
+				ExpiryLoopInterval: time.Second * 5,
+			},
 		},
 		QueueManagement: configuration.QueueManagementConfig{
 			AutoCreateQueues:      true,


### PR DESCRIPTION
We weren't setting LeaseSettings on our server tests. Causing the values defaulted to 0 and it was trying to expire pods every millisecond. Occasionally it'd succeed in causing a lease to expire and cause another bug (see below) which caused the TestCancelJob test to fail
 - Updated LeaseSettings to our default config. This will mean leases won't get expired the test

GetActiveJobIds was loading queued and leased ids in separate calls to redis. This meant jobs could change state between the calls and give inconsistent data:
 - i.e If a job was leased between the get queued ids and get leased ids calls, the job id would appear in both lists
 - If a job had its lease expire between these two calls, it could appear in neither list, effectively disappearing (which is what was happening in the flakey test above)

These are very edge case issues, but worth fixing to make the loading more consistent.