### PR TITLE
Allow the default schedulerName to be configured

### DIFF
--- a/internal/executor/application.go
+++ b/internal/executor/application.go
@@ -93,7 +93,8 @@ func StartUpWithContext(config configuration.ExecutorConfiguration, clusterConte
 		clusterContext,
 		eventReporter,
 		jobLeaseService,
-		clusterUtilisationService)
+		clusterUtilisationService,
+		config.Kubernetes.PodDefaults)
 
 	service.RunIngressCleanup(clusterContext)
 

--- a/internal/executor/configuration/types.go
+++ b/internal/executor/configuration/types.go
@@ -12,6 +12,10 @@ type ApplicationConfiguration struct {
 	Pool      string
 }
 
+type PodDefaults struct {
+	SchedulerName string
+}
+
 type KubernetesConfiguration struct {
 	ImpersonateUsers  bool
 	TrackedNodeLabels []string
@@ -20,6 +24,7 @@ type KubernetesConfiguration struct {
 	FailedPodExpiry   time.Duration
 	StuckPodExpiry    time.Duration
 	MinimumJobSize    common.ComputeResources
+	PodDefaults       *PodDefaults
 }
 
 type TaskConfiguration struct {

--- a/internal/executor/service/cluster_allocation.go
+++ b/internal/executor/service/cluster_allocation.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/G-Research/armada/internal/common"
+	"github.com/G-Research/armada/internal/executor/configuration"
 	"github.com/G-Research/armada/internal/executor/context"
 	"github.com/G-Research/armada/internal/executor/domain"
 	"github.com/G-Research/armada/internal/executor/reporter"
@@ -25,19 +26,22 @@ type ClusterAllocationService struct {
 	eventReporter      reporter.EventReporter
 	utilisationService UtilisationService
 	clusterContext     context.ClusterContext
+	podDefaults        *configuration.PodDefaults
 }
 
 func NewClusterAllocationService(
 	clusterContext context.ClusterContext,
 	eventReporter reporter.EventReporter,
 	leaseService LeaseService,
-	utilisationService UtilisationService) *ClusterAllocationService {
+	utilisationService UtilisationService,
+	podDefaults *configuration.PodDefaults) *ClusterAllocationService {
 
 	return &ClusterAllocationService{
 		leaseService:       leaseService,
 		eventReporter:      eventReporter,
 		utilisationService: utilisationService,
-		clusterContext:     clusterContext}
+		clusterContext:     clusterContext,
+		podDefaults:        podDefaults}
 }
 
 func (allocationService *ClusterAllocationService) AllocateSpareClusterCapacity() {
@@ -105,7 +109,7 @@ func (allocationService *ClusterAllocationService) submitJobs(jobsToSubmit []*ap
 }
 
 func (allocationService *ClusterAllocationService) submitPod(job *api.Job, i int) (*v1.Pod, error) {
-	pod := createPod(job, i)
+	pod := createPod(job, allocationService.podDefaults, i)
 
 	if exposesPorts(job, &pod.Spec) {
 		pod.Annotations = mergeMaps(pod.Annotations, map[string]string{
@@ -260,10 +264,11 @@ func createService(job *api.Job, pod *v1.Pod) *v1.Service {
 	return service
 }
 
-func createPod(job *api.Job, i int) *v1.Pod {
+func createPod(job *api.Job, defaults *configuration.PodDefaults, i int) *v1.Pod {
 
 	allPodSpecs := job.GetAllPodSpecs()
 	podSpec := allPodSpecs[i]
+	applyDefaults(podSpec, defaults)
 
 	labels := mergeMaps(job.Labels, map[string]string{
 		domain.JobId:     job.Id,
@@ -289,6 +294,15 @@ func createPod(job *api.Job, i int) *v1.Pod {
 	}
 
 	return pod
+}
+
+func applyDefaults(spec *v1.PodSpec, defaults *configuration.PodDefaults) {
+	if defaults == nil {
+		return
+	}
+	if defaults.SchedulerName != "" && spec.SchedulerName == "" {
+		spec.SchedulerName = defaults.SchedulerName
+	}
 }
 
 func setRestartPolicyNever(podSpec *v1.PodSpec) {


### PR DESCRIPTION
This change allows the executor to set the schedulerName on pods to the scheduler set in config
- This is optional
- This won't override the schedulerName field if the podSpec explicitly sets it

This is useful if you want the Armada pods be scheduled by kubernetes using the non-default scheduler
 - For example having a bin packing scheduler that is only used for Armada pods