### PR TITLE
Support LDAP group name lookup in Kerberos auth.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
 	github.com/doug-martin/goqu/v9 v9.10.0
+	github.com/go-ldap/ldap/v3 v3.3.0
 	github.com/go-openapi/analysis v0.19.10
 	github.com/go-openapi/errors v0.19.4 // indirect
 	github.com/go-openapi/jsonreference v0.19.3

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6L
 github.com/Azure/go-autorest/logger v0.2.0/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
+github.com/Azure/go-ntlmssp v0.0.0-20200615164410-66371956d46c h1:/IBSNwUN8+eKzUzbJPqhK839ygXJ82sde8x3ogr6R28=
+github.com/Azure/go-ntlmssp v0.0.0-20200615164410-66371956d46c/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
@@ -139,11 +141,15 @@ github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2H
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
+github.com/go-asn1-ber/asn1-ber v1.5.1 h1:pDbRAunXzIUXfx4CB2QJFv5IuPiuoW+sWvr/Us009o8=
+github.com/go-asn1-ber/asn1-ber v1.5.1/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
+github.com/go-ldap/ldap/v3 v3.3.0 h1:lwx+SJpgOHd8tG6SumBQZXCmNX51zM8B1cfxJ5gv4tQ=
+github.com/go-ldap/ldap/v3 v3.3.0/go.mod h1:iYS1MdmrmceOJ1QOTnRXrIs7i3kloqtmGQjRvjKpyMg=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
@@ -648,6 +654,7 @@ golang.org/x/crypto v0.0.0-20200117160349-530e935923ad/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200206161412-a0c6ece9d31a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0 h1:hb9wdF1z5waM+dSIICn1l0DkLVDT3hqhhQsDNUmHPRE=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/internal/armada/authorization/groups/ldap.go
+++ b/internal/armada/authorization/groups/ldap.go
@@ -46,13 +46,16 @@ func (lookup *LDAPGroupLookup) GetGroupNames(SIDs []string) ([]string, error) {
 		if ok {
 			result = append(result, record.name)
 		} else {
-			return nil, fmt.Errorf("could not find group name for %s", sid)
+			log.Errorf("could not find group name for %s", sid)
 		}
 	}
 	return result, nil
 }
 
 func (lookup *LDAPGroupLookup) updateCache(SIDs []string) error {
+
+	log.Info("Looking up group SIDS: %v", SIDs)
+
 	deadline := time.Now().Add(-lookup.cacheExpiry)
 	missing := []string{}
 	for _, sid := range SIDs {
@@ -66,6 +69,8 @@ func (lookup *LDAPGroupLookup) updateCache(SIDs []string) error {
 	if err != nil {
 		return err
 	}
+
+	log.Info("Found group names: %v", groupNames)
 
 	for sid, name := range groupNames {
 		lookup.cache[sid] = cacheRecord{

--- a/internal/armada/authorization/groups/ldap.go
+++ b/internal/armada/authorization/groups/ldap.go
@@ -1,0 +1,144 @@
+package groups
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-ldap/ldap/v3"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/G-Research/armada/internal/armada/configuration"
+)
+
+type GroupLookup interface {
+	GetGroupNames(SIDs []string) ([]string, error)
+}
+
+type LDAPGroupLookup struct {
+	config      configuration.LDAPConfig
+	cache       map[string]cacheRecord
+	cacheExpiry time.Duration
+}
+
+func NewLDAPGroupLookup(config configuration.LDAPConfig) *LDAPGroupLookup {
+	return &LDAPGroupLookup{
+		config:      config,
+		cache:       map[string]cacheRecord{},
+		cacheExpiry: 5 * time.Minute,
+	}
+}
+
+type cacheRecord struct {
+	name    string
+	created time.Time
+}
+
+func (lookup *LDAPGroupLookup) GetGroupNames(SIDs []string) ([]string, error) {
+	err := lookup.updateCache(SIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	result := []string{}
+	for _, sid := range SIDs {
+		record, ok := lookup.cache[sid]
+		if ok {
+			result = append(result, record.name)
+		} else {
+			return nil, fmt.Errorf("could not find group name for %s", sid)
+		}
+	}
+	return result, nil
+}
+
+func (lookup *LDAPGroupLookup) updateCache(SIDs []string) error {
+	deadline := time.Now().Add(-lookup.cacheExpiry)
+	missing := []string{}
+	for _, sid := range SIDs {
+		record, ok := lookup.cache[sid]
+		if !ok || record.created.Before(deadline) {
+			missing = append(missing, sid)
+		}
+	}
+
+	groupNames, err := lookup.getGroupNames(missing)
+	if err != nil {
+		return err
+	}
+
+	for sid, name := range groupNames {
+		lookup.cache[sid] = cacheRecord{
+			name:    name,
+			created: time.Now(),
+		}
+	}
+	return nil
+}
+
+func (lookup *LDAPGroupLookup) getGroupNames(SIDs []string) (map[string]string, error) {
+	l, err := ldap.DialURL(lookup.config.URL)
+	if err != nil {
+		log.Errorf("LDAP dial error: %s", err)
+		return nil, err
+	}
+	defer l.Close()
+	err = l.Bind(lookup.config.Username, lookup.config.Password)
+	if err != nil {
+		log.Errorf("LDAP bind error %s", err)
+		return nil, err
+	}
+	searchRequest := lookup.createGroupSearch(SIDs)
+	sr, err := l.Search(searchRequest)
+	if err != nil {
+		log.Errorf("LDAP search error %s", err)
+		return nil, err
+	}
+	result := map[string]string{}
+	for _, entry := range sr.Entries {
+		bytes := entry.GetEqualFoldRawAttributeValue("objectSid")
+		sid := decodeSID(bytes)
+		result[sid] = entry.GetAttributeValue("cn")
+	}
+	return result, nil
+}
+
+func (lookup *LDAPGroupLookup) createGroupSearch(SIDs []string) *ldap.SearchRequest {
+	return ldap.NewSearchRequest(
+		lookup.config.GroupSearchBase,
+		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
+		"(&(objectClass=group)(|(objectSID="+
+			strings.Join(SIDs, ")(objectSID=")+
+			")))",
+		[]string{"cn", "objectSid"},
+		nil,
+	)
+}
+
+// Modified from https://github.com/bwmarrin/go-objectsid, newer go compiler requires uints for bit shifts
+func decodeSID(b []byte) string {
+	revisionLevel := int(b[0])
+	subAuthorityCount := int(b[1]) & 0xFF
+	var authority uint = 0
+	for i := 2; i <= 7; i++ {
+		authority = authority | uint(b[i])<<uint(8*(5-(i-2)))
+	}
+
+	var offset = 8
+	var size = 4
+	var subAuthorities []uint
+	for i := 0; i < subAuthorityCount; i++ {
+		var subAuthority uint
+		for k := 0; k < size; k++ {
+			subAuthority = subAuthority | (uint(b[offset+k])&0xFF)<<uint(8*k)
+		}
+		subAuthorities = append(subAuthorities, subAuthority)
+		offset += size
+	}
+
+	s := fmt.Sprintf("S-%d-%d", revisionLevel, authority)
+	for _, v := range subAuthorities {
+		s += fmt.Sprintf("-%d", v)
+	}
+	return s
+}

--- a/internal/armada/authorization/groups/ldap.go
+++ b/internal/armada/authorization/groups/ldap.go
@@ -24,10 +24,15 @@ type LDAPGroupLookup struct {
 }
 
 func NewLDAPGroupLookup(config configuration.LDAPConfig) *LDAPGroupLookup {
+	expiry := config.CacheExpiry
+	if expiry == 0 {
+		expiry = 5 * time.Minute
+	}
+
 	return &LDAPGroupLookup{
 		config:      config,
 		cache:       map[string]cacheRecord{},
-		cacheExpiry: 5 * time.Minute,
+		cacheExpiry: expiry,
 	}
 }
 

--- a/internal/armada/authorization/groups/ldap.go
+++ b/internal/armada/authorization/groups/ldap.go
@@ -54,7 +54,7 @@ func (lookup *LDAPGroupLookup) GetGroupNames(SIDs []string) ([]string, error) {
 
 func (lookup *LDAPGroupLookup) updateCache(SIDs []string) error {
 
-	log.Info("Looking up group SIDS: %v", SIDs)
+	log.Infof("Looking up group SIDS: %v", SIDs)
 
 	deadline := time.Now().Add(-lookup.cacheExpiry)
 	missing := []string{}
@@ -70,7 +70,7 @@ func (lookup *LDAPGroupLookup) updateCache(SIDs []string) error {
 		return err
 	}
 
-	log.Info("Found group names: %v", groupNames)
+	log.Infof("Found group names: %v", groupNames)
 
 	for sid, name := range groupNames {
 		lookup.cache[sid] = cacheRecord{

--- a/internal/armada/authorization/groups/ldap_test.go
+++ b/internal/armada/authorization/groups/ldap_test.go
@@ -1,0 +1,18 @@
+package groups
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_decodeSID(t *testing.T) {
+	hexSID := []byte("010500000000000515000000A065CF7E784B9B5FE77C8770091C0100")
+	sid := "S-1-5-21-2127521184-1604012920-1887927527-72713"
+
+	data := make([]byte, hex.DecodedLen(len(hexSID)))
+	_, err := hex.Decode(data, hexSID)
+	assert.NoError(t, err)
+	assert.Equal(t, decodeSID(data), sid)
+}

--- a/internal/armada/authorization/kerberos.go
+++ b/internal/armada/authorization/kerberos.go
@@ -126,8 +126,6 @@ func (authService *KerberosAuthService) Authenticate(ctx context.Context) (Princ
 				userGroups = groupSIDs
 			}
 
-			log.Infof("Domain ID: %s", adCredentials.LogonDomainID)
-
 			// Original library sets ticket accepted header here, but this breaks python
 			// request-negotiate-sspi module
 			// removing the header as workaround before moving away from kerberos

--- a/internal/armada/authorization/kerberos.go
+++ b/internal/armada/authorization/kerberos.go
@@ -126,7 +126,7 @@ func (authService *KerberosAuthService) Authenticate(ctx context.Context) (Princ
 				userGroups = groupSIDs
 			}
 
-			log.Errorf("Domain ID: ", adCredentials.LogonDomainID)
+			log.Infof("Domain ID: %s", adCredentials.LogonDomainID)
 
 			// Original library sets ticket accepted header here, but this breaks python
 			// request-negotiate-sspi module

--- a/internal/armada/configuration/types.go
+++ b/internal/armada/configuration/types.go
@@ -55,10 +55,11 @@ type BasicAuthenticationConfig struct {
 }
 
 type KerberosAuthenticationConfig struct {
-	KeytabLocation string
-	PrincipalName  string
-	UserNameSuffix string
-	LDAP           LDAPConfig
+	KeytabLocation  string
+	PrincipalName   string
+	UserNameSuffix  string
+	GroupNameSuffix string
+	LDAP            LDAPConfig
 }
 
 type LDAPConfig struct {

--- a/internal/armada/configuration/types.go
+++ b/internal/armada/configuration/types.go
@@ -58,6 +58,14 @@ type KerberosAuthenticationConfig struct {
 	KeytabLocation string
 	PrincipalName  string
 	UserNameSuffix string
+	LDAP           LDAPConfig
+}
+
+type LDAPConfig struct {
+	URL             string
+	Username        string
+	Password        string
+	GroupSearchBase string
 }
 
 type SchedulingConfig struct {

--- a/internal/armada/configuration/types.go
+++ b/internal/armada/configuration/types.go
@@ -66,6 +66,7 @@ type LDAPConfig struct {
 	Username        string
 	Password        string
 	GroupSearchBase string
+	CacheExpiry     time.Duration
 }
 
 type SchedulingConfig struct {


### PR DESCRIPTION
Kerberos can now be configured with LDAP lookup credentials to find user group names, this means that permission configuration does not have to use SIDs anymore.