### PR TITLE
Executor services refactoring.

### DIFF
--- a/internal/executor/application.go
+++ b/internal/executor/application.go
@@ -13,7 +13,7 @@ import (
 	"github.com/G-Research/armada/internal/executor/cluster"
 	"github.com/G-Research/armada/internal/executor/configuration"
 	"github.com/G-Research/armada/internal/executor/context"
-	"github.com/G-Research/armada/internal/executor/job_context"
+	"github.com/G-Research/armada/internal/executor/job"
 	"github.com/G-Research/armada/internal/executor/metrics"
 	"github.com/G-Research/armada/internal/executor/metrics/pod_metrics"
 	"github.com/G-Research/armada/internal/executor/reporter"
@@ -62,7 +62,8 @@ func StartUpWithContext(config configuration.ExecutorConfiguration, clusterConte
 		clusterContext,
 		eventClient)
 
-	jobContext := job_context.NewClusterJobContext(clusterContext)
+	jobContext := job.NewClusterJobContext(clusterContext)
+	submitter := job.NewSubmitter(clusterContext, config.Kubernetes.PodDefaults)
 
 	jobLeaseService := service.NewJobLeaseService(
 		clusterContext,
@@ -95,9 +96,9 @@ func StartUpWithContext(config configuration.ExecutorConfiguration, clusterConte
 		eventReporter,
 		jobLeaseService,
 		clusterUtilisationService,
-		config.Kubernetes.PodDefaults)
+		submitter)
 
-	service.RunIngressCleanup(clusterContext)
+	job.RunIngressCleanup(clusterContext)
 
 	pod_metrics.ExposeClusterContextMetrics(clusterContext, clusterUtilisationService, queueUtilisationService)
 

--- a/internal/executor/configuration/types.go
+++ b/internal/executor/configuration/types.go
@@ -32,7 +32,6 @@ type TaskConfiguration struct {
 	MissingJobEventReconciliationInterval time.Duration
 	JobLeaseRenewalInterval               time.Duration
 	AllocateSpareClusterCapacityInterval  time.Duration
-	StuckPodScanInterval                  time.Duration
 	PodDeletionInterval                   time.Duration
 	QueueUsageDataRefreshInterval         time.Duration
 	UtilisationEventProcessingInterval    time.Duration

--- a/internal/executor/job/ingress_cleanup.go
+++ b/internal/executor/job/ingress_cleanup.go
@@ -1,4 +1,4 @@
-package service
+package job
 
 import (
 	log "github.com/sirupsen/logrus"

--- a/internal/executor/job/job_context.go
+++ b/internal/executor/job/job_context.go
@@ -1,4 +1,4 @@
-package job_context
+package job
 
 import (
 	"sync"

--- a/internal/executor/job/submit.go
+++ b/internal/executor/job/submit.go
@@ -1,0 +1,262 @@
+package job
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/G-Research/armada/internal/common"
+	"github.com/G-Research/armada/internal/executor/configuration"
+	"github.com/G-Research/armada/internal/executor/context"
+	"github.com/G-Research/armada/internal/executor/domain"
+	"github.com/G-Research/armada/internal/executor/reporter"
+	"github.com/G-Research/armada/pkg/api"
+)
+
+const admissionWebhookValidationFailureMessage string = "admission webhook"
+
+type Submitter interface {
+	SubmitJobs(jobsToSubmit []*api.Job) []*FailedSubmissionDetails
+}
+
+type SubmitService struct {
+	eventReporter  reporter.EventReporter
+	clusterContext context.ClusterContext
+	podDefaults    *configuration.PodDefaults
+}
+
+func NewSubmitter(
+	clusterContext context.ClusterContext,
+	podDefaults *configuration.PodDefaults) *SubmitService {
+
+	return &SubmitService{
+		clusterContext: clusterContext,
+		podDefaults:    podDefaults}
+}
+
+type FailedSubmissionDetails struct {
+	Pod         *v1.Pod
+	Job         *api.Job
+	Error       error
+	Recoverable bool
+}
+
+func (allocationService *SubmitService) SubmitJobs(jobsToSubmit []*api.Job) []*FailedSubmissionDetails {
+	toBeFailedJobs := make([]*FailedSubmissionDetails, 0, 10)
+	for _, job := range jobsToSubmit {
+		jobPods := []*v1.Pod{}
+		for i, _ := range job.GetAllPodSpecs() {
+			pod, err := allocationService.submitPod(job, i)
+			jobPods = append(jobPods, pod)
+
+			if err != nil {
+				log.Errorf("Failed to submit job %s because %s", job.Id, err)
+
+				status, ok := err.(errors.APIStatus)
+				recoverable := !ok || isNotRecoverable(status.Status())
+
+				errDetails := &FailedSubmissionDetails{
+					Job:         job,
+					Pod:         pod,
+					Error:       err,
+					Recoverable: recoverable,
+				}
+
+				toBeFailedJobs = append(toBeFailedJobs, errDetails)
+
+				// remove just created pods
+				allocationService.clusterContext.DeletePods(jobPods)
+				break
+			}
+		}
+	}
+
+	return toBeFailedJobs
+}
+
+func (allocationService *SubmitService) submitPod(job *api.Job, i int) (*v1.Pod, error) {
+	pod := createPod(job, allocationService.podDefaults, i)
+
+	if exposesPorts(job, &pod.Spec) {
+		pod.Annotations = mergeMaps(pod.Annotations, map[string]string{
+			domain.HasIngress: "true",
+		})
+		submittedPod, err := allocationService.clusterContext.SubmitPod(pod, job.Owner, job.QueueOwnershipUserGroups)
+		if err != nil {
+			return pod, err
+		}
+		service := createService(job, submittedPod)
+		_, err = allocationService.clusterContext.SubmitService(service)
+		return pod, err
+	} else {
+		_, err := allocationService.clusterContext.SubmitPod(pod, job.Owner, job.QueueOwnershipUserGroups)
+		return pod, err
+	}
+}
+
+func getServicePorts(job *api.Job, podSpec *v1.PodSpec) []v1.ServicePort {
+	var servicePorts []v1.ServicePort
+	if job.Ingress == nil || len(job.Ingress) == 0 {
+		return servicePorts
+	}
+
+	for _, container := range podSpec.Containers {
+		ports := container.Ports
+		for _, port := range ports {
+			//Don't expose host via service, this will already be handled by kubernetes
+			if port.HostPort > 0 {
+				continue
+			}
+			if shouldExposeWithNodePort(port, job) {
+				servicePort := v1.ServicePort{
+					Name:     fmt.Sprintf("%s-%d", container.Name, port.ContainerPort),
+					Port:     port.ContainerPort,
+					Protocol: port.Protocol,
+				}
+
+				servicePorts = append(servicePorts, servicePort)
+			}
+		}
+	}
+
+	return servicePorts
+}
+
+func contains(portConfig *api.IngressConfig, port uint32) bool {
+	for _, p := range portConfig.Ports {
+		if p == port {
+			return true
+		}
+	}
+	return false
+}
+
+func shouldExposeWithNodePort(port v1.ContainerPort, job *api.Job) bool {
+	for _, ingressConfig := range job.Ingress {
+		if ingressConfig.Type == api.IngressType_NodePort &&
+			contains(ingressConfig, uint32(port.ContainerPort)) {
+			return true
+		}
+	}
+	return false
+}
+
+func exposesPorts(job *api.Job, podSpec *v1.PodSpec) bool {
+	return len(getServicePorts(job, podSpec)) > 0
+}
+
+func isNotRecoverable(status metav1.Status) bool {
+	if status.Reason == metav1.StatusReasonInvalid ||
+		status.Reason == metav1.StatusReasonForbidden {
+		return true
+	}
+
+	//This message shows it was rejected by an admission webhook.
+	// By default admission webhooks blocking results in a 500 so we can't use the status code as we could confuse it with Kubernetes outage
+	if strings.Contains(status.Message, admissionWebhookValidationFailureMessage) {
+		return true
+	}
+
+	return false
+}
+
+func createService(job *api.Job, pod *v1.Pod) *v1.Service {
+	servicePorts := getServicePorts(job, &pod.Spec)
+
+	ownerReference := metav1.OwnerReference{
+		APIVersion: "v1",
+		Kind:       "Pod",
+		Name:       pod.Name,
+		UID:        pod.UID,
+	}
+	serviceSpec := v1.ServiceSpec{
+		Type: v1.ServiceTypeNodePort,
+		Selector: map[string]string{
+			domain.JobId:     pod.Labels[domain.JobId],
+			domain.Queue:     pod.Labels[domain.Queue],
+			domain.PodNumber: pod.Labels[domain.PodNumber],
+		},
+		Ports: servicePorts,
+	}
+	labels := mergeMaps(job.Labels, map[string]string{
+		domain.JobId:     pod.Labels[domain.JobId],
+		domain.Queue:     pod.Labels[domain.Queue],
+		domain.PodNumber: pod.Labels[domain.PodNumber],
+	})
+	annotation := mergeMaps(job.Annotations, map[string]string{
+		domain.JobSetId: job.JobSetId,
+		domain.Owner:    job.Owner,
+	})
+	service := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            pod.Name,
+			Labels:          labels,
+			Annotations:     annotation,
+			Namespace:       job.Namespace,
+			OwnerReferences: []metav1.OwnerReference{ownerReference},
+		},
+		Spec: serviceSpec,
+	}
+	return service
+}
+
+func createPod(job *api.Job, defaults *configuration.PodDefaults, i int) *v1.Pod {
+
+	allPodSpecs := job.GetAllPodSpecs()
+	podSpec := allPodSpecs[i]
+	applyDefaults(podSpec, defaults)
+
+	labels := mergeMaps(job.Labels, map[string]string{
+		domain.JobId:     job.Id,
+		domain.Queue:     job.Queue,
+		domain.PodNumber: strconv.Itoa(i),
+		domain.PodCount:  strconv.Itoa(len(allPodSpecs)),
+	})
+	annotation := mergeMaps(job.Annotations, map[string]string{
+		domain.JobSetId: job.JobSetId,
+		domain.Owner:    job.Owner,
+	})
+
+	setRestartPolicyNever(podSpec)
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        common.PodNamePrefix + job.Id + "-" + strconv.Itoa(i),
+			Labels:      labels,
+			Annotations: annotation,
+			Namespace:   job.Namespace,
+		},
+		Spec: *podSpec,
+	}
+
+	return pod
+}
+
+func applyDefaults(spec *v1.PodSpec, defaults *configuration.PodDefaults) {
+	if defaults == nil {
+		return
+	}
+	if defaults.SchedulerName != "" && spec.SchedulerName == "" {
+		spec.SchedulerName = defaults.SchedulerName
+	}
+}
+
+func setRestartPolicyNever(podSpec *v1.PodSpec) {
+	podSpec.RestartPolicy = v1.RestartPolicyNever
+}
+
+func mergeMaps(a map[string]string, b map[string]string) map[string]string {
+	result := make(map[string]string)
+	for k, v := range a {
+		result[k] = v
+	}
+	for k, v := range b {
+		result[k] = v
+	}
+	return result
+}

--- a/internal/executor/job/submit_test.go
+++ b/internal/executor/job/submit_test.go
@@ -1,4 +1,4 @@
-package service
+package job
 
 import (
 	"testing"

--- a/internal/executor/service/cluster_allocation.go
+++ b/internal/executor/service/cluster_allocation.go
@@ -2,32 +2,24 @@ package service
 
 import (
 	"fmt"
-	"strconv"
-	"strings"
 
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/G-Research/armada/internal/common"
-	"github.com/G-Research/armada/internal/executor/configuration"
 	"github.com/G-Research/armada/internal/executor/context"
-	"github.com/G-Research/armada/internal/executor/domain"
+	"github.com/G-Research/armada/internal/executor/job"
 	"github.com/G-Research/armada/internal/executor/reporter"
 	"github.com/G-Research/armada/internal/executor/util"
 	"github.com/G-Research/armada/internal/executor/utilisation"
-	"github.com/G-Research/armada/pkg/api"
 )
-
-const admissionWebhookValidationFailureMessage string = "admission webhook"
 
 type ClusterAllocationService struct {
 	leaseService       LeaseService
 	eventReporter      reporter.EventReporter
 	utilisationService utilisation.UtilisationService
 	clusterContext     context.ClusterContext
-	podDefaults        *configuration.PodDefaults
+	submitter          job.Submitter
 }
 
 func NewClusterAllocationService(
@@ -35,14 +27,14 @@ func NewClusterAllocationService(
 	eventReporter reporter.EventReporter,
 	leaseService LeaseService,
 	utilisationService utilisation.UtilisationService,
-	podDefaults *configuration.PodDefaults) *ClusterAllocationService {
+	submitter job.Submitter) *ClusterAllocationService {
 
 	return &ClusterAllocationService{
 		leaseService:       leaseService,
 		eventReporter:      eventReporter,
 		utilisationService: utilisationService,
 		clusterContext:     clusterContext,
-		podDefaults:        podDefaults}
+		submitter:          submitter}
 }
 
 func (allocationService *ClusterAllocationService) AllocateSpareClusterCapacity() {
@@ -69,141 +61,33 @@ func (allocationService *ClusterAllocationService) AllocateSpareClusterCapacity(
 		log.Errorf("Failed to lease new jobs because %s", err)
 		return
 	} else {
-		allocationService.submitJobs(newJobs)
-	}
-}
+		failedJobs := allocationService.submitter.SubmitJobs(newJobs)
 
-func (allocationService *ClusterAllocationService) submitJobs(jobsToSubmit []*api.Job) {
-	toBeFailedJobs := make([]*failedSubmissionDetails, 0, 10)
-
-	for _, job := range jobsToSubmit {
-		jobPods := []*v1.Pod{}
-		for i, _ := range job.GetAllPodSpecs() {
-			pod, err := allocationService.submitPod(job, i)
-			jobPods = append(jobPods, pod)
-
-			if err != nil {
-				log.Errorf("Failed to submit job %s because %s", job.Id, err)
-
-				status, ok := err.(errors.APIStatus)
-				if ok && (isNotRecoverable(status.Status())) {
-					errDetails := &failedSubmissionDetails{
-						job:   job,
-						pod:   pod,
-						error: status,
-					}
-					toBeFailedJobs = append(toBeFailedJobs, errDetails)
-				} else {
-					allocationService.returnLease(pod, fmt.Sprintf("Failed to submit pod because %s", err))
-				}
-				// remove just created pods
-				allocationService.clusterContext.DeletePods(jobPods)
-				break
-			}
-		}
-	}
-
-	err := allocationService.failJobs(toBeFailedJobs)
-	if err != nil {
-		log.Errorf("Failed to report failed jobs as done because %s", err)
-	}
-}
-
-func (allocationService *ClusterAllocationService) submitPod(job *api.Job, i int) (*v1.Pod, error) {
-	pod := createPod(job, allocationService.podDefaults, i)
-
-	if exposesPorts(job, &pod.Spec) {
-		pod.Annotations = mergeMaps(pod.Annotations, map[string]string{
-			domain.HasIngress: "true",
-		})
-		submittedPod, err := allocationService.clusterContext.SubmitPod(pod, job.Owner, job.QueueOwnershipUserGroups)
+		err := allocationService.processFailedJobs(failedJobs)
 		if err != nil {
-			return pod, err
-		}
-		service := createService(job, submittedPod)
-		_, err = allocationService.clusterContext.SubmitService(service)
-		return pod, err
-	} else {
-		_, err := allocationService.clusterContext.SubmitPod(pod, job.Owner, job.QueueOwnershipUserGroups)
-		return pod, err
-	}
-}
-
-func getServicePorts(job *api.Job, podSpec *v1.PodSpec) []v1.ServicePort {
-	var servicePorts []v1.ServicePort
-	if job.Ingress == nil || len(job.Ingress) == 0 {
-		return servicePorts
-	}
-
-	for _, container := range podSpec.Containers {
-		ports := container.Ports
-		for _, port := range ports {
-			//Don't expose host via service, this will already be handled by kubernetes
-			if port.HostPort > 0 {
-				continue
-			}
-			if shouldExposeWithNodePort(port, job) {
-				servicePort := v1.ServicePort{
-					Name:     fmt.Sprintf("%s-%d", container.Name, port.ContainerPort),
-					Port:     port.ContainerPort,
-					Protocol: port.Protocol,
-				}
-
-				servicePorts = append(servicePorts, servicePort)
-			}
+			log.Errorf("Failed to process failed jobs  because %s", err)
 		}
 	}
-
-	return servicePorts
 }
 
-func contains(portConfig *api.IngressConfig, port uint32) bool {
-	for _, p := range portConfig.Ports {
-		if p == port {
-			return true
-		}
-	}
-	return false
-}
-
-func shouldExposeWithNodePort(port v1.ContainerPort, job *api.Job) bool {
-	for _, ingressConfig := range job.Ingress {
-		if ingressConfig.Type == api.IngressType_NodePort &&
-			contains(ingressConfig, uint32(port.ContainerPort)) {
-			return true
-		}
-	}
-	return false
-}
-
-func exposesPorts(job *api.Job, podSpec *v1.PodSpec) bool {
-	return len(getServicePorts(job, podSpec)) > 0
-}
-
-func isNotRecoverable(status metav1.Status) bool {
-	if status.Reason == metav1.StatusReasonInvalid ||
-		status.Reason == metav1.StatusReasonForbidden {
-		return true
-	}
-
-	//This message shows it was rejected by an admission webhook.
-	// By default admission webhooks blocking results in a 500 so we can't use the status code as we could confuse it with Kubernetes outage
-	if strings.Contains(status.Message, admissionWebhookValidationFailureMessage) {
-		return true
-	}
-
-	return false
-}
-
-func (allocationService *ClusterAllocationService) failJobs(failedSubmissions []*failedSubmissionDetails) error {
+func (allocationService *ClusterAllocationService) processFailedJobs(failedSubmissions []*job.FailedSubmissionDetails) error {
 	toBeReportedDone := make([]string, 0, 10)
 
 	for _, details := range failedSubmissions {
-		failEvent := reporter.CreateSimpleJobFailedEvent(details.pod, details.error.Status().Message, allocationService.clusterContext.GetClusterId())
-		err := allocationService.eventReporter.Report(failEvent)
+		message := details.Error.Error()
+		if apiError, ok := details.Error.(errors.APIStatus); ok {
+			message = apiError.Status().Message
+		}
 
-		if err == nil {
-			toBeReportedDone = append(toBeReportedDone, details.job.JobSetId)
+		if details.Recoverable {
+			allocationService.returnLease(details.Pod, fmt.Sprintf("Failed to submit pod because %s", message))
+		} else {
+			failEvent := reporter.CreateSimpleJobFailedEvent(details.Pod, message, allocationService.clusterContext.GetClusterId())
+			err := allocationService.eventReporter.Report(failEvent)
+
+			if err == nil {
+				toBeReportedDone = append(toBeReportedDone, details.Job.JobSetId)
+			}
 		}
 	}
 
@@ -223,106 +107,4 @@ func (allocationService *ClusterAllocationService) returnLease(pod *v1.Pod, reas
 			log.Errorf("Failed to report event %+v because %s", leaseReturnedEvent, err)
 		}
 	}
-}
-
-func createService(job *api.Job, pod *v1.Pod) *v1.Service {
-	servicePorts := getServicePorts(job, &pod.Spec)
-
-	ownerReference := metav1.OwnerReference{
-		APIVersion: "v1",
-		Kind:       "Pod",
-		Name:       pod.Name,
-		UID:        pod.UID,
-	}
-	serviceSpec := v1.ServiceSpec{
-		Type: v1.ServiceTypeNodePort,
-		Selector: map[string]string{
-			domain.JobId:     pod.Labels[domain.JobId],
-			domain.Queue:     pod.Labels[domain.Queue],
-			domain.PodNumber: pod.Labels[domain.PodNumber],
-		},
-		Ports: servicePorts,
-	}
-	labels := mergeMaps(job.Labels, map[string]string{
-		domain.JobId:     pod.Labels[domain.JobId],
-		domain.Queue:     pod.Labels[domain.Queue],
-		domain.PodNumber: pod.Labels[domain.PodNumber],
-	})
-	annotation := mergeMaps(job.Annotations, map[string]string{
-		domain.JobSetId: job.JobSetId,
-		domain.Owner:    job.Owner,
-	})
-	service := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            pod.Name,
-			Labels:          labels,
-			Annotations:     annotation,
-			Namespace:       job.Namespace,
-			OwnerReferences: []metav1.OwnerReference{ownerReference},
-		},
-		Spec: serviceSpec,
-	}
-	return service
-}
-
-func createPod(job *api.Job, defaults *configuration.PodDefaults, i int) *v1.Pod {
-
-	allPodSpecs := job.GetAllPodSpecs()
-	podSpec := allPodSpecs[i]
-	applyDefaults(podSpec, defaults)
-
-	labels := mergeMaps(job.Labels, map[string]string{
-		domain.JobId:     job.Id,
-		domain.Queue:     job.Queue,
-		domain.PodNumber: strconv.Itoa(i),
-		domain.PodCount:  strconv.Itoa(len(allPodSpecs)),
-	})
-	annotation := mergeMaps(job.Annotations, map[string]string{
-		domain.JobSetId: job.JobSetId,
-		domain.Owner:    job.Owner,
-	})
-
-	setRestartPolicyNever(podSpec)
-
-	pod := &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        common.PodNamePrefix + job.Id + "-" + strconv.Itoa(i),
-			Labels:      labels,
-			Annotations: annotation,
-			Namespace:   job.Namespace,
-		},
-		Spec: *podSpec,
-	}
-
-	return pod
-}
-
-func applyDefaults(spec *v1.PodSpec, defaults *configuration.PodDefaults) {
-	if defaults == nil {
-		return
-	}
-	if defaults.SchedulerName != "" && spec.SchedulerName == "" {
-		spec.SchedulerName = defaults.SchedulerName
-	}
-}
-
-func setRestartPolicyNever(podSpec *v1.PodSpec) {
-	podSpec.RestartPolicy = v1.RestartPolicyNever
-}
-
-type failedSubmissionDetails struct {
-	pod   *v1.Pod
-	job   *api.Job
-	error errors.APIStatus
-}
-
-func mergeMaps(a map[string]string, b map[string]string) map[string]string {
-	result := make(map[string]string)
-	for k, v := range a {
-		result[k] = v
-	}
-	for k, v := range b {
-		result[k] = v
-	}
-	return result
 }

--- a/internal/executor/service/fake/lease_service.go
+++ b/internal/executor/service/fake/lease_service.go
@@ -1,0 +1,52 @@
+package fake
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/G-Research/armada/internal/common"
+	"github.com/G-Research/armada/internal/executor/job"
+	"github.com/G-Research/armada/pkg/api"
+)
+
+type MockLeaseService struct {
+	ReturnLeaseCalls      int
+	RequestJobLeasesCalls int
+	ReportDoneCalls       int
+
+	ReturnLeaseArg *v1.Pod
+	ReportDoneArg  []string
+}
+
+func NewMockLeaseService() *MockLeaseService {
+	return &MockLeaseService{0, 0, 0, nil, nil}
+}
+
+func (ls *MockLeaseService) RenewJobLeases(jobs []*job.RunningJob) ([]*job.RunningJob, error) {
+	return []*job.RunningJob{}, nil
+}
+
+func (ls *MockLeaseService) ReturnLease(pod *v1.Pod) error {
+	ls.ReturnLeaseArg = pod
+	ls.ReturnLeaseCalls++
+	return nil
+}
+
+func (ls *MockLeaseService) RequestJobLeases(availableResource *common.ComputeResources, nodes []api.NodeInfo, leasedResourceByQueue map[string]common.ComputeResources) ([]*api.Job, error) {
+	ls.RequestJobLeasesCalls++
+	return make([]*api.Job, 0), nil
+}
+
+func (ls *MockLeaseService) ReportDone(jobIds []string) error {
+	ls.ReportDoneArg = jobIds
+	ls.ReportDoneCalls++
+	return nil
+}
+
+func (ls *MockLeaseService) AssertReportDoneCalledOnceWith(t *testing.T, expected []string) {
+	assert.Equal(t, 1, ls.ReportDoneCalls)
+	assert.Equal(t, expected, ls.ReportDoneArg)
+}

--- a/internal/executor/service/fake/queue_client.go
+++ b/internal/executor/service/fake/queue_client.go
@@ -1,0 +1,29 @@
+package fake
+
+import (
+	"context"
+
+	"github.com/gogo/protobuf/types"
+	"google.golang.org/grpc"
+
+	"github.com/G-Research/armada/pkg/api"
+)
+
+type queueClientMock struct {
+}
+
+func (queueClientMock) LeaseJobs(ctx context.Context, in *api.LeaseRequest, opts ...grpc.CallOption) (*api.JobLease, error) {
+	return &api.JobLease{}, nil
+}
+
+func (queueClientMock) RenewLease(ctx context.Context, in *api.RenewLeaseRequest, opts ...grpc.CallOption) (*api.IdList, error) {
+	return &api.IdList{}, nil
+}
+
+func (queueClientMock) ReturnLease(ctx context.Context, in *api.ReturnLeaseRequest, opts ...grpc.CallOption) (*types.Empty, error) {
+	return &types.Empty{}, nil
+}
+
+func (queueClientMock) ReportDone(ctx context.Context, in *api.IdList, opts ...grpc.CallOption) (*api.IdList, error) {
+	return &api.IdList{}, nil
+}

--- a/internal/executor/service/job_lease_test.go
+++ b/internal/executor/service/job_lease_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/G-Research/armada/internal/common"
 	"github.com/G-Research/armada/internal/executor/configuration"
 	context2 "github.com/G-Research/armada/internal/executor/fake/context"
-	"github.com/G-Research/armada/internal/executor/job_context"
+	"github.com/G-Research/armada/internal/executor/job"
 	reporter_fake "github.com/G-Research/armada/internal/executor/reporter/fake"
 	"github.com/G-Research/armada/pkg/api"
 )
@@ -33,7 +33,7 @@ func TestCanBeRemovedConditions(t *testing.T) {
 	}
 
 	for pod, expected := range pods {
-		result := s.canBeRemoved(&job_context.RunningJob{JobId: "", Pods: []*v1.Pod{pod}})
+		result := s.canBeRemoved(&job.RunningJob{JobId: "", Pods: []*v1.Pod{pod}})
 		assert.Equal(t, expected, result)
 	}
 }
@@ -53,15 +53,15 @@ func TestCanBeRemovedMinumumPodTime(t *testing.T) {
 	}
 
 	for pod, expected := range pods {
-		result := s.canBeRemoved(&job_context.RunningJob{JobId: "", Pods: []*v1.Pod{pod}})
+		result := s.canBeRemoved(&job.RunningJob{JobId: "", Pods: []*v1.Pod{pod}})
 		assert.Equal(t, expected, result)
 	}
 }
 
 func TestChunkPods(t *testing.T) {
-	j := &job_context.RunningJob{}
-	chunks := chunkJobs([]*job_context.RunningJob{j, j, j}, 2)
-	assert.Equal(t, [][]*job_context.RunningJob{{j, j}, {j}}, chunks)
+	j := &job.RunningJob{}
+	chunks := chunkJobs([]*job.RunningJob{j, j, j}, 2)
+	assert.Equal(t, [][]*job.RunningJob{{j, j}, {j}}, chunks)
 }
 
 func makeFinishedPodWithTimestamp(state v1.PodPhase, timestamp time.Time) *v1.Pod {
@@ -91,7 +91,7 @@ func makePodWithCurrentStateReported(state v1.PodPhase, reportedDone bool) *v1.P
 
 func createLeaseService(minimumPodAge, failedPodExpiry time.Duration) *JobLeaseService {
 	fakeClusterContext := context2.NewFakeClusterContext(configuration.ApplicationConfiguration{ClusterId: "test", Pool: "pool"}, nil)
-	jobContext := job_context.NewClusterJobContext(fakeClusterContext)
+	jobContext := job.NewClusterJobContext(fakeClusterContext)
 	return NewJobLeaseService(fakeClusterContext, jobContext, &reporter_fake.FakeEventReporter{}, &queueClientMock{}, minimumPodAge, failedPodExpiry, common.ComputeResources{})
 }
 

--- a/internal/executor/service/job_manager.go
+++ b/internal/executor/service/job_manager.go
@@ -1,0 +1,136 @@
+package service
+
+import (
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+
+	context2 "github.com/G-Research/armada/internal/executor/context"
+	"github.com/G-Research/armada/internal/executor/job"
+	"github.com/G-Research/armada/internal/executor/reporter"
+	"github.com/G-Research/armada/internal/executor/util"
+)
+
+type JobManager struct {
+	clusterIdentity  context2.ClusterIdentity
+	jobContext       job.JobContext
+	eventReporter    reporter.EventReporter
+	stuckPodDetector *StuckPodDetector
+	jobLeaseService  LeaseService
+	minimumPodAge    time.Duration
+	failedPodExpiry  time.Duration
+}
+
+func NewJobManager(
+	clusterIdentity context2.ClusterIdentity,
+	jobContext job.JobContext,
+	eventReporter reporter.EventReporter,
+	stuckPodDetector *StuckPodDetector,
+	jobLeaseService LeaseService,
+	minimumPodAge time.Duration,
+	failedPodExpiry time.Duration) *JobManager {
+	return &JobManager{
+		clusterIdentity:  clusterIdentity,
+		jobContext:       jobContext,
+		eventReporter:    eventReporter,
+		stuckPodDetector: stuckPodDetector,
+		jobLeaseService:  jobLeaseService,
+		minimumPodAge:    minimumPodAge,
+		failedPodExpiry:  failedPodExpiry}
+}
+
+func (m *JobManager) ManageJobLeases() {
+	jobs, err := m.jobContext.GetRunningJobs()
+
+	if err != nil {
+		log.Errorf("Failed to manage job leases due to %s", err)
+		return
+	}
+
+	jobsToRenew := filterRunningJobs(jobs, jobShouldBeRenewed)
+	chunkedJobs := chunkJobs(jobsToRenew, maxPodRequestSize)
+	for _, chunk := range chunkedJobs {
+		failedJobs, err := m.jobLeaseService.RenewJobLeases(chunk)
+		if err == nil && len(failedJobs) > 0 {
+			m.reportTerminated(extractPods(failedJobs))
+			m.jobContext.DeleteJobs(failedJobs)
+		}
+	}
+
+	jobsForReporting := filterRunningJobs(jobs, shouldBeReportedDone)
+	chunkedJobsToReportDone := chunkJobs(jobsForReporting, maxPodRequestSize)
+	for _, chunk := range chunkedJobsToReportDone {
+		err = m.reportDoneAndMarkReported(chunk)
+		if err != nil {
+			log.Errorf("Failed reporting jobs as done because %s", err)
+			return
+		}
+	}
+
+	jobsToCleanup := filterRunningJobs(jobs, m.canBeRemoved)
+	m.jobContext.DeleteJobs(jobsToCleanup)
+
+	m.stuckPodDetector.HandleStuckPods(jobsToRenew)
+}
+
+func (m *JobManager) reportDoneAndMarkReported(jobs []*job.RunningJob) error {
+	if len(jobs) <= 0 {
+		return nil
+	}
+	err := m.jobLeaseService.ReportDone(extractJobIds(jobs))
+	if err == nil {
+		m.markAsDone(jobs)
+	}
+	return err
+}
+
+func (m *JobManager) markAsDone(jobs []*job.RunningJob) {
+	err := m.jobContext.AddAnnotation(jobs, map[string]string{
+		jobDoneAnnotation: time.Now().String(),
+	})
+	if err != nil {
+		log.Warnf("Failed to annotate jobs as done: %v", err)
+	}
+}
+
+func (m *JobManager) reportTerminated(pods []*v1.Pod) {
+	for _, pod := range pods {
+		event := reporter.CreateJobTerminatedEvent(pod, "Pod terminated because lease could not be renewed.", m.clusterIdentity.GetClusterId())
+		m.eventReporter.QueueEvent(event, func(err error) {
+			if err != nil {
+				log.Errorf("Failed to report terminated pod %s: %s", pod.Name, err)
+			}
+		})
+	}
+}
+
+func (m *JobManager) canBeRemoved(job *job.RunningJob) bool {
+	for _, pod := range job.Pods {
+		if !m.canPodBeRemoved(pod) {
+			return false
+		}
+	}
+	return true
+}
+
+func (m *JobManager) canPodBeRemoved(pod *v1.Pod) bool {
+	if !util.IsInTerminalState(pod) ||
+		!isReportedDone(pod) ||
+		!reporter.HasCurrentStateBeenReported(pod) {
+		return false
+	}
+
+	lastContainerStart := util.FindLastContainerStartTime(pod)
+	if lastContainerStart.Add(m.minimumPodAge).After(time.Now()) {
+		return false
+	}
+
+	if pod.Status.Phase == v1.PodFailed {
+		lastChange, err := util.LastStatusChange(pod)
+		if err == nil && lastChange.Add(m.failedPodExpiry).After(time.Now()) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/executor/service/job_manager_test.go
+++ b/internal/executor/service/job_manager_test.go
@@ -85,7 +85,7 @@ func createManager(minimumPodAge, failedPodExpiry time.Duration) *JobManager {
 	jobContext := job.NewClusterJobContext(fakeClusterContext)
 
 	jobLeaseService := fake.NewMockLeaseService()
-	stuckPodDetector := NewPodProgressMonitorService(fakeClusterContext, fakeEventReporter, jobLeaseService, time.Second)
+	stuckPodDetector := NewPodProgressMonitorService(fakeClusterContext, jobContext, fakeEventReporter, jobLeaseService, time.Second)
 
 	return NewJobManager(
 		fakeClusterContext,

--- a/internal/executor/service/job_manager_test.go
+++ b/internal/executor/service/job_manager_test.go
@@ -1,26 +1,22 @@
 package service
 
 import (
-	"context"
 	"testing"
 	"time"
 
-	"github.com/gogo/protobuf/types"
 	"github.com/stretchr/testify/assert"
-	"google.golang.org/grpc"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/G-Research/armada/internal/common"
 	"github.com/G-Research/armada/internal/executor/configuration"
 	context2 "github.com/G-Research/armada/internal/executor/fake/context"
 	"github.com/G-Research/armada/internal/executor/job"
 	reporter_fake "github.com/G-Research/armada/internal/executor/reporter/fake"
-	"github.com/G-Research/armada/pkg/api"
+	"github.com/G-Research/armada/internal/executor/service/fake"
 )
 
 func TestCanBeRemovedConditions(t *testing.T) {
-	s := createLeaseService(time.Second, time.Second)
+	s := createManager(time.Second, time.Second)
 	pods := map[*v1.Pod]bool{
 		// should not be cleaned yet
 		makePodWithCurrentStateReported(v1.PodRunning, false):   false,
@@ -39,7 +35,7 @@ func TestCanBeRemovedConditions(t *testing.T) {
 }
 
 func TestCanBeRemovedMinumumPodTime(t *testing.T) {
-	s := createLeaseService(5*time.Minute, 10*time.Minute)
+	s := createManager(5*time.Minute, 10*time.Minute)
 	now := time.Now()
 	pods := map[*v1.Pod]bool{
 		// should not be cleaned yet
@@ -56,12 +52,6 @@ func TestCanBeRemovedMinumumPodTime(t *testing.T) {
 		result := s.canBeRemoved(&job.RunningJob{JobId: "", Pods: []*v1.Pod{pod}})
 		assert.Equal(t, expected, result)
 	}
-}
-
-func TestChunkPods(t *testing.T) {
-	j := &job.RunningJob{}
-	chunks := chunkJobs([]*job.RunningJob{j, j, j}, 2)
-	assert.Equal(t, [][]*job.RunningJob{{j, j}, {j}}, chunks)
 }
 
 func makeFinishedPodWithTimestamp(state v1.PodPhase, timestamp time.Time) *v1.Pod {
@@ -89,27 +79,20 @@ func makePodWithCurrentStateReported(state v1.PodPhase, reportedDone bool) *v1.P
 	return &pod
 }
 
-func createLeaseService(minimumPodAge, failedPodExpiry time.Duration) *JobLeaseService {
+func createManager(minimumPodAge, failedPodExpiry time.Duration) *JobManager {
 	fakeClusterContext := context2.NewFakeClusterContext(configuration.ApplicationConfiguration{ClusterId: "test", Pool: "pool"}, nil)
+	fakeEventReporter := &reporter_fake.FakeEventReporter{}
 	jobContext := job.NewClusterJobContext(fakeClusterContext)
-	return NewJobLeaseService(fakeClusterContext, jobContext, &reporter_fake.FakeEventReporter{}, &queueClientMock{}, minimumPodAge, failedPodExpiry, common.ComputeResources{})
-}
 
-type queueClientMock struct {
-}
+	jobLeaseService := fake.NewMockLeaseService()
+	stuckPodDetector := NewPodProgressMonitorService(fakeClusterContext, fakeEventReporter, jobLeaseService, time.Second)
 
-func (queueClientMock) LeaseJobs(ctx context.Context, in *api.LeaseRequest, opts ...grpc.CallOption) (*api.JobLease, error) {
-	return &api.JobLease{}, nil
-}
-
-func (queueClientMock) RenewLease(ctx context.Context, in *api.RenewLeaseRequest, opts ...grpc.CallOption) (*api.IdList, error) {
-	return &api.IdList{}, nil
-}
-
-func (queueClientMock) ReturnLease(ctx context.Context, in *api.ReturnLeaseRequest, opts ...grpc.CallOption) (*types.Empty, error) {
-	return &types.Empty{}, nil
-}
-
-func (queueClientMock) ReportDone(ctx context.Context, in *api.IdList, opts ...grpc.CallOption) (*api.IdList, error) {
-	return &api.IdList{}, nil
+	return NewJobManager(
+		fakeClusterContext,
+		jobContext,
+		fakeEventReporter,
+		stuckPodDetector,
+		jobLeaseService,
+		minimumPodAge,
+		failedPodExpiry)
 }

--- a/internal/executor/service/stuck_pod_detector.go
+++ b/internal/executor/service/stuck_pod_detector.go
@@ -119,12 +119,7 @@ func (d *StuckPodDetector) onStuckPodDeleted(record *stuckJobRecord) (resolved b
 	return true
 }
 
-func (d *StuckPodDetector) HandleStuckPods() {
-	allRunningJobs, err := d.jobContext.GetRunningJobs()
-	if err != nil {
-		log.Errorf("Failed to load all pods for stuck pod handling %s ", err)
-		return
-	}
+func (d *StuckPodDetector) HandleStuckPods(allRunningJobs []*job.RunningJob) {
 
 	for _, job := range allRunningJobs {
 		_, exists := d.stuckJobCache[job.JobId]

--- a/internal/executor/service/stuck_pod_detector_test.go
+++ b/internal/executor/service/stuck_pod_detector_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/G-Research/armada/internal/common/util"
 	"github.com/G-Research/armada/internal/executor/context"
 	"github.com/G-Research/armada/internal/executor/domain"
-	"github.com/G-Research/armada/internal/executor/job_context"
+	"github.com/G-Research/armada/internal/executor/job"
 
 	reporter_fake "github.com/G-Research/armada/internal/executor/reporter/fake"
 	"github.com/G-Research/armada/pkg/api"
@@ -204,7 +204,7 @@ func addPod(t *testing.T, fakeClusterContext context.ClusterContext, runningPod 
 
 func makeStuckPodDetectorWithTestDoubles() (context.ClusterContext, *mockLeaseService, *reporter_fake.FakeEventReporter, *StuckPodDetector) {
 	fakeClusterContext := newSyncFakeClusterContext()
-	jobContext := job_context.NewClusterJobContext(fakeClusterContext)
+	jobContext := job.NewClusterJobContext(fakeClusterContext)
 	mockLeaseService := NewMockLeaseService()
 	eventReporter := &reporter_fake.FakeEventReporter{nil}
 

--- a/internal/executor/service/stuck_pod_detector_test.go
+++ b/internal/executor/service/stuck_pod_detector_test.go
@@ -12,60 +12,64 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 
-	"github.com/G-Research/armada/internal/common"
 	"github.com/G-Research/armada/internal/common/util"
 	"github.com/G-Research/armada/internal/executor/context"
 	"github.com/G-Research/armada/internal/executor/domain"
 	"github.com/G-Research/armada/internal/executor/job"
+	"github.com/G-Research/armada/internal/executor/service/fake"
 
 	reporter_fake "github.com/G-Research/armada/internal/executor/reporter/fake"
 	"github.com/G-Research/armada/pkg/api"
 )
 
 func TestStuckPodDetector_DoesNothingIfNoPodsAreFound(t *testing.T) {
-	_, mockLeaseService, _, stuckPodDetector := makeStuckPodDetectorWithTestDoubles()
+	_, mockLeaseService, _, jobContext, stuckPodDetector := makeStuckPodDetectorWithTestDoubles()
 
-	stuckPodDetector.HandleStuckPods()
+	jobs, _ := jobContext.GetRunningJobs()
+	stuckPodDetector.HandleStuckPods(jobs)
 
-	assert.Zero(t, mockLeaseService.returnLeaseCalls)
+	assert.Zero(t, mockLeaseService.ReturnLeaseCalls)
 
-	mockLeaseService.assertReportDoneCalledOnceWith(t, []string{})
+	mockLeaseService.AssertReportDoneCalledOnceWith(t, []string{})
 }
 
 func TestStuckPodDetector_DoesNothingIfNoStuckPodsAreFound(t *testing.T) {
 	runningPod := makeRunningPod()
 
-	fakeClusterContext, mockLeaseService, _, stuckPodDetector := makeStuckPodDetectorWithTestDoubles()
+	fakeClusterContext, mockLeaseService, _, jobContext, stuckPodDetector := makeStuckPodDetectorWithTestDoubles()
 
 	addPod(t, fakeClusterContext, runningPod)
 
-	stuckPodDetector.HandleStuckPods()
+	jobs, _ := jobContext.GetRunningJobs()
+	stuckPodDetector.HandleStuckPods(jobs)
 
-	assert.Zero(t, mockLeaseService.returnLeaseCalls)
+	assert.Zero(t, mockLeaseService.ReturnLeaseCalls)
 
-	mockLeaseService.assertReportDoneCalledOnceWith(t, []string{})
+	mockLeaseService.AssertReportDoneCalledOnceWith(t, []string{})
 }
 
 func TestStuckPodDetector_DeletesPodAndReportsDoneIfStuckAndUnretryable(t *testing.T) {
 	unretryableStuckPod := makeUnretryableStuckPod()
 
-	fakeClusterContext, mockLeaseService, eventsReporter, stuckPodDetector := makeStuckPodDetectorWithTestDoubles()
+	fakeClusterContext, mockLeaseService, eventsReporter, jobContext, stuckPodDetector := makeStuckPodDetectorWithTestDoubles()
 
 	addPod(t, fakeClusterContext, unretryableStuckPod)
 
-	stuckPodDetector.HandleStuckPods()
+	jobs, _ := jobContext.GetRunningJobs()
+	stuckPodDetector.HandleStuckPods(jobs)
 
 	remainingActivePods := getActivePods(t, fakeClusterContext)
 	assert.Equal(t, []*v1.Pod{}, remainingActivePods)
 
-	assert.Zero(t, mockLeaseService.returnLeaseCalls)
+	assert.Zero(t, mockLeaseService.ReturnLeaseCalls)
 
-	mockLeaseService.assertReportDoneCalledOnceWith(t, []string{unretryableStuckPod.Labels[domain.JobId]})
+	mockLeaseService.AssertReportDoneCalledOnceWith(t, []string{unretryableStuckPod.Labels[domain.JobId]})
 
 	_, ok := eventsReporter.ReceivedEvents[0].(*api.JobUnableToScheduleEvent)
 	assert.True(t, ok)
 
-	stuckPodDetector.HandleStuckPods()
+	jobs, _ = jobContext.GetRunningJobs()
+	stuckPodDetector.HandleStuckPods(jobs)
 
 	failedEvent, ok := eventsReporter.ReceivedEvents[1].(*api.JobFailedEvent)
 	assert.True(t, ok)
@@ -75,19 +79,21 @@ func TestStuckPodDetector_DeletesPodAndReportsDoneIfStuckAndUnretryable(t *testi
 func TestStuckPodDetector_DeletesPodAndReportsFailedIfStuckTerminating(t *testing.T) {
 	terminatingPod := makeTerminatingPod()
 
-	fakeClusterContext, mockLeaseService, eventsReporter, stuckPodDetector := makeStuckPodDetectorWithTestDoubles()
+	fakeClusterContext, mockLeaseService, eventsReporter, jobContext, stuckPodDetector := makeStuckPodDetectorWithTestDoubles()
 
 	addPod(t, fakeClusterContext, terminatingPod)
 
-	stuckPodDetector.HandleStuckPods()
+	jobs, _ := jobContext.GetRunningJobs()
+	stuckPodDetector.HandleStuckPods(jobs)
 
 	remainingActivePods := getActivePods(t, fakeClusterContext)
 	assert.Equal(t, []*v1.Pod{}, remainingActivePods)
 
-	assert.Zero(t, mockLeaseService.returnLeaseCalls)
-	mockLeaseService.assertReportDoneCalledOnceWith(t, []string{terminatingPod.Labels[domain.JobId]})
+	assert.Zero(t, mockLeaseService.ReturnLeaseCalls)
+	mockLeaseService.AssertReportDoneCalledOnceWith(t, []string{terminatingPod.Labels[domain.JobId]})
 
-	stuckPodDetector.HandleStuckPods()
+	jobs, _ = jobContext.GetRunningJobs()
+	stuckPodDetector.HandleStuckPods(jobs)
 
 	failedEvent, ok := eventsReporter.ReceivedEvents[0].(*api.JobFailedEvent)
 	assert.True(t, ok)
@@ -97,32 +103,34 @@ func TestStuckPodDetector_DeletesPodAndReportsFailedIfStuckTerminating(t *testin
 func TestStuckPodDetector_ReturnsLeaseAndDeletesRetryableStuckPod(t *testing.T) {
 	retryableStuckPod := makeRetryableStuckPod()
 
-	fakeClusterContext, mockLeaseService, _, stuckPodDetector := makeStuckPodDetectorWithTestDoubles()
+	fakeClusterContext, mockLeaseService, _, jobContext, stuckPodDetector := makeStuckPodDetectorWithTestDoubles()
 
 	addPod(t, fakeClusterContext, retryableStuckPod)
 
-	stuckPodDetector.HandleStuckPods()
+	jobs, _ := jobContext.GetRunningJobs()
+	stuckPodDetector.HandleStuckPods(jobs)
 
 	// Not done as can be retried
-	assert.Equal(t, 1, mockLeaseService.reportDoneCalls)
-	assert.Equal(t, []string{}, mockLeaseService.reportDoneArg)
+	assert.Equal(t, 1, mockLeaseService.ReportDoneCalls)
+	assert.Equal(t, []string{}, mockLeaseService.ReportDoneArg)
 
 	// Not returning lease yet
-	assert.Equal(t, 0, mockLeaseService.returnLeaseCalls)
+	assert.Equal(t, 0, mockLeaseService.ReturnLeaseCalls)
 
 	// Still deletes pod
 	remainingActivePods := getActivePods(t, fakeClusterContext)
 	assert.Equal(t, []*v1.Pod{}, remainingActivePods)
 
-	stuckPodDetector.HandleStuckPods()
+	jobs, _ = jobContext.GetRunningJobs()
+	stuckPodDetector.HandleStuckPods(jobs)
 
 	// Not done as can be retried
-	assert.Equal(t, 2, mockLeaseService.reportDoneCalls)
-	assert.Equal(t, []string{}, mockLeaseService.reportDoneArg)
+	assert.Equal(t, 2, mockLeaseService.ReportDoneCalls)
+	assert.Equal(t, []string{}, mockLeaseService.ReportDoneArg)
 
 	// Return lease for retry
-	assert.Equal(t, 1, mockLeaseService.returnLeaseCalls)
-	assert.Equal(t, retryableStuckPod, mockLeaseService.returnLeaseArg)
+	assert.Equal(t, 1, mockLeaseService.ReturnLeaseCalls)
+	assert.Equal(t, retryableStuckPod, mockLeaseService.ReturnLeaseArg)
 }
 
 func getActivePods(t *testing.T, clusterContext context.ClusterContext) []*v1.Pod {
@@ -202,55 +210,19 @@ func addPod(t *testing.T, fakeClusterContext context.ClusterContext, runningPod 
 	}
 }
 
-func makeStuckPodDetectorWithTestDoubles() (context.ClusterContext, *mockLeaseService, *reporter_fake.FakeEventReporter, *StuckPodDetector) {
+func makeStuckPodDetectorWithTestDoubles() (context.ClusterContext, *fake.MockLeaseService, *reporter_fake.FakeEventReporter, job.JobContext, *StuckPodDetector) {
 	fakeClusterContext := newSyncFakeClusterContext()
 	jobContext := job.NewClusterJobContext(fakeClusterContext)
-	mockLeaseService := NewMockLeaseService()
+	mockLeaseService := fake.NewMockLeaseService()
 	eventReporter := &reporter_fake.FakeEventReporter{nil}
 
 	stuckPodDetector := NewPodProgressMonitorService(
 		fakeClusterContext,
-		jobContext,
 		eventReporter,
 		mockLeaseService,
 		time.Second)
 
-	return fakeClusterContext, mockLeaseService, eventReporter, stuckPodDetector
-}
-
-type mockLeaseService struct {
-	returnLeaseCalls      int
-	requestJobLeasesCalls int
-	reportDoneCalls       int
-
-	returnLeaseArg *v1.Pod
-	reportDoneArg  []string
-}
-
-func NewMockLeaseService() *mockLeaseService {
-	return &mockLeaseService{0, 0, 0, nil, nil}
-}
-
-func (ls *mockLeaseService) ReturnLease(pod *v1.Pod) error {
-	ls.returnLeaseArg = pod
-	ls.returnLeaseCalls++
-	return nil
-}
-
-func (ls *mockLeaseService) RequestJobLeases(availableResource *common.ComputeResources, nodes []api.NodeInfo, leasedResourceByQueue map[string]common.ComputeResources) ([]*api.Job, error) {
-	ls.requestJobLeasesCalls++
-	return make([]*api.Job, 0), nil
-}
-
-func (ls *mockLeaseService) ReportDone(jobIds []string) error {
-	ls.reportDoneArg = jobIds
-	ls.reportDoneCalls++
-	return nil
-}
-
-func (ls *mockLeaseService) assertReportDoneCalledOnceWith(t *testing.T, expected []string) {
-	assert.Equal(t, 1, ls.reportDoneCalls)
-	assert.Equal(t, expected, ls.reportDoneArg)
+	return fakeClusterContext, mockLeaseService, eventReporter, jobContext, stuckPodDetector
 }
 
 type syncFakeClusterContext struct {

--- a/internal/executor/service/stuck_pod_detector_test.go
+++ b/internal/executor/service/stuck_pod_detector_test.go
@@ -218,6 +218,7 @@ func makeStuckPodDetectorWithTestDoubles() (context.ClusterContext, *fake.MockLe
 
 	stuckPodDetector := NewPodProgressMonitorService(
 		fakeClusterContext,
+		jobContext,
 		eventReporter,
 		mockLeaseService,
 		time.Second)

--- a/internal/executor/service/util.go
+++ b/internal/executor/service/util.go
@@ -1,0 +1,79 @@
+package service
+
+import (
+	v1 "k8s.io/api/core/v1"
+
+	commonUtil "github.com/G-Research/armada/internal/common/util"
+	"github.com/G-Research/armada/internal/executor/job"
+	"github.com/G-Research/armada/internal/executor/util"
+)
+
+func extractJobIds(jobs []*job.RunningJob) []string {
+	ids := []string{}
+	for _, job := range jobs {
+		ids = append(ids, job.JobId)
+	}
+	return ids
+}
+
+func filterRunningJobs(jobs []*job.RunningJob, filter func(*job.RunningJob) bool) []*job.RunningJob {
+	result := make([]*job.RunningJob, 0)
+	for _, job := range jobs {
+		if filter(job) {
+			result = append(result, job)
+		}
+	}
+	return result
+}
+
+func filterRunningJobsByIds(jobs []*job.RunningJob, ids []string) []*job.RunningJob {
+	idSet := commonUtil.StringListToSet(ids)
+	return filterRunningJobs(jobs, func(j *job.RunningJob) bool { return idSet[j.JobId] })
+}
+
+func shouldBeRenewed(pod *v1.Pod) bool {
+	return !isReportedDone(pod)
+}
+
+func jobShouldBeRenewed(job *job.RunningJob) bool {
+	for _, pod := range job.Pods {
+		if !isReportedDone(pod) {
+			return true
+		}
+	}
+	return false
+}
+
+func shouldBeReportedDone(job *job.RunningJob) bool {
+	for _, pod := range job.Pods {
+		if util.IsInTerminalState(pod) && !isReportedDone(pod) {
+			return true
+		}
+	}
+	return false
+}
+
+func isReportedDone(pod *v1.Pod) bool {
+	_, exists := pod.Annotations[jobDoneAnnotation]
+	return exists
+}
+
+func extractPods(jobs []*job.RunningJob) []*v1.Pod {
+	pods := []*v1.Pod{}
+	for _, job := range jobs {
+		pods = append(pods, job.Pods...)
+	}
+	return pods
+}
+
+func chunkJobs(jobs []*job.RunningJob, size int) [][]*job.RunningJob {
+	chunks := [][]*job.RunningJob{}
+	for start := 0; start < len(jobs); start += size {
+		end := start + size
+		if end > len(jobs) {
+			end = len(jobs)
+		}
+		chunks = append(chunks, jobs[start:end])
+	}
+	return chunks
+}

--- a/internal/executor/service/util.go
+++ b/internal/executor/service/util.go
@@ -37,7 +37,7 @@ func shouldBeRenewed(pod *v1.Pod) bool {
 
 func jobShouldBeRenewed(job *job.RunningJob) bool {
 	for _, pod := range job.Pods {
-		if !isReportedDone(pod) {
+		if shouldBeRenewed(pod) {
 			return true
 		}
 	}

--- a/internal/executor/service/util_test.go
+++ b/internal/executor/service/util_test.go
@@ -1,0 +1,14 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/G-Research/armada/internal/executor/job"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChunkPods(t *testing.T) {
+	j := &job.RunningJob{}
+	chunks := chunkJobs([]*job.RunningJob{j, j, j}, 2)
+	assert.Equal(t, [][]*job.RunningJob{{j, j}, {j}}, chunks)
+}

--- a/internal/executor/service/util_test.go
+++ b/internal/executor/service/util_test.go
@@ -3,8 +3,9 @@ package service
 import (
 	"testing"
 
-	"github.com/G-Research/armada/internal/executor/job"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/G-Research/armada/internal/executor/job"
 )
 
 func TestChunkPods(t *testing.T) {


### PR DESCRIPTION
- Splits job submitting into job package.
- Split job manager from lease service.
- Makes stuck pod detection run after lease management to avoid any race conditions between these operations. (Next step could be to separate stuck pod detector to just detection in job package, and reporting merged into job manager).