### PR TITLE
Set stuckPodExpiry from config in job_context

### DIFF
--- a/internal/executor/application.go
+++ b/internal/executor/application.go
@@ -67,7 +67,7 @@ func StartUpWithContext(config configuration.ExecutorConfiguration, clusterConte
 		queueClient,
 		config.Kubernetes.MinimumJobSize)
 
-	jobContext := job.NewClusterJobContext(clusterContext)
+	jobContext := job.NewClusterJobContext(clusterContext, config.Kubernetes.StuckPodExpiry)
 	submitter := job.NewSubmitter(clusterContext, config.Kubernetes.PodDefaults)
 
 	queueUtilisationService := utilisation.NewMetricsServerQueueUtilisationService(

--- a/internal/executor/job/job_context.go
+++ b/internal/executor/job/job_context.go
@@ -59,9 +59,10 @@ type ClusterJobContext struct {
 	activeJobIdsMutex sync.Mutex
 }
 
-func NewClusterJobContext(clusterContext context.ClusterContext) *ClusterJobContext {
+func NewClusterJobContext(clusterContext context.ClusterContext, stuckPodExpiry time.Duration) *ClusterJobContext {
 	jobContext := &ClusterJobContext{
 		clusterContext:    clusterContext,
+		stuckPodExpiry:    stuckPodExpiry,
 		activeJobs:        map[string]*jobRecord{},
 		activeJobIdsMutex: sync.Mutex{},
 	}

--- a/internal/executor/service/job_manager_stuck_test.go
+++ b/internal/executor/service/job_manager_stuck_test.go
@@ -203,7 +203,7 @@ func makejobManagerWithTestDoubles() (context.ClusterContext, *fake.MockLeaseSer
 	fakeClusterContext := fake.NewSyncFakeClusterContext()
 	mockLeaseService := fake.NewMockLeaseService()
 	eventReporter := reporter_fake.NewFakeEventReporter()
-	jobContext := job.NewClusterJobContext(fakeClusterContext, time.Minute * 3)
+	jobContext := job.NewClusterJobContext(fakeClusterContext, time.Minute*3)
 
 	jobManager := NewJobManager(
 		fakeClusterContext,

--- a/internal/executor/service/job_manager_stuck_test.go
+++ b/internal/executor/service/job_manager_stuck_test.go
@@ -203,7 +203,7 @@ func makejobManagerWithTestDoubles() (context.ClusterContext, *fake.MockLeaseSer
 	fakeClusterContext := fake.NewSyncFakeClusterContext()
 	mockLeaseService := fake.NewMockLeaseService()
 	eventReporter := reporter_fake.NewFakeEventReporter()
-	jobContext := job.NewClusterJobContext(fakeClusterContext, time.Minute*3)
+	jobContext := job.NewClusterJobContext(fakeClusterContext, time.Minute * 3)
 
 	jobManager := NewJobManager(
 		fakeClusterContext,

--- a/internal/executor/service/job_manager_stuck_test.go
+++ b/internal/executor/service/job_manager_stuck_test.go
@@ -203,7 +203,7 @@ func makejobManagerWithTestDoubles() (context.ClusterContext, *fake.MockLeaseSer
 	fakeClusterContext := fake.NewSyncFakeClusterContext()
 	mockLeaseService := fake.NewMockLeaseService()
 	eventReporter := reporter_fake.NewFakeEventReporter()
-	jobContext := job.NewClusterJobContext(fakeClusterContext)
+	jobContext := job.NewClusterJobContext(fakeClusterContext, time.Minute*3)
 
 	jobManager := NewJobManager(
 		fakeClusterContext,

--- a/internal/executor/service/job_manager_test.go
+++ b/internal/executor/service/job_manager_test.go
@@ -82,7 +82,7 @@ func makePodWithCurrentStateReported(state v1.PodPhase, reportedDone bool) *v1.P
 func createManager(minimumPodAge, failedPodExpiry time.Duration) *JobManager {
 	fakeClusterContext := context2.NewFakeClusterContext(configuration.ApplicationConfiguration{ClusterId: "test", Pool: "pool"}, nil)
 	fakeEventReporter := &reporter_fake.FakeEventReporter{}
-	jobContext := job.NewClusterJobContext(fakeClusterContext, time.Minute * 3)
+	jobContext := job.NewClusterJobContext(fakeClusterContext, time.Minute*3)
 
 	jobLeaseService := fake.NewMockLeaseService()
 

--- a/internal/executor/service/job_manager_test.go
+++ b/internal/executor/service/job_manager_test.go
@@ -82,7 +82,7 @@ func makePodWithCurrentStateReported(state v1.PodPhase, reportedDone bool) *v1.P
 func createManager(minimumPodAge, failedPodExpiry time.Duration) *JobManager {
 	fakeClusterContext := context2.NewFakeClusterContext(configuration.ApplicationConfiguration{ClusterId: "test", Pool: "pool"}, nil)
 	fakeEventReporter := &reporter_fake.FakeEventReporter{}
-	jobContext := job.NewClusterJobContext(fakeClusterContext)
+	jobContext := job.NewClusterJobContext(fakeClusterContext, time.Minute*3)
 
 	jobLeaseService := fake.NewMockLeaseService()
 

--- a/internal/executor/service/job_manager_test.go
+++ b/internal/executor/service/job_manager_test.go
@@ -82,7 +82,7 @@ func makePodWithCurrentStateReported(state v1.PodPhase, reportedDone bool) *v1.P
 func createManager(minimumPodAge, failedPodExpiry time.Duration) *JobManager {
 	fakeClusterContext := context2.NewFakeClusterContext(configuration.ApplicationConfiguration{ClusterId: "test", Pool: "pool"}, nil)
 	fakeEventReporter := &reporter_fake.FakeEventReporter{}
-	jobContext := job.NewClusterJobContext(fakeClusterContext, time.Minute*3)
+	jobContext := job.NewClusterJobContext(fakeClusterContext, time.Minute * 3)
 
 	jobLeaseService := fake.NewMockLeaseService()
 


### PR DESCRIPTION
stuckPodExpiry was not getting set in job_context.

This meant that the expiry default to 0 and caused pods to incorrectly be marked stuck.