### PR TITLE
Making executor mark pods that are unrecoverably stuck sooner

### DIFF
--- a/internal/executor/job/job_context.go
+++ b/internal/executor/job/job_context.go
@@ -14,6 +14,8 @@ import (
 	"github.com/G-Research/armada/internal/executor/util"
 )
 
+const defaultTimeBeforeCheckingPendingPodHealth = time.Second * 90
+
 type IssueType int
 
 const (
@@ -204,6 +206,11 @@ func (c *ClusterJobContext) addIssues(jobs []*RunningJob) []*RunningJob {
 }
 
 func (c *ClusterJobContext) detectStuckPods(runningJob *RunningJob) {
+	gracePeriodBeforeHealthCheck := defaultTimeBeforeCheckingPendingPodHealth
+	if gracePeriodBeforeHealthCheck > c.stuckPodExpiry {
+		gracePeriodBeforeHealthCheck = c.stuckPodExpiry
+	}
+
 	for _, pod := range runningJob.ActivePods {
 		if pod.DeletionTimestamp != nil && pod.DeletionTimestamp.Add(c.stuckPodExpiry).Before(time.Now()) {
 			// pod is stuck in terminating phase, this sometimes happen on node failure
@@ -217,19 +224,25 @@ func (c *ClusterJobContext) detectStuckPods(runningJob *RunningJob) {
 			break
 
 		} else if (pod.Status.Phase == v1.PodUnknown || pod.Status.Phase == v1.PodPending) &&
-			reporter.HasPodBeenInStateForLongerThanGivenDuration(pod, c.stuckPodExpiry) {
+			reporter.HasPodBeenInStateForLongerThanGivenDuration(pod, gracePeriodBeforeHealthCheck) {
 
 			podEvents, err := c.clusterContext.GetPodEvents(pod)
 			if err != nil {
 				log.Errorf("Unable to get pod events: %v", err)
 			}
 
-			retryable, message := util.DiagnoseStuckPod(pod, podEvents)
-			if retryable {
-				message = fmt.Sprintf("Unable to schedule pod, Armada will return lease and retry.\n%s", message)
+			stuckPodStatus, message := util.DiagnoseStuckPod(pod, podEvents)
+			retryable := true
+			if stuckPodStatus == util.Unrecoverable {
+				retryable = false
+			} else if !reporter.HasPodBeenInStateForLongerThanGivenDuration(pod, c.stuckPodExpiry) {
+				// Possibly stuck, but don't do anything until expiry is up
+				continue
 			} else {
-				message = fmt.Sprintf("Unable to schedule pod with unrecoverable problem, Armada will not retry.\n%s", message)
+				retryable = stuckPodStatus == util.Healthy
 			}
+
+			message = createStuckPodMessage(retryable, message)
 			c.registerIssue(runningJob, &PodIssue{
 				OriginatingPod: pod.DeepCopy(),
 				Pods:           runningJob.ActivePods,
@@ -240,6 +253,13 @@ func (c *ClusterJobContext) detectStuckPods(runningJob *RunningJob) {
 			break
 		}
 	}
+}
+
+func createStuckPodMessage(retryable bool, originalMessage string) string {
+	if retryable {
+		return fmt.Sprintf("Unable to schedule pod, Armada will return lease and retry.\n%s", originalMessage)
+	}
+	return fmt.Sprintf("Unable to schedule pod with unrecoverable problem, Armada will not retry.\n%s", originalMessage)
 }
 
 func (c *ClusterJobContext) handleDeletedPod(pod *v1.Pod) {

--- a/internal/executor/job/job_context.go
+++ b/internal/executor/job/job_context.go
@@ -232,14 +232,11 @@ func (c *ClusterJobContext) detectStuckPods(runningJob *RunningJob) {
 			}
 
 			stuckPodStatus, message := util.DiagnoseStuckPod(pod, podEvents)
-			retryable := true
-			if stuckPodStatus == util.Unrecoverable {
-				retryable = false
-			} else if !reporter.HasPodBeenInStateForLongerThanGivenDuration(pod, c.stuckPodExpiry) {
+			retryable := stuckPodStatus == util.Healthy
+
+			if stuckPodStatus != util.Unrecoverable && !reporter.HasPodBeenInStateForLongerThanGivenDuration(pod, c.stuckPodExpiry) {
 				// Possibly stuck, but don't do anything until expiry is up
 				continue
-			} else {
-				retryable = stuckPodStatus == util.Healthy
 			}
 
 			message = createStuckPodMessage(retryable, message)

--- a/internal/executor/util/pod_status.go
+++ b/internal/executor/util/pod_status.go
@@ -202,12 +202,9 @@ func hasUnstableContainerStates(pod *v1.Pod) bool {
 func hasUnpullableImageEvent(podEvents []*v1.Event) (bool, *v1.Event) {
 	for _, event := range podEvents {
 		if event.Type == v1.EventTypeWarning && strings.HasPrefix(event.Message, failedPullPrefix) {
-			// Failed to pull image "alpine:latst": rpc error: code = NotFound desc = failed to pull and unpack image "docker.io/library/alpine:latst": failed to resolve reference "docker.io/library/alpine:latst": docker.io/library/alpine:latst: not found
-			// Failed to pull image "docker.artifactory.something.net/alpine:latest": rpc error: code = Unknown desc = failed to pull and unpack image "docker.artifactory.something.net/alpine:latest": failed to resolve reference "docker.artifactory.something.net/alpine:latest": failed to do request: Head https://docker.artifactory.something.net/v2/alpine/manifests/latest: dial tcp 52.128.23.153:443: connect: connection refused
 			if strings.Contains(event.Message, failedPullAndUnpack) {
 				return true, event
 			}
-			// Failed to pull image <image>: rpc error: code = Unknown desc = Error response from daemon: manifest for <image> not found: manifest unknown: The named manifest is not known to the registry.
 			if strings.Contains(event.Message, failedPullErrorResponse) {
 				return true, event
 			}

--- a/internal/executor/util/pod_util.go
+++ b/internal/executor/util/pod_util.go
@@ -193,3 +193,9 @@ func maxTime(a, b time.Time) time.Time {
 	}
 	return b
 }
+
+func GetPodContainerStatuses(pod *v1.Pod) []v1.ContainerStatus {
+	containerStatuses := pod.Status.ContainerStatuses
+	containerStatuses = append(containerStatuses, pod.Status.InitContainerStatuses...)
+	return containerStatuses
+}


### PR DESCRIPTION
Currently if a pod is submitted with something that causes it to get "stuck" (i.e stay in Pending but Kubernetes doesn't consider it a failure), users must with the full stuckPodExpiry before Armada does anything about it.

However some reasons pods get stuck are never going to recover (invalid mount path, invalid image name etc).

Now the executor will try to spot these unrecoverable situations and return this error back to the user sooner, rather than waiting the whole stuckPodExpiry.