### PR TITLE
Make developer instructions work with kind v0.11.1

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -42,8 +42,8 @@ This is recommended when working on features that are purely Armada specific or 
     As this step is using Docker, it will require root to run
     
     ```bash
-    kind create cluster --name demoA --config ./example/kind-config.yaml
-    kind create cluster --name demoB --config ./example/kind-config.yaml 
+    kind create cluster --name demo-a --config ./example/kind-config.yaml
+    kind create cluster --name demo-b --config ./example/kind-config.yaml
     ```
 3. Start Redis
     ```bash
@@ -56,13 +56,13 @@ This is recommended when working on features that are purely Armada specific or 
     ```bash
     go run ./cmd/armada/main.go
     ```
-5. Start executor for demoA in a new terminal
+5. Start executor for demo-a in a new terminal
     ```bash
-    KUBECONFIG=$(kind get kubeconfig-path --name="demoA") ARMADA_APPLICATION_CLUSTERID=demoA ARMADA_METRIC_PORT=9001 go run ./cmd/executor/main.go
+    KUBECONFIG=$(kind get kubeconfig-path --name="demo-a") ARMADA_APPLICATION_CLUSTERID=demo-a ARMADA_METRIC_PORT=9001 go run ./cmd/executor/main.go
     ```
-6. Start executor for demoB in a new terminal
+6. Start executor for demo-b in a new terminal
     ```bash
-    KUBECONFIG=$(kind get kubeconfig-path --name="demoB") ARMADA_APPLICATION_CLUSTERID=demoB ARMADA_METRIC_PORT=9002 go run ./cmd/executor/main.go
+    KUBECONFIG=$(kind get kubeconfig-path --name="demo-b") ARMADA_APPLICATION_CLUSTERID=demo-b ARMADA_METRIC_PORT=9002 go run ./cmd/executor/main.go
     ```
 
 #### Setup Fake-executor development
@@ -78,13 +78,13 @@ This is recommended when working on features that are purely Armada specific or 
     ```bash
     go run ./cmd/armada/main.go
     ```
-3. Start executor for demoA in a new terminal
+3. Start executor for demo-a in a new terminal
     ```bash
-    ARMADA_APPLICATION_CLUSTERID=demoA ARMADA_METRIC_PORT=9001 go run ./cmd/fakeexecutor/main.go
+    ARMADA_APPLICATION_CLUSTERID=demo-a ARMADA_METRIC_PORT=9001 go run ./cmd/fakeexecutor/main.go
     ```
-4. Start executor for demoB in a new terminal
+4. Start executor for demo-b in a new terminal
     ```bash
-    ARMADA_APPLICATION_CLUSTERID=demoB ARMADA_METRIC_PORT=9002 go run ./cmd/fakeexecutor/main.go
+    ARMADA_APPLICATION_CLUSTERID=demo-b ARMADA_METRIC_PORT=9002 go run ./cmd/fakeexecutor/main.go
     ```
 
 #### Optional components

--- a/example/kind-config.yaml
+++ b/example/kind-config.yaml
@@ -1,5 +1,5 @@
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
   - role: worker


### PR DESCRIPTION
Newer kind doesn't support that api version - so move to newer version already used by the quickstart
Newer kind also wants names in lowercase