### PR TITLE
Better error messages/status code on failure to load queue

### DIFF
--- a/internal/armada/repository/queue.go
+++ b/internal/armada/repository/queue.go
@@ -1,6 +1,8 @@
 package repository
 
 import (
+	"errors"
+
 	"github.com/go-redis/redis"
 	"github.com/gogo/protobuf/proto"
 
@@ -44,7 +46,9 @@ func (r *RedisQueueRepository) GetAllQueues() ([]*api.Queue, error) {
 
 func (r *RedisQueueRepository) GetQueue(name string) (*api.Queue, error) {
 	result, err := r.db.HGet(queueHashKey, name).Result()
-	if err != nil {
+	if err == redis.Nil {
+		return nil, errors.New("Queue does not exist")
+	} else if err != nil {
 		return nil, err
 	}
 	queue := &api.Queue{}

--- a/internal/armada/repository/queue.go
+++ b/internal/armada/repository/queue.go
@@ -11,7 +11,7 @@ import (
 
 const queueHashKey = "Queue"
 
-var QueueNotFound = errors.New("Queue does not exist")
+var ErrQueueNotFound = errors.New("Queue does not exist")
 
 type QueueRepository interface {
 	GetAllQueues() ([]*api.Queue, error)
@@ -49,7 +49,7 @@ func (r *RedisQueueRepository) GetAllQueues() ([]*api.Queue, error) {
 func (r *RedisQueueRepository) GetQueue(name string) (*api.Queue, error) {
 	result, err := r.db.HGet(queueHashKey, name).Result()
 	if err == redis.Nil {
-		return nil, QueueNotFound
+		return nil, ErrQueueNotFound
 	} else if err != nil {
 		return nil, err
 	}

--- a/internal/armada/repository/queue.go
+++ b/internal/armada/repository/queue.go
@@ -11,6 +11,8 @@ import (
 
 const queueHashKey = "Queue"
 
+var QueueNotFound = errors.New("Queue does not exist")
+
 type QueueRepository interface {
 	GetAllQueues() ([]*api.Queue, error)
 	GetQueue(name string) (*api.Queue, error)
@@ -47,7 +49,7 @@ func (r *RedisQueueRepository) GetAllQueues() ([]*api.Queue, error) {
 func (r *RedisQueueRepository) GetQueue(name string) (*api.Queue, error) {
 	result, err := r.db.HGet(queueHashKey, name).Result()
 	if err == redis.Nil {
-		return nil, errors.New("Queue does not exist")
+		return nil, QueueNotFound
 	} else if err != nil {
 		return nil, err
 	}

--- a/internal/armada/server/submit.go
+++ b/internal/armada/server/submit.go
@@ -316,7 +316,7 @@ func (server *SubmitServer) checkQueuePermission(
 	allQueuesPermission permission.Permission) (e error, ownershipGroups []string) {
 
 	queue, e := server.queueRepository.GetQueue(queueName)
-	if e == repository.QueueNotFound {
+	if e == repository.ErrQueueNotFound {
 		if attemptToCreate &&
 			server.queueManagementConfig.AutoCreateQueues &&
 			server.permissions.UserHasPermission(ctx, permissions.SubmitAnyJobs) {

--- a/internal/armada/server/submit.go
+++ b/internal/armada/server/submit.go
@@ -316,7 +316,7 @@ func (server *SubmitServer) checkQueuePermission(
 	allQueuesPermission permission.Permission) (e error, ownershipGroups []string) {
 
 	queue, e := server.queueRepository.GetQueue(queueName)
-	if e != nil {
+	if e == repository.QueueNotFound {
 		if attemptToCreate &&
 			server.queueManagementConfig.AutoCreateQueues &&
 			server.permissions.UserHasPermission(ctx, permissions.SubmitAnyJobs) {
@@ -331,9 +331,12 @@ func (server *SubmitServer) checkQueuePermission(
 			}
 			return nil, []string{}
 		} else {
-			return status.Errorf(codes.NotFound, "Could not load queue %q: %s", queueName, e.Error()), []string{}
+			return status.Errorf(codes.NotFound, "Queue %q not found", queueName), []string{}
 		}
+	} else if e != nil {
+		return status.Errorf(codes.Unavailable, "Could not load queue %q: %s", queueName, e.Error()), []string{}
 	}
+
 	permissionToCheck := basicPermission
 	owned, groups := server.permissions.UserOwns(ctx, queue)
 	if !owned {

--- a/internal/armada/server/submit.go
+++ b/internal/armada/server/submit.go
@@ -331,7 +331,7 @@ func (server *SubmitServer) checkQueuePermission(
 			}
 			return nil, []string{}
 		} else {
-			return status.Errorf(codes.NotFound, "Could not load queue: %s", e.Error()), []string{}
+			return status.Errorf(codes.NotFound, "Could not load queue %q: %s", queueName, e.Error()), []string{}
 		}
 	}
 	permissionToCheck := basicPermission


### PR DESCRIPTION
1) Replace message `Could not load queue: redis: nil` with `Queue "myqueue"  not found`

2) Only return NotFound status if genuinely not found. For other errors (e.g. redis down) return Unavailable
