### PR TITLE
Fix executor failing finished jobs

### DIFF
--- a/internal/common/util/map.go
+++ b/internal/common/util/map.go
@@ -7,3 +7,14 @@ func GetOrDefault(m map[string]float64, key string, def float64) float64 {
 	}
 	return def
 }
+
+func MergeMaps(a map[string]string, b map[string]string) map[string]string {
+	result := make(map[string]string)
+	for k, v := range a {
+		result[k] = v
+	}
+	for k, v := range b {
+		result[k] = v
+	}
+	return result
+}

--- a/internal/executor/context/cluster_context.go
+++ b/internal/executor/context/cluster_context.go
@@ -282,7 +282,6 @@ func (c *KubernetesClusterContext) ProcessPodsToDelete() {
 			}
 		}
 
-		fmt.Printf("err %s", err)
 		if err == nil {
 			err = c.kubernetesClient.CoreV1().Pods(podToDelete.Namespace).Delete(ctx.Background(), podToDelete.Name, deleteOptions)
 		}

--- a/internal/executor/context/cluster_context.go
+++ b/internal/executor/context/cluster_context.go
@@ -21,6 +21,7 @@ import (
 	"github.com/G-Research/armada/internal/common/cluster"
 	"github.com/G-Research/armada/internal/executor/configuration"
 	"github.com/G-Research/armada/internal/executor/domain"
+	"github.com/G-Research/armada/internal/executor/job"
 	"github.com/G-Research/armada/internal/executor/util"
 )
 
@@ -269,8 +270,22 @@ func (c *KubernetesClusterContext) ProcessPodsToDelete() {
 		if podToDelete == nil {
 			continue
 		}
-		err := c.kubernetesClient.CoreV1().Pods(podToDelete.Namespace).Delete(ctx.Background(), podToDelete.Name, deleteOptions)
 		podId := util.ExtractPodKey(podToDelete)
+
+		var err error
+		if !util.IsMarkedForDeletion(podToDelete) {
+			updatedPod, annotationErr := c.markForDeletion(podToDelete)
+			err = annotationErr
+			if annotationErr == nil {
+				podToDelete = updatedPod
+				c.podsToDelete.Update(podId, podToDelete)
+			}
+		}
+
+		if err == nil {
+			err = c.kubernetesClient.CoreV1().Pods(podToDelete.Namespace).Delete(ctx.Background(), podToDelete.Name, deleteOptions)
+		}
+
 		if err == nil || errors.IsNotFound(err) {
 			c.podsToDelete.Update(podId, nil)
 		} else {
@@ -278,6 +293,16 @@ func (c *KubernetesClusterContext) ProcessPodsToDelete() {
 			c.podsToDelete.Delete(podId)
 		}
 	}
+}
+
+func (c *KubernetesClusterContext) markForDeletion(pod *v1.Pod) (*v1.Pod, error) {
+	annotations := make(map[string]string)
+	annotationName := domain.MarkedForDeletion
+	annotations[annotationName] = time.Now().String()
+
+	err := c.AddAnnotation(pod, annotations)
+	pod.Annotations = job.MergeMaps(pod.Annotations, annotations)
+	return pod, err
 }
 
 func (c *KubernetesClusterContext) GetService(name string, namespace string) (*v1.Service, error) {

--- a/internal/executor/context/cluster_context.go
+++ b/internal/executor/context/cluster_context.go
@@ -19,9 +19,9 @@ import (
 	"k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 
 	"github.com/G-Research/armada/internal/common/cluster"
+	util2 "github.com/G-Research/armada/internal/common/util"
 	"github.com/G-Research/armada/internal/executor/configuration"
 	"github.com/G-Research/armada/internal/executor/domain"
-	"github.com/G-Research/armada/internal/executor/job"
 	"github.com/G-Research/armada/internal/executor/util"
 )
 
@@ -282,6 +282,7 @@ func (c *KubernetesClusterContext) ProcessPodsToDelete() {
 			}
 		}
 
+		fmt.Printf("err %s", err)
 		if err == nil {
 			err = c.kubernetesClient.CoreV1().Pods(podToDelete.Namespace).Delete(ctx.Background(), podToDelete.Name, deleteOptions)
 		}
@@ -301,7 +302,7 @@ func (c *KubernetesClusterContext) markForDeletion(pod *v1.Pod) (*v1.Pod, error)
 	annotations[annotationName] = time.Now().String()
 
 	err := c.AddAnnotation(pod, annotations)
-	pod.Annotations = job.MergeMaps(pod.Annotations, annotations)
+	pod.Annotations = util2.MergeMaps(pod.Annotations, annotations)
 	return pod, err
 }
 

--- a/internal/executor/context/cluster_context_test.go
+++ b/internal/executor/context/cluster_context_test.go
@@ -2,6 +2,7 @@ package context
 
 import (
 	ctx "context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -154,16 +155,77 @@ func TestKubernetesClusterContext_ProcessPodsToDelete_CallDeleteOnClient_WhenPod
 	clusterContext.DeletePods([]*v1.Pod{pod})
 	clusterContext.ProcessPodsToDelete()
 
-	assert.Equal(t, len(client.Fake.Actions()), 1)
-	assert.True(t, client.Fake.Actions()[0].Matches("delete", "pods"))
+	assert.Equal(t, len(client.Fake.Actions()), 2)
+	assert.True(t, client.Fake.Actions()[1].Matches("delete", "pods"))
 
-	deleteAction, ok := client.Fake.Actions()[0].(clientTesting.DeleteAction)
+	deleteAction, ok := client.Fake.Actions()[1].(clientTesting.DeleteAction)
 	assert.True(t, ok)
 	assert.Equal(t, deleteAction.GetName(), pod.Name)
 }
 
-func TestKubernetesClusterContext_ProcessPodsToDelete_PreventsRepeatedDeleteCallsToClient_OnClientSuccess(t *testing.T) {
+func TestKubernetesClusterContext_ProcessPodsToDelete_CallPatchOnClient_WhenPodsMarkedForDeletion(t *testing.T) {
 	clusterContext, client := setupTest()
+
+	pod := createSubmittedBatchPod(t, clusterContext)
+
+	client.Fake.ClearActions()
+	clusterContext.DeletePods([]*v1.Pod{pod})
+	clusterContext.ProcessPodsToDelete()
+
+	assert.Equal(t, len(client.Fake.Actions()), 2)
+	assert.True(t, client.Fake.Actions()[0].Matches("patch", "pods"))
+
+	patchAction, ok := client.Fake.Actions()[0].(clientTesting.PatchAction)
+	assert.True(t, ok)
+	assert.Equal(t, patchAction.GetName(), pod.Name)
+
+	patch := &domain.Patch{}
+	err := json.Unmarshal(patchAction.GetPatch(), patch)
+	assert.NoError(t, err)
+	_, exists := patch.MetaData.Annotations[domain.MarkedForDeletion]
+	assert.True(t, exists)
+}
+
+func TestKubernetesClusterContext_ProcessPodsToDelete_PreventsRepeatedPatchCallsToClient_WhenPodAlreadyMarkedForDeletion(t *testing.T) {
+	clusterContext, client := setupTest()
+
+	pod := createSubmittedBatchPod(t, clusterContext)
+	pod.ObjectMeta.Annotations = map[string]string{domain.MarkedForDeletion: "now"}
+
+	client.Fake.ClearActions()
+	clusterContext.DeletePods([]*v1.Pod{pod})
+	clusterContext.ProcessPodsToDelete()
+
+	assert.Equal(t, len(client.Fake.Actions()), 1)
+	assert.True(t, client.Fake.Actions()[0].Matches("delete", "pods"))
+}
+
+func TestKubernetesClusterContext_ProcessPodsToDelete_PreventsRepeatedDeleteCallsToClient_OnDeleteClientSuccess(t *testing.T) {
+	clusterContext, client := setupTest()
+
+	pod := createSubmittedBatchPod(t, clusterContext)
+
+	client.Fake.ClearActions()
+	clusterContext.DeletePods([]*v1.Pod{pod})
+	clusterContext.ProcessPodsToDelete()
+	assert.Equal(t, len(client.Fake.Actions()), 2)
+
+	client.Fake.ClearActions()
+	clusterContext.DeletePods([]*v1.Pod{pod})
+	clusterContext.ProcessPodsToDelete()
+	assert.Equal(t, len(client.Fake.Actions()), 0)
+}
+
+func TestKubernetesClusterContext_ProcessPodsToDelete_PreventsRepeatedDeleteCallsToClient_OnPatchClientErrorNotFound(t *testing.T) {
+	clusterContext, client := setupTest()
+	client.Fake.PrependReactor("patch", "pods", func(action clientTesting.Action) (bool, runtime.Object, error) {
+		notFound := errors2.StatusError{
+			ErrStatus: metav1.Status{
+				Reason: metav1.StatusReasonNotFound,
+			},
+		}
+		return true, nil, &notFound
+	})
 
 	pod := createSubmittedBatchPod(t, clusterContext)
 
@@ -194,7 +256,7 @@ func TestKubernetesClusterContext_ProcessPodsToDelete_PreventsRepeatedDeleteCall
 	client.Fake.ClearActions()
 	clusterContext.DeletePods([]*v1.Pod{pod})
 	clusterContext.ProcessPodsToDelete()
-	assert.Equal(t, len(client.Fake.Actions()), 1)
+	assert.Equal(t, len(client.Fake.Actions()), 2)
 
 	client.Fake.ClearActions()
 	clusterContext.DeletePods([]*v1.Pod{pod})
@@ -213,12 +275,12 @@ func TestKubernetesClusterContext_ProcessPodsToDelete_AllowsRepeatedDeleteCallTo
 	client.Fake.ClearActions()
 	clusterContext.DeletePods([]*v1.Pod{pod})
 	clusterContext.ProcessPodsToDelete()
-	assert.Equal(t, len(client.Fake.Actions()), 1)
+	assert.Equal(t, len(client.Fake.Actions()), 2)
 
 	client.Fake.ClearActions()
 	clusterContext.DeletePods([]*v1.Pod{pod})
 	clusterContext.ProcessPodsToDelete()
-	assert.Equal(t, len(client.Fake.Actions()), 1)
+	assert.Equal(t, len(client.Fake.Actions()), 2)
 }
 
 func TestKubernetesClusterContext_ProcessPodsToDelete_AllowsRepeatedDeleteCallToClient_AfterMinimumDeletePeriodHasPassed(t *testing.T) {
@@ -227,19 +289,19 @@ func TestKubernetesClusterContext_ProcessPodsToDelete_AllowsRepeatedDeleteCallTo
 	client := provider.FakeClient
 
 	pod := createSubmittedBatchPod(t, clusterContext)
-
 	client.Fake.ClearActions()
 	clusterContext.DeletePods([]*v1.Pod{pod})
 	clusterContext.ProcessPodsToDelete()
-	assert.Equal(t, len(client.Fake.Actions()), 1)
+	assert.Equal(t, len(client.Fake.Actions()), 2)
 
 	//Wait time required between repeated delete calls
 	time.Sleep(timeBetweenRepeatedDeleteCalls + 200*time.Millisecond)
 
+	submitPodsWithWait(t, clusterContext, pod)
 	client.Fake.ClearActions()
 	clusterContext.DeletePods([]*v1.Pod{pod})
 	clusterContext.ProcessPodsToDelete()
-	assert.Equal(t, len(client.Fake.Actions()), 1)
+	assert.Equal(t, len(client.Fake.Actions()), 2)
 }
 
 func TestKubernetesClusterContext_AddAnnotation(t *testing.T) {

--- a/internal/executor/domain/pod_labels.go
+++ b/internal/executor/domain/pod_labels.go
@@ -1,12 +1,13 @@
 package domain
 
 const (
-	JobId           = "armada_job_id"
-	PodNumber       = "armada_pod_number"
-	PodCount        = "armada_pod_count"
-	JobSetId        = "armada_jobset_id"
-	Queue           = "armada_queue_id"
-	Owner           = "armada_owner"
-	HasIngress      = "has_ingress"
-	IngressReported = "ingress_reported"
+	JobId             = "armada_job_id"
+	PodNumber         = "armada_pod_number"
+	PodCount          = "armada_pod_count"
+	JobSetId          = "armada_jobset_id"
+	Queue             = "armada_queue_id"
+	Owner             = "armada_owner"
+	HasIngress        = "has_ingress"
+	IngressReported   = "ingress_reported"
+	MarkedForDeletion = "deletion"
 )

--- a/internal/executor/domain/pod_metadata.go
+++ b/internal/executor/domain/pod_metadata.go
@@ -9,5 +9,6 @@ const (
 	Owner             = "armada_owner"
 	HasIngress        = "has_ingress"
 	IngressReported   = "ingress_reported"
-	MarkedForDeletion = "deletion"
+	MarkedForDeletion = "deletion_requested"
+	JobDoneAnnotation = "reported_done"
 )

--- a/internal/executor/job/job_context.go
+++ b/internal/executor/job/job_context.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/G-Research/armada/internal/executor/service"
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -253,7 +252,7 @@ func (c *ClusterJobContext) handleDeletedPod(pod *v1.Pod) {
 	jobId := util.ExtractJobId(pod)
 	if jobId != "" {
 		record, exists := c.activeJobs[jobId]
-		active := exists && !util.IsMarkedForDeletion(pod) && !service.IsPodFinishedAndReported(pod)
+		active := exists && !util.IsMarkedForDeletion(pod) && !util.IsPodFinishedAndReported(pod)
 		if active {
 			record.issue = &PodIssue{
 				OriginatingPod: pod,

--- a/internal/executor/job/job_context.go
+++ b/internal/executor/job/job_context.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/G-Research/armada/internal/executor/service"
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -263,7 +264,7 @@ func (c *ClusterJobContext) handleDeletedPod(pod *v1.Pod) {
 	jobId := util.ExtractJobId(pod)
 	if jobId != "" {
 		record, exists := c.activeJobs[jobId]
-		active := exists && !record.markedForDeletion
+		active := exists && !record.markedForDeletion && !service.IsPodFinishedAndReported(pod)
 		if active {
 			record.issue = &PodIssue{
 				OriginatingPod: pod,

--- a/internal/executor/job/submit.go
+++ b/internal/executor/job/submit.go
@@ -83,7 +83,7 @@ func (allocationService *SubmitService) submitPod(job *api.Job, i int) (*v1.Pod,
 	pod := createPod(job, allocationService.podDefaults, i)
 
 	if exposesPorts(job, &pod.Spec) {
-		pod.Annotations = mergeMaps(pod.Annotations, map[string]string{
+		pod.Annotations = MergeMaps(pod.Annotations, map[string]string{
 			domain.HasIngress: "true",
 		})
 		submittedPod, err := allocationService.clusterContext.SubmitPod(pod, job.Owner, job.QueueOwnershipUserGroups)
@@ -183,12 +183,12 @@ func createService(job *api.Job, pod *v1.Pod) *v1.Service {
 		},
 		Ports: servicePorts,
 	}
-	labels := mergeMaps(job.Labels, map[string]string{
+	labels := MergeMaps(job.Labels, map[string]string{
 		domain.JobId:     pod.Labels[domain.JobId],
 		domain.Queue:     pod.Labels[domain.Queue],
 		domain.PodNumber: pod.Labels[domain.PodNumber],
 	})
-	annotation := mergeMaps(job.Annotations, map[string]string{
+	annotation := MergeMaps(job.Annotations, map[string]string{
 		domain.JobSetId: job.JobSetId,
 		domain.Owner:    job.Owner,
 	})
@@ -211,13 +211,13 @@ func createPod(job *api.Job, defaults *configuration.PodDefaults, i int) *v1.Pod
 	podSpec := allPodSpecs[i]
 	applyDefaults(podSpec, defaults)
 
-	labels := mergeMaps(job.Labels, map[string]string{
+	labels := MergeMaps(job.Labels, map[string]string{
 		domain.JobId:     job.Id,
 		domain.Queue:     job.Queue,
 		domain.PodNumber: strconv.Itoa(i),
 		domain.PodCount:  strconv.Itoa(len(allPodSpecs)),
 	})
-	annotation := mergeMaps(job.Annotations, map[string]string{
+	annotation := MergeMaps(job.Annotations, map[string]string{
 		domain.JobSetId: job.JobSetId,
 		domain.Owner:    job.Owner,
 	})
@@ -250,7 +250,7 @@ func setRestartPolicyNever(podSpec *v1.PodSpec) {
 	podSpec.RestartPolicy = v1.RestartPolicyNever
 }
 
-func mergeMaps(a map[string]string, b map[string]string) map[string]string {
+func MergeMaps(a map[string]string, b map[string]string) map[string]string {
 	result := make(map[string]string)
 	for k, v := range a {
 		result[k] = v

--- a/internal/executor/job/submit.go
+++ b/internal/executor/job/submit.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/G-Research/armada/internal/common"
+	"github.com/G-Research/armada/internal/common/util"
 	"github.com/G-Research/armada/internal/executor/configuration"
 	"github.com/G-Research/armada/internal/executor/context"
 	"github.com/G-Research/armada/internal/executor/domain"
@@ -83,7 +84,7 @@ func (allocationService *SubmitService) submitPod(job *api.Job, i int) (*v1.Pod,
 	pod := createPod(job, allocationService.podDefaults, i)
 
 	if exposesPorts(job, &pod.Spec) {
-		pod.Annotations = MergeMaps(pod.Annotations, map[string]string{
+		pod.Annotations = util.MergeMaps(pod.Annotations, map[string]string{
 			domain.HasIngress: "true",
 		})
 		submittedPod, err := allocationService.clusterContext.SubmitPod(pod, job.Owner, job.QueueOwnershipUserGroups)
@@ -183,12 +184,12 @@ func createService(job *api.Job, pod *v1.Pod) *v1.Service {
 		},
 		Ports: servicePorts,
 	}
-	labels := MergeMaps(job.Labels, map[string]string{
+	labels := util.MergeMaps(job.Labels, map[string]string{
 		domain.JobId:     pod.Labels[domain.JobId],
 		domain.Queue:     pod.Labels[domain.Queue],
 		domain.PodNumber: pod.Labels[domain.PodNumber],
 	})
-	annotation := MergeMaps(job.Annotations, map[string]string{
+	annotation := util.MergeMaps(job.Annotations, map[string]string{
 		domain.JobSetId: job.JobSetId,
 		domain.Owner:    job.Owner,
 	})
@@ -211,13 +212,13 @@ func createPod(job *api.Job, defaults *configuration.PodDefaults, i int) *v1.Pod
 	podSpec := allPodSpecs[i]
 	applyDefaults(podSpec, defaults)
 
-	labels := MergeMaps(job.Labels, map[string]string{
+	labels := util.MergeMaps(job.Labels, map[string]string{
 		domain.JobId:     job.Id,
 		domain.Queue:     job.Queue,
 		domain.PodNumber: strconv.Itoa(i),
 		domain.PodCount:  strconv.Itoa(len(allPodSpecs)),
 	})
-	annotation := MergeMaps(job.Annotations, map[string]string{
+	annotation := util.MergeMaps(job.Annotations, map[string]string{
 		domain.JobSetId: job.JobSetId,
 		domain.Owner:    job.Owner,
 	})
@@ -248,15 +249,4 @@ func applyDefaults(spec *v1.PodSpec, defaults *configuration.PodDefaults) {
 
 func setRestartPolicyNever(podSpec *v1.PodSpec) {
 	podSpec.RestartPolicy = v1.RestartPolicyNever
-}
-
-func MergeMaps(a map[string]string, b map[string]string) map[string]string {
-	result := make(map[string]string)
-	for k, v := range a {
-		result[k] = v
-	}
-	for k, v := range b {
-		result[k] = v
-	}
-	return result
 }

--- a/internal/executor/reporter/job_event_reporter.go
+++ b/internal/executor/reporter/job_event_reporter.go
@@ -291,17 +291,11 @@ func (eventReporter *JobEventReporter) hasPendingEvents(pod *v1.Pod) bool {
 func filterPodsWithCurrentStateNotReported(pods []*v1.Pod) []*v1.Pod {
 	podsWithMissingEvent := make([]*v1.Pod, 0)
 	for _, pod := range pods {
-		if !HasCurrentStateBeenReported(pod) && HasPodBeenInStateForLongerThanGivenDuration(pod, 30*time.Second) {
+		if !util.HasCurrentStateBeenReported(pod) && HasPodBeenInStateForLongerThanGivenDuration(pod, 30*time.Second) {
 			podsWithMissingEvent = append(podsWithMissingEvent, pod)
 		}
 	}
 	return podsWithMissingEvent
-}
-
-func HasCurrentStateBeenReported(pod *v1.Pod) bool {
-	podPhase := pod.Status.Phase
-	_, annotationPresent := pod.Annotations[string(podPhase)]
-	return annotationPresent
 }
 
 func HasPodBeenInStateForLongerThanGivenDuration(pod *v1.Pod, duration time.Duration) bool {

--- a/internal/executor/reporter/job_event_reporter_test.go
+++ b/internal/executor/reporter/job_event_reporter_test.go
@@ -53,44 +53,6 @@ func TestHasPodBeenInStateForLongerThanGivenDuration_ReturnsFalse_WhenNoPodState
 	assert.False(t, result)
 }
 
-func TestHasCurrentStateBeenReported_TrueWhenAnnotationExistsForCurrentPhase(t *testing.T) {
-	podPhase := v1.PodRunning
-	pod := v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Annotations: map[string]string{string(podPhase): time.Now().String()},
-		},
-		Status: v1.PodStatus{
-			Phase: podPhase,
-		},
-	}
-	result := HasCurrentStateBeenReported(&pod)
-	assert.True(t, result)
-}
-
-func TestHasCurrentStateBeenReported_FalseWhenNoAnnotationExistsForCurrentPhase(t *testing.T) {
-	pod := v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			//Annotation for different phase
-			Annotations: map[string]string{string(v1.PodPending): time.Now().String()},
-		},
-		Status: v1.PodStatus{
-			Phase: v1.PodRunning,
-		},
-	}
-	result := HasCurrentStateBeenReported(&pod)
-	assert.False(t, result)
-}
-
-func TestHasCurrentStateBeenReported_FalseWhenNoAnnotationsExist(t *testing.T) {
-	pod := v1.Pod{
-		Status: v1.PodStatus{
-			Phase: v1.PodRunning,
-		},
-	}
-	result := HasCurrentStateBeenReported(&pod)
-	assert.False(t, result)
-}
-
 func TestRequiresIngressToBeReported_FalseWhenIngressHasBeenReported(t *testing.T) {
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/executor/service/job_lease.go
+++ b/internal/executor/service/job_lease.go
@@ -18,7 +18,6 @@ import (
 )
 
 const maxPodRequestSize = 10000
-const jobDoneAnnotation = "reported_done"
 
 type LeaseService interface {
 	ReturnLease(pod *v1.Pod) error

--- a/internal/executor/service/job_manager.go
+++ b/internal/executor/service/job_manager.go
@@ -113,9 +113,7 @@ func (m *JobManager) canBeRemoved(job *job.RunningJob) bool {
 }
 
 func (m *JobManager) canPodBeRemoved(pod *v1.Pod) bool {
-	if !util.IsInTerminalState(pod) ||
-		!isReportedDone(pod) ||
-		!reporter.HasCurrentStateBeenReported(pod) {
+	if !IsPodFinishedAndReported(pod) {
 		return false
 	}
 

--- a/internal/executor/service/job_manager.go
+++ b/internal/executor/service/job_manager.go
@@ -8,6 +8,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	context2 "github.com/G-Research/armada/internal/executor/context"
+	"github.com/G-Research/armada/internal/executor/domain"
 	"github.com/G-Research/armada/internal/executor/job"
 	"github.com/G-Research/armada/internal/executor/reporter"
 	"github.com/G-Research/armada/internal/executor/util"
@@ -85,7 +86,7 @@ func (m *JobManager) reportDoneAndMarkReported(jobs []*job.RunningJob) error {
 
 func (m *JobManager) markAsDone(jobs []*job.RunningJob) {
 	err := m.jobContext.AddAnnotation(jobs, map[string]string{
-		jobDoneAnnotation: time.Now().String(),
+		domain.JobDoneAnnotation: time.Now().String(),
 	})
 	if err != nil {
 		log.Warnf("Failed to annotate jobs as done: %v", err)
@@ -113,7 +114,7 @@ func (m *JobManager) canBeRemoved(job *job.RunningJob) bool {
 }
 
 func (m *JobManager) canPodBeRemoved(pod *v1.Pod) bool {
-	if !IsPodFinishedAndReported(pod) {
+	if !util.IsPodFinishedAndReported(pod) {
 		return false
 	}
 

--- a/internal/executor/service/job_manager_test.go
+++ b/internal/executor/service/job_manager_test.go
@@ -4,12 +4,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/G-Research/armada/internal/executor/domain"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/G-Research/armada/internal/executor/configuration"
+	"github.com/G-Research/armada/internal/executor/domain"
 	context2 "github.com/G-Research/armada/internal/executor/fake/context"
 	"github.com/G-Research/armada/internal/executor/job"
 	reporter_fake "github.com/G-Research/armada/internal/executor/reporter/fake"

--- a/internal/executor/service/job_manager_test.go
+++ b/internal/executor/service/job_manager_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/G-Research/armada/internal/executor/domain"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -73,7 +74,7 @@ func makePodWithCurrentStateReported(state v1.PodPhase, reportedDone bool) *v1.P
 	}
 
 	if reportedDone {
-		pod.Annotations[jobDoneAnnotation] = time.Now().String()
+		pod.Annotations[domain.JobDoneAnnotation] = time.Now().String()
 	}
 
 	return &pod

--- a/internal/executor/service/util.go
+++ b/internal/executor/service/util.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"github.com/G-Research/armada/internal/executor/reporter"
 	v1 "k8s.io/api/core/v1"
 
 	commonUtil "github.com/G-Research/armada/internal/common/util"
@@ -76,4 +77,13 @@ func chunkJobs(jobs []*job.RunningJob, size int) [][]*job.RunningJob {
 		chunks = append(chunks, jobs[start:end])
 	}
 	return chunks
+}
+
+func IsPodFinishedAndReported(pod *v1.Pod) bool {
+	if !util.IsInTerminalState(pod) ||
+		!isReportedDone(pod) ||
+		!reporter.HasCurrentStateBeenReported(pod) {
+		return false
+	}
+	return true
 }

--- a/internal/executor/service/util.go
+++ b/internal/executor/service/util.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"github.com/G-Research/armada/internal/executor/reporter"
 	v1 "k8s.io/api/core/v1"
 
 	commonUtil "github.com/G-Research/armada/internal/common/util"
@@ -33,7 +32,7 @@ func filterRunningJobsByIds(jobs []*job.RunningJob, ids []string) []*job.Running
 }
 
 func shouldBeRenewed(pod *v1.Pod) bool {
-	return !isReportedDone(pod)
+	return !util.IsReportedDone(pod)
 }
 
 func jobShouldBeRenewed(job *job.RunningJob) bool {
@@ -47,16 +46,11 @@ func jobShouldBeRenewed(job *job.RunningJob) bool {
 
 func shouldBeReportedDone(job *job.RunningJob) bool {
 	for _, pod := range job.ActivePods {
-		if util.IsInTerminalState(pod) && !isReportedDone(pod) {
+		if util.IsInTerminalState(pod) && !util.IsReportedDone(pod) {
 			return true
 		}
 	}
 	return false
-}
-
-func isReportedDone(pod *v1.Pod) bool {
-	_, exists := pod.Annotations[jobDoneAnnotation]
-	return exists
 }
 
 func extractPods(jobs []*job.RunningJob) []*v1.Pod {
@@ -77,13 +71,4 @@ func chunkJobs(jobs []*job.RunningJob, size int) [][]*job.RunningJob {
 		chunks = append(chunks, jobs[start:end])
 	}
 	return chunks
-}
-
-func IsPodFinishedAndReported(pod *v1.Pod) bool {
-	if !util.IsInTerminalState(pod) ||
-		!isReportedDone(pod) ||
-		!reporter.HasCurrentStateBeenReported(pod) {
-		return false
-	}
-	return true
 }

--- a/internal/executor/util/pod_util.go
+++ b/internal/executor/util/pod_util.go
@@ -204,3 +204,23 @@ func IsMarkedForDeletion(pod *v1.Pod) bool {
 	_, exists := pod.Annotations[domain.MarkedForDeletion]
 	return exists
 }
+
+func IsReportedDone(pod *v1.Pod) bool {
+	_, exists := pod.Annotations[domain.JobDoneAnnotation]
+	return exists
+}
+
+func IsPodFinishedAndReported(pod *v1.Pod) bool {
+	if !IsInTerminalState(pod) ||
+		!IsReportedDone(pod) ||
+		!HasCurrentStateBeenReported(pod) {
+		return false
+	}
+	return true
+}
+
+func HasCurrentStateBeenReported(pod *v1.Pod) bool {
+	podPhase := pod.Status.Phase
+	_, annotationPresent := pod.Annotations[string(podPhase)]
+	return annotationPresent
+}

--- a/internal/executor/util/pod_util.go
+++ b/internal/executor/util/pod_util.go
@@ -199,3 +199,8 @@ func GetPodContainerStatuses(pod *v1.Pod) []v1.ContainerStatus {
 	containerStatuses = append(containerStatuses, pod.Status.InitContainerStatuses...)
 	return containerStatuses
 }
+
+func IsMarkedForDeletion(pod *v1.Pod) bool {
+	_, exists := pod.Annotations[domain.MarkedForDeletion]
+	return exists
+}

--- a/internal/executor/util/pod_util_test.go
+++ b/internal/executor/util/pod_util_test.go
@@ -442,3 +442,63 @@ func TestLastStatusChange_ReportsTimeFromContainerStatus(t *testing.T) {
 	assert.Equal(t, result, now)
 	assert.Nil(t, err)
 }
+
+func TestIsReportedDone(t *testing.T) {
+	isNotReportedDone := &v1.Pod{}
+	isReportedDone := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{domain.JobDoneAnnotation: time.Now().String()},
+		},
+	}
+	assert.False(t, IsReportedDone(isNotReportedDone))
+	assert.True(t, IsReportedDone(isReportedDone))
+}
+
+func TestIsMarkedForDeletion(t *testing.T) {
+	isNotMarkedForDeletion := &v1.Pod{}
+	isMarkedForDeletion := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{domain.MarkedForDeletion: time.Now().String()},
+		},
+	}
+	assert.False(t, IsMarkedForDeletion(isNotMarkedForDeletion))
+	assert.True(t, IsMarkedForDeletion(isMarkedForDeletion))
+}
+
+func TestHasCurrentStateBeenReported_TrueWhenAnnotationExistsForCurrentPhase(t *testing.T) {
+	podPhase := v1.PodRunning
+	pod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{string(podPhase): time.Now().String()},
+		},
+		Status: v1.PodStatus{
+			Phase: podPhase,
+		},
+	}
+	result := HasCurrentStateBeenReported(&pod)
+	assert.True(t, result)
+}
+
+func TestHasCurrentStateBeenReported_FalseWhenNoAnnotationExistsForCurrentPhase(t *testing.T) {
+	pod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			//Annotation for different phase
+			Annotations: map[string]string{string(v1.PodPending): time.Now().String()},
+		},
+		Status: v1.PodStatus{
+			Phase: v1.PodRunning,
+		},
+	}
+	result := HasCurrentStateBeenReported(&pod)
+	assert.False(t, result)
+}
+
+func TestHasCurrentStateBeenReported_FalseWhenNoAnnotationsExist(t *testing.T) {
+	pod := v1.Pod{
+		Status: v1.PodStatus{
+			Phase: v1.PodRunning,
+		},
+	}
+	result := HasCurrentStateBeenReported(&pod)
+	assert.False(t, result)
+}


### PR DESCRIPTION
Kubernetes automatically starts deleting pods once you hit a certain number of terminated pods (configured by `terminated-pod-gc-threshold` in kube-controller-manager)

Armada was detecting these deletions as something external deleting the pods (which it was) and then failing the jobs. (Even though they were already finished).

Now we:
 - Ignore deletions from external source when the Pod is "Done" (Terminated + Armada has reported all necessary info back to the server). So we should no longer error on kubernetes cleaning up old terminated pods
 - We mark pods with an annotation when Armada is deleting them. This makes it very clear when Armada deleted the pod vs some other source. (Based on the presence of the annotation).

