### PR TITLE
Add server liveness probe, tweak probe settings

### DIFF
--- a/deployment/armada/templates/deployment.yaml
+++ b/deployment/armada/templates/deployment.yaml
@@ -66,12 +66,14 @@ spec:
               port: rest
             initialDelaySeconds: 5
             timeoutSeconds: 5
+            failureThreshold: 2
           livenessProbe:
             httpGet:
               path: /health
               port: rest
             initialDelaySeconds: 10
             timeoutSeconds: 10
+            failureThreshold: 3
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/deployment/armada/templates/deployment.yaml
+++ b/deployment/armada/templates/deployment.yaml
@@ -66,6 +66,12 @@ spec:
               port: rest
             initialDelaySeconds: 5
             timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: web
+            initialDelaySeconds: 10
+            timeoutSeconds: 10
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/deployment/armada/templates/deployment.yaml
+++ b/deployment/armada/templates/deployment.yaml
@@ -69,7 +69,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /health
-              port: web
+              port: rest
             initialDelaySeconds: 10
             timeoutSeconds: 10
       affinity:

--- a/deployment/binoculars/templates/deployment.yaml
+++ b/deployment/binoculars/templates/deployment.yaml
@@ -70,8 +70,8 @@ spec:
             httpGet:
               path: /health
               port: web
-            initialDelaySeconds: 5
-            timeoutSeconds: 5
+            initialDelaySeconds: 10
+            timeoutSeconds: 10
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/deployment/binoculars/templates/deployment.yaml
+++ b/deployment/binoculars/templates/deployment.yaml
@@ -66,12 +66,14 @@ spec:
               port: web
             initialDelaySeconds: 5
             timeoutSeconds: 5
+            failureThreshold: 2
           livenessProbe:
             httpGet:
               path: /health
               port: web
             initialDelaySeconds: 10
             timeoutSeconds: 10
+            failureThreshold: 3
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/deployment/lookout/templates/deployment.yaml
+++ b/deployment/lookout/templates/deployment.yaml
@@ -70,8 +70,8 @@ spec:
             httpGet:
               path: /health
               port: web
-            initialDelaySeconds: 5
-            timeoutSeconds: 5
+            initialDelaySeconds: 10
+            timeoutSeconds: 10
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/deployment/lookout/templates/deployment.yaml
+++ b/deployment/lookout/templates/deployment.yaml
@@ -66,12 +66,14 @@ spec:
               port: web
             initialDelaySeconds: 5
             timeoutSeconds: 5
+            failureThreshold: 2
           livenessProbe:
             httpGet:
               path: /health
               port: web
             initialDelaySeconds: 10
             timeoutSeconds: 10
+            failureThreshold: 3
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Liveness probe 5s timeout probe is perhaps a bit aggressive now /health will fail until the program has started, and also includes checks for redis/sql/nats.

Liveness probe was also missing entirely for the armada server, add it

