### PR TITLE
Check Go Formatting first for faster feedback

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,6 +118,13 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Check TypeScript formatting
+          command: |
+            npm version
+            cd ./internal/lookout/ui && npm install && npm run fmt || exit 1
+            exit $(git status -s -uno | wc -l)
+            
+      - run:
           name: Check Go formatting
           command: |
             go install golang.org/x/tools/cmd/goimports@v0.1.1
@@ -130,12 +137,6 @@ jobs:
             go get -u github.com/gordonklaus/ineffassign
             cd ~/go/src/github.com/G-Research/armada
             ineffassign ./...
-
-      - run:
-          name: Check TypeScript formatting
-          command: |
-            cd ./internal/lookout/ui && npm install && npm run fmt || exit 1
-            exit $(git status -s -uno | wc -l)
 
       - run:
           name: Check generated files

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ jobs:
   code_style:
     machine:
       docker_layer_caching: false
-      image: ubuntu-2004:202104-01
+      image: ubuntu-2004:202101-01
     environment:
       GO111MODULE: "on"
       GOPATH: "/home/circleci/go"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ jobs:
   code_style:
     machine:
       docker_layer_caching: false
-      image: ubuntu-2004:202107-02
+      image: ubuntu-2004:202104-01
     environment:
       GO111MODULE: "on"
       GOPATH: "/home/circleci/go"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ jobs:
   code_style:
     machine:
       docker_layer_caching: false
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2004:202104-01
     environment:
       GO111MODULE: "on"
       GOPATH: "/home/circleci/go"
@@ -121,7 +121,7 @@ jobs:
           name: Check TypeScript formatting
           command: |
             npm version
-            cd ./internal/lookout/ui && npm install && npm run fmt || exit 1
+            cd ./internal/lookout/ui && npm install && npm run fmt
             exit $(git status -s -uno | wc -l)
             
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ jobs:
   code_style:
     machine:
       docker_layer_caching: false
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2004:202107-02
     environment:
       GO111MODULE: "on"
       GOPATH: "/home/circleci/go"
@@ -117,6 +117,12 @@ jobs:
     working_directory: ~/go/src/github.com/G-Research/armada
     steps:
       - checkout
+      - run:
+          name: Check Go formatting
+          command: |
+            go install golang.org/x/tools/cmd/goimports@v0.1.1
+            exit $(goimports -l -local "github.com/G-Research/armada" | wc -l)
+
       - run:
           name: ineffassign
           command: |
@@ -138,11 +144,6 @@ jobs:
             git status -s -uno
             git --no-pager diff
             exit $(git status -s -uno | wc -l)
-
-      - run:
-          name: Check Go formatting
-          command: |
-            exit $(go run golang.org/x/tools/cmd/goimports -l -local "github.com/G-Research/armada" . | wc -l)
 
   test:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,9 @@ jobs:
           name: Check TypeScript formatting
           command: |
             npm version
-            cd ./internal/lookout/ui && npm install && npm run fmt
+            cd ./internal/lookout/ui
+            npm install
+            npm run fmt
             exit $(git status -s -uno | wc -l)
             
       - run:

--- a/internal/lookout/ui/package.json
+++ b/internal/lookout/ui/package.json
@@ -7,8 +7,8 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "openapi": "docker run --rm -u $(id -u ${USER}):$(id -g ${USER}) -v \"${PWD}/../../../:/project\" openapitools/openapi-generator-cli /project/internal/lookout/ui/openapi.sh",
-    "lint": "eslint ./src/**/*.{js,ts,tsx}",
-    "fmt": "eslint ./src/**/*.{js,ts,tsx} --fix"
+    "lint": "eslint './src/**/*.{js,ts,tsx}'",
+    "fmt": "eslint './src/**/*.{js,ts,tsx}' --fix"
   },
   "dependencies": {
     "@material-ui/core": "^4.11.4",


### PR DESCRIPTION
 - This check is fast so it should run first
 - Using a newer machine image to get Go 1.16, which has go install (doesn't change mod file)