### PR TITLE
Check Go Formatting first for faster feedback

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ jobs:
           name: Check Go formatting
           command: |
             go install golang.org/x/tools/cmd/goimports@v0.1.1
-            goimports -l -local "github.com/G-Research/armada" | wc -l
+            goimports -l -local "github.com/G-Research/armada"
             exit $(goimports -l -local "github.com/G-Research/armada" | wc -l)
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,6 +119,13 @@ jobs:
       - checkout
 
       - run:
+          name: Check Go formatting
+          command: |
+            go install golang.org/x/tools/cmd/goimports@v0.1.1
+            goimports -l -local "github.com/G-Research/armada" | wc -l
+            exit $(goimports -l -local "github.com/G-Research/armada" | wc -l)
+
+      - run:
           name: ineffassign
           command: |
             cd /tmp
@@ -143,11 +150,6 @@ jobs:
             git --no-pager diff
             git status -s -uno
             exit $(git status -s -uno | wc -l)
-
-      - run:
-          name: Check Go formatting
-          command: |
-            exit $(go run golang.org/x/tools/cmd/goimports -l -local "github.com/G-Research/armada" . | wc -l)
 
   test:
     machine:


### PR DESCRIPTION
 The Go formatting check is very fast and it is the cause of most formatting errors, so it should be run first to speed up feedback