### PR TITLE
Adding the concept of IgnoredTaints to executor

### DIFF
--- a/cmd/executor/main.go
+++ b/cmd/executor/main.go
@@ -6,6 +6,7 @@ import (
 	"syscall"
 
 	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
@@ -29,6 +30,11 @@ func main() {
 	var config configuration.ExecutorConfiguration
 	userSpecifiedConfigs := viper.GetStringSlice(CustomConfigLocation)
 	common.LoadConfig(&config, "./config/executor", userSpecifiedConfigs)
+	err := configuration.ValidateExecutorConfiguration(config)
+	if err != nil {
+		log.Errorf("Invalid config found: %s", err)
+		os.Exit(-1)
+	}
 
 	shutdownChannel := make(chan os.Signal, 1)
 	signal.Notify(shutdownChannel, syscall.SIGINT, syscall.SIGTERM)

--- a/internal/executor/application.go
+++ b/internal/executor/application.go
@@ -80,6 +80,7 @@ func StartUpWithContext(config configuration.ExecutorConfiguration, clusterConte
 		nodeInfoService,
 		usageClient,
 		config.Kubernetes.TrackedNodeLabels,
+		config.Kubernetes.IgnoredTaints,
 		config.Kubernetes.ToleratedTaints)
 
 	clusterAllocationService := service.NewClusterAllocationService(

--- a/internal/executor/configuration/types.go
+++ b/internal/executor/configuration/types.go
@@ -26,6 +26,7 @@ type KubernetesConfiguration struct {
 	ImpersonateUsers  bool
 	TrackedNodeLabels []string
 	ToleratedTaints   []string
+	IgnoredTaints     []string
 	MinimumPodAge     time.Duration
 	FailedPodExpiry   time.Duration
 	StuckPodExpiry    time.Duration

--- a/internal/executor/configuration/validation.go
+++ b/internal/executor/configuration/validation.go
@@ -1,0 +1,18 @@
+package configuration
+
+import (
+	"fmt"
+
+	"github.com/G-Research/armada/internal/common/util"
+)
+
+func ValidateExecutorConfiguration(config ExecutorConfiguration) error {
+	toleratedTaints := util.StringListToSet(config.Kubernetes.ToleratedTaints)
+	ignoredTaints := util.StringListToSet(config.Kubernetes.IgnoredTaints)
+	for key := range toleratedTaints {
+		if _, exists := ignoredTaints[key]; exists {
+			return fmt.Errorf("cannot have the same value in both toleratedTaints and ignoredTaints. Value found in both lists \"%s\"", key)
+		}
+	}
+	return nil
+}

--- a/internal/executor/configuration/validation_test.go
+++ b/internal/executor/configuration/validation_test.go
@@ -1,0 +1,40 @@
+package configuration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateExecutorConfiguration_NoTaintConfig(t *testing.T) {
+	config := ExecutorConfiguration{
+		Kubernetes: KubernetesConfiguration{},
+	}
+
+	result := ValidateExecutorConfiguration(config)
+	assert.NoError(t, result)
+}
+
+func TestValidateExecutorConfiguration_TaintConfigWithDisjointValues(t *testing.T) {
+	config := ExecutorConfiguration{
+		Kubernetes: KubernetesConfiguration{
+			ToleratedTaints: []string{"tolerated"},
+			IgnoredTaints:   []string{"ignored"},
+		},
+	}
+
+	result := ValidateExecutorConfiguration(config)
+	assert.NoError(t, result)
+}
+
+func TestValidateExecutorConfiguration_TaintConfigWithOverlappingValues(t *testing.T) {
+	config := ExecutorConfiguration{
+		Kubernetes: KubernetesConfiguration{
+			ToleratedTaints: []string{"overlapping"},
+			IgnoredTaints:   []string{"overlapping"},
+		},
+	}
+
+	result := ValidateExecutorConfiguration(config)
+	assert.Error(t, result)
+}

--- a/internal/executor/utilisation/cluster_utilisation.go
+++ b/internal/executor/utilisation/cluster_utilisation.go
@@ -252,8 +252,7 @@ func (clusterUtilisationService *ClusterUtilisationService) isAvailableProcessin
 
 	for _, taint := range node.Spec.Taints {
 		if taint.Effect == v1.TaintEffectNoSchedule &&
-			!clusterUtilisationService.toleratedTaints[taint.Key] &&
-			!clusterUtilisationService.ignoredTaints[taint.Key] {
+			!clusterUtilisationService.toleratedTaints[taint.Key] {
 			return false
 		}
 	}

--- a/internal/executor/utilisation/cluster_utilisation_test.go
+++ b/internal/executor/utilisation/cluster_utilisation_test.go
@@ -104,7 +104,7 @@ func TestFilterAvailableProcessingNodes_IsTrue_NodeWithIgnoredTaint(t *testing.T
 	assert.True(t, result)
 }
 
-func TestFilterNodeTaints(t *testing.T) {
+func TestFilterIgnoredNodeTaints(t *testing.T) {
 	context := fakeContext.NewFakeClusterContext(testAppConfig, nil)
 	service := NewClusterUtilisationService(context, nil, nil, nil, nil, []string{"ignored"}, nil)
 
@@ -112,12 +112,12 @@ func TestFilterNodeTaints(t *testing.T) {
 		Key:    "normal",
 		Effect: v1.TaintEffectNoSchedule,
 	}
-	result := service.filterNodeTaints([]v1.Taint{taint})
+	result := service.filterIgnoredTaints([]v1.Taint{taint})
 	assert.Equal(t, len(result), 1)
 	assert.Equal(t, result[0], taint)
 }
 
-func TestFilterNodeTaints_RemovesIgnoredTaints(t *testing.T) {
+func TestFilterIgnoredNodeTaints_RemovesIgnoredTaints(t *testing.T) {
 	context := fakeContext.NewFakeClusterContext(testAppConfig, nil)
 	service := NewClusterUtilisationService(context, nil, nil, nil, nil, []string{"ignored"}, nil)
 
@@ -125,7 +125,7 @@ func TestFilterNodeTaints_RemovesIgnoredTaints(t *testing.T) {
 		Key:    "ignored",
 		Effect: v1.TaintEffectNoSchedule,
 	}
-	result := service.filterNodeTaints([]v1.Taint{taint})
+	result := service.filterIgnoredTaints([]v1.Taint{taint})
 	assert.Equal(t, len(result), 0)
 }
 

--- a/internal/executor/utilisation/cluster_utilisation_test.go
+++ b/internal/executor/utilisation/cluster_utilisation_test.go
@@ -85,25 +85,6 @@ func TestFilterAvailableProcessingNodes_IsTrue_NodeWithToleratedTaint(t *testing
 	assert.True(t, result)
 }
 
-func TestFilterAvailableProcessingNodes_IsTrue_NodeWithIgnoredTaint(t *testing.T) {
-	context := fakeContext.NewFakeClusterContext(testAppConfig, nil)
-	service := NewClusterUtilisationService(context, nil, nil, nil, nil, []string{"taint"}, nil)
-
-	taint := v1.Taint{
-		Key:    "taint",
-		Effect: v1.TaintEffectNoSchedule,
-	}
-	node := v1.Node{
-		Spec: v1.NodeSpec{
-			Unschedulable: false,
-			Taints:        []v1.Taint{taint},
-		},
-	}
-
-	result := service.isAvailableProcessingNode(&node)
-	assert.True(t, result)
-}
-
 func TestFilterIgnoredNodeTaints(t *testing.T) {
 	context := fakeContext.NewFakeClusterContext(testAppConfig, nil)
 	service := NewClusterUtilisationService(context, nil, nil, nil, nil, []string{"ignored"}, nil)


### PR DESCRIPTION
We have `toleratedTaints` that the executor tracks and uses to decide if a node can be used by Armada (by default we ignored any tainted node)

Now we also have `ignoredTaints` which are used to make the executor completely ignore the taint as if it doesn't exist

This is useful if:
 - You taint all your nodes but have an admission webhook that adds appropriate tolerations on pod submission

Without the `ignoredTaints` Armada will always see these nodes as tainted (as it isn't aware of the webhook adding the tolerations) and will only schedule pods on these nodes if they have the toleration when submitted to Armada

With `ignoredTaints` the tainted nodes are completely transparent to the end user of Armada. Armada will schedule pods on them as if the taint doesn't exist, and it is up to a webhook or other means to add the toleration.