### PR TITLE
Lookout perform exact Job id lookup

### DIFF
--- a/internal/lookout/repository/jobs.go
+++ b/internal/lookout/repository/jobs.go
@@ -106,7 +106,7 @@ func (r *SQLJobRepository) createWhereFilters(opts *lookout.GetJobsRequest) []go
 	}
 
 	if opts.JobId != "" {
-		filters = append(filters, StartsWith(job_jobId, opts.JobId))
+		filters = append(filters, job_jobId.Eq(opts.JobId))
 	}
 
 	if opts.Owner != "" {


### PR DESCRIPTION
Primarily for performance, startsWith queries should be handled differently (possibly on the UI)