### PR TITLE
Add DefaultJobTolerations to API

### DIFF
--- a/internal/armada/configuration/types.go
+++ b/internal/armada/configuration/types.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/go-redis/redis"
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/G-Research/armada/internal/common"
 	"github.com/G-Research/armada/internal/common/auth/configuration"
@@ -38,6 +39,7 @@ type SchedulingConfig struct {
 	MaximalResourceFractionPerQueue           map[string]float64
 	Lease                                     LeaseSettings
 	DefaultJobLimits                          common.ComputeResources
+	DefaultJobTolerations                     []v1.Toleration
 	MaxRetries                                uint // Maximum number of retries before a Job is failed
 	ResourceScarcity                          map[string]float64
 	PoolResourceScarcity                      map[string]map[string]float64

--- a/internal/armada/metrics/metrics_test.go
+++ b/internal/armada/metrics/metrics_test.go
@@ -187,6 +187,6 @@ func withRepository(action func(r *repository.RedisJobRepository)) {
 	defer db.Close()
 
 	redisClient := redis.NewClient(&redis.Options{Addr: db.Addr()})
-	repo := repository.NewRedisJobRepository(redisClient, nil)
+	repo := repository.NewRedisJobRepository(redisClient, nil, nil)
 	action(repo)
 }

--- a/internal/armada/server.go
+++ b/internal/armada/server.go
@@ -37,7 +37,7 @@ func Serve(config *configuration.ArmadaConfig, healthChecks *health.MultiChecker
 	db := createRedisClient(&config.Redis)
 	eventsDb := createRedisClient(&config.EventsRedis)
 
-	jobRepository := repository.NewRedisJobRepository(db, config.Scheduling.DefaultJobLimits)
+	jobRepository := repository.NewRedisJobRepository(db, config.Scheduling.DefaultJobLimits, config.Scheduling.DefaultJobTolerations)
 	usageRepository := repository.NewRedisUsageRepository(db)
 	queueRepository := repository.NewRedisQueueRepository(db)
 	schedulingInfoRepository := repository.NewRedisSchedulingInfoRepository(db)

--- a/internal/armada/server/submit_test.go
+++ b/internal/armada/server/submit_test.go
@@ -540,7 +540,7 @@ func withSubmitServerAndRepos(action func(s *SubmitServer, jobRepo repository.Jo
 	// using real redis instance as miniredis does not support streams
 	client := redis.NewClient(&redis.Options{Addr: "localhost:6379", DB: 10})
 
-	jobRepo := repository.NewRedisJobRepository(client, nil)
+	jobRepo := repository.NewRedisJobRepository(client, nil, nil)
 	queueRepo := repository.NewRedisQueueRepository(client)
 	eventRepo := repository.NewRedisEventRepository(client, configuration.EventRetentionPolicy{ExpiryEnabled: false})
 	schedulingInfoRepository := repository.NewRedisSchedulingInfoRepository(client)


### PR DESCRIPTION
This allows you to add these tolerations to all jobs submitted to the API
 - The reason to do this may be because you classify all nodes in your clusters with taints. But you don't want users to have to worry about adding the toleration to run their jobs