### PR TITLE
Preventing Armada scraping unneeded pod metrics

### DIFF
--- a/internal/executor/application.go
+++ b/internal/executor/application.go
@@ -71,16 +71,15 @@ func StartUpWithContext(config configuration.ExecutorConfiguration, clusterConte
 	jobContext := job.NewClusterJobContext(clusterContext, config.Kubernetes.StuckPodExpiry)
 	submitter := job.NewSubmitter(clusterContext, config.Kubernetes.PodDefaults)
 
+	nodeInfoService := node.NewKubernetesNodeInfoService(clusterContext, config.Kubernetes.ToleratedTaints)
 	queueUtilisationService := utilisation.NewMetricsServerQueueUtilisationService(
-		clusterContext)
-	nodeInfoService := node.NewKubernetesNodeInfoService(clusterContext.GetClusterPool(), config.Kubernetes.ToleratedTaints)
+		clusterContext, nodeInfoService)
 	clusterUtilisationService := utilisation.NewClusterUtilisationService(
 		clusterContext,
 		queueUtilisationService,
 		nodeInfoService,
 		usageClient,
-		config.Kubernetes.TrackedNodeLabels,
-		config.Kubernetes.ToleratedTaints)
+		config.Kubernetes.TrackedNodeLabels)
 
 	clusterAllocationService := service.NewClusterAllocationService(
 		clusterContext,

--- a/internal/executor/job/job_context.go
+++ b/internal/executor/job/job_context.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/G-Research/armada/internal/executor/context"
-	"github.com/G-Research/armada/internal/executor/reporter"
 	"github.com/G-Research/armada/internal/executor/util"
 )
 
@@ -213,7 +212,7 @@ func (c *ClusterJobContext) detectStuckPods(runningJob *RunningJob) {
 			break
 
 		} else if (pod.Status.Phase == v1.PodUnknown || pod.Status.Phase == v1.PodPending) &&
-			reporter.HasPodBeenInStateForLongerThanGivenDuration(pod, gracePeriodBeforeHealthCheck) {
+			util.HasPodBeenInStateForLongerThanGivenDuration(pod, gracePeriodBeforeHealthCheck) {
 
 			podEvents, err := c.clusterContext.GetPodEvents(pod)
 			if err != nil {
@@ -223,7 +222,7 @@ func (c *ClusterJobContext) detectStuckPods(runningJob *RunningJob) {
 			stuckPodStatus, message := util.DiagnoseStuckPod(pod, podEvents)
 			retryable := stuckPodStatus == util.Healthy
 
-			if stuckPodStatus != util.Unrecoverable && !reporter.HasPodBeenInStateForLongerThanGivenDuration(pod, c.stuckPodExpiry) {
+			if stuckPodStatus != util.Unrecoverable && !util.HasPodBeenInStateForLongerThanGivenDuration(pod, c.stuckPodExpiry) {
 				// Possibly stuck, but don't do anything until expiry is up
 				continue
 			}

--- a/internal/executor/metrics/pod_metrics/cluster_context.go
+++ b/internal/executor/metrics/pod_metrics/cluster_context.go
@@ -67,7 +67,7 @@ type ClusterContextMetrics struct {
 	context                 context.ClusterContext
 	utilisationService      utilisation.UtilisationService
 	queueUtilisationService utilisation.PodUtilisationService
-	nodeInfoService         node.NodeGroupInfoService
+	nodeInfoService         node.NodeInfoService
 	knownQueues             map[string]map[string]bool
 	podCountTotal           *prometheus.CounterVec
 }
@@ -76,7 +76,7 @@ func ExposeClusterContextMetrics(
 	context context.ClusterContext,
 	utilisationService utilisation.UtilisationService,
 	queueUtilisationService utilisation.PodUtilisationService,
-	nodeInfoService node.NodeGroupInfoService) *ClusterContextMetrics {
+	nodeInfoService node.NodeInfoService) *ClusterContextMetrics {
 	m := &ClusterContextMetrics{
 		context:                 context,
 		utilisationService:      utilisationService,

--- a/internal/executor/node/node_group_test.go
+++ b/internal/executor/node/node_group_test.go
@@ -3,11 +3,12 @@ package node
 import (
 	"testing"
 
-	"github.com/G-Research/armada/internal/executor/configuration"
-	fakeContext "github.com/G-Research/armada/internal/executor/fake/context"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/G-Research/armada/internal/executor/configuration"
+	fakeContext "github.com/G-Research/armada/internal/executor/fake/context"
 )
 
 var testAppConfig = configuration.ApplicationConfiguration{ClusterId: "test", Pool: "pool"}

--- a/internal/executor/reporter/job_event_reporter.go
+++ b/internal/executor/reporter/job_event_reporter.go
@@ -232,7 +232,7 @@ func (eventReporter *JobEventReporter) ReportMissingJobEvents() {
 	podWithIngressNotReported := util.FilterPods(allBatchPods, func(pod *v1.Pod) bool {
 		return pod.Status.Phase == v1.PodRunning &&
 			requiresIngressToBeReported(pod) &&
-			HasPodBeenInStateForLongerThanGivenDuration(pod, 15*time.Second)
+			util.HasPodBeenInStateForLongerThanGivenDuration(pod, 15*time.Second)
 	})
 
 	for _, pod := range podWithIngressNotReported {
@@ -302,20 +302,9 @@ func (eventReporter *JobEventReporter) hasPendingEvents(pod *v1.Pod) bool {
 func filterPodsWithCurrentStateNotReported(pods []*v1.Pod) []*v1.Pod {
 	podsWithMissingEvent := make([]*v1.Pod, 0)
 	for _, pod := range pods {
-		if !util.HasCurrentStateBeenReported(pod) && HasPodBeenInStateForLongerThanGivenDuration(pod, 30*time.Second) {
+		if !util.HasCurrentStateBeenReported(pod) && util.HasPodBeenInStateForLongerThanGivenDuration(pod, 30*time.Second) {
 			podsWithMissingEvent = append(podsWithMissingEvent, pod)
 		}
 	}
 	return podsWithMissingEvent
-}
-
-func HasPodBeenInStateForLongerThanGivenDuration(pod *v1.Pod, duration time.Duration) bool {
-	deadline := time.Now().Add(-duration)
-	lastStatusChange, err := util.LastStatusChange(pod)
-
-	if err != nil {
-		log.Errorf("Problem with pod %v: %v", pod.Name, err)
-		return false
-	}
-	return lastStatusChange.Before(deadline)
 }

--- a/internal/executor/reporter/job_event_reporter_test.go
+++ b/internal/executor/reporter/job_event_reporter_test.go
@@ -11,48 +11,6 @@ import (
 	"github.com/G-Research/armada/internal/executor/domain"
 )
 
-func TestHasPodBeenInStateForLongerThanGivenDuration_ReturnsTrue(t *testing.T) {
-	now := time.Now()
-	sixSecondsAgo := now.Add(-6 * time.Second)
-
-	pod := v1.Pod{
-		Status: v1.PodStatus{
-			Conditions: []v1.PodCondition{{LastTransitionTime: metav1.NewTime(sixSecondsAgo)}},
-		},
-	}
-
-	result := HasPodBeenInStateForLongerThanGivenDuration(&pod, 5*time.Second)
-
-	assert.True(t, result)
-}
-
-func TestHasPodBeenInStateForLongerThanGivenDuration_ReturnsFalse(t *testing.T) {
-	now := time.Now()
-	threeSecondsAgo := now.Add(-3 * time.Second)
-
-	pod := v1.Pod{
-		Status: v1.PodStatus{
-			Conditions: []v1.PodCondition{{LastTransitionTime: metav1.NewTime(threeSecondsAgo)}},
-		},
-	}
-
-	result := HasPodBeenInStateForLongerThanGivenDuration(&pod, 5*time.Second)
-
-	assert.False(t, result)
-}
-
-func TestHasPodBeenInStateForLongerThanGivenDuration_ReturnsFalse_WhenNoPodStateChangesCanBeFound(t *testing.T) {
-	pod := v1.Pod{
-		Status: v1.PodStatus{
-			Conditions: []v1.PodCondition{},
-		},
-	}
-
-	result := HasPodBeenInStateForLongerThanGivenDuration(&pod, 5*time.Second)
-
-	assert.False(t, result)
-}
-
 func TestRequiresIngressToBeReported_FalseWhenIngressHasBeenReported(t *testing.T) {
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/executor/util/node_util.go
+++ b/internal/executor/util/node_util.go
@@ -1,8 +1,9 @@
 package util
 
 import (
-	"github.com/G-Research/armada/internal/common/util"
 	v1 "k8s.io/api/core/v1"
+
+	"github.com/G-Research/armada/internal/common/util"
 )
 
 func GetPodsOnNodes(pods []*v1.Pod, nodes []*v1.Node) []*v1.Pod {

--- a/internal/executor/util/node_util.go
+++ b/internal/executor/util/node_util.go
@@ -1,6 +1,9 @@
 package util
 
-import v1 "k8s.io/api/core/v1"
+import (
+	"github.com/G-Research/armada/internal/common/util"
+	v1 "k8s.io/api/core/v1"
+)
 
 func GetPodsOnNodes(pods []*v1.Pod, nodes []*v1.Node) []*v1.Pod {
 	nodeSet := make(map[string]*v1.Node)
@@ -11,12 +14,51 @@ func GetPodsOnNodes(pods []*v1.Pod, nodes []*v1.Node) []*v1.Pod {
 	podsOnNodes := []*v1.Pod{}
 
 	for _, pod := range pods {
-		if _, presentOnProcessingNode := nodeSet[pod.Spec.NodeName]; presentOnProcessingNode {
+		if _, presentOnNode := nodeSet[pod.Spec.NodeName]; presentOnNode {
 			podsOnNodes = append(podsOnNodes, pod)
 		}
 	}
 
 	return podsOnNodes
+}
+
+func ExtractNodeNames(nodes []*v1.Node) []string {
+	nodeNames := make([]string, 0, len(nodes))
+
+	for _, node := range nodes {
+		nodeNames = append(nodeNames, node.Name)
+	}
+
+	return nodeNames
+}
+
+func RemoveNodesFromList(list1 []*v1.Node, list2 []*v1.Node) []*v1.Node {
+	nodesToRemove := ExtractNodeNames(list2)
+	nodesToRemoveSet := util.StringListToSet(nodesToRemove)
+	remainingNodes := []*v1.Node{}
+
+	for _, node := range list1 {
+		if !nodesToRemoveSet[node.Name] {
+			remainingNodes = append(remainingNodes, node)
+		}
+	}
+
+	return remainingNodes
+}
+
+func MergeNodeList(list1 []*v1.Node, list2 []*v1.Node) []*v1.Node {
+	nodeNames := ExtractNodeNames(list1)
+	nodeNamesSet := util.StringListToSet(nodeNames)
+
+	allNodes := list1
+
+	for _, node := range list2 {
+		if !nodeNamesSet[node.Name] {
+			allNodes = append(allNodes, node)
+		}
+	}
+
+	return allNodes
 }
 
 func FilterNodes(nodes []*v1.Node, filter func(node *v1.Node) bool) []*v1.Node {

--- a/internal/executor/util/node_util_test.go
+++ b/internal/executor/util/node_util_test.go
@@ -112,3 +112,67 @@ func TestGetPodsOnNodes_Empty(t *testing.T) {
 	result = GetPodsOnNodes([]*v1.Pod{}, []*v1.Node{})
 	assert.Equal(t, len(result), 0)
 }
+
+func TestExtractNodeNames(t *testing.T) {
+	node1 := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}
+	node2 := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node2"}}
+
+	result := ExtractNodeNames([]*v1.Node{})
+	assert.Equal(t, []string{}, result)
+
+	result = ExtractNodeNames([]*v1.Node{node1, node2})
+	assert.Equal(t, []string{node1.Name, node2.Name}, result)
+
+	//Returns duplicates
+	result = ExtractNodeNames([]*v1.Node{node1, node1})
+	assert.Equal(t, []string{node1.Name, node1.Name}, result)
+}
+
+func TestMergeNodeList(t *testing.T) {
+	node1 := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}
+	node2 := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node2"}}
+
+	result := MergeNodeList([]*v1.Node{node1}, []*v1.Node{node2})
+	assert.Equal(t, []*v1.Node{node1, node2}, result)
+}
+
+func TestMergeNodeList_DoesNotAddDuplicateNodes(t *testing.T) {
+	node1 := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}
+
+	result := MergeNodeList([]*v1.Node{node1}, []*v1.Node{node1})
+	assert.Equal(t, []*v1.Node{node1}, result)
+}
+
+func TestMergeNodeList_HandlesEmptyLists(t *testing.T) {
+	node1 := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}
+
+	result := MergeNodeList([]*v1.Node{}, []*v1.Node{})
+	assert.Equal(t, []*v1.Node{}, result)
+
+	result = MergeNodeList([]*v1.Node{}, []*v1.Node{node1})
+	assert.Equal(t, []*v1.Node{node1}, result)
+
+	result = MergeNodeList([]*v1.Node{node1}, []*v1.Node{})
+	assert.Equal(t, []*v1.Node{node1}, result)
+}
+
+func TestRemoveNodesFromList(t *testing.T) {
+	node1 := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}
+	node2 := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node2"}}
+
+	result := RemoveNodesFromList([]*v1.Node{node1, node2}, []*v1.Node{node2})
+	assert.Equal(t, []*v1.Node{node1}, result)
+}
+
+func TestRemoveNodesFromList_HandlesEmptyLists(t *testing.T) {
+	node1 := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}
+
+	result := RemoveNodesFromList([]*v1.Node{}, []*v1.Node{})
+	assert.Equal(t, []*v1.Node{}, result)
+
+	result = RemoveNodesFromList([]*v1.Node{}, []*v1.Node{node1})
+	assert.Equal(t, []*v1.Node{}, result)
+
+	result = RemoveNodesFromList([]*v1.Node{node1}, []*v1.Node{})
+	assert.Equal(t, []*v1.Node{node1}, result)
+}

--- a/internal/executor/util/pod_util.go
+++ b/internal/executor/util/pod_util.go
@@ -218,6 +218,17 @@ func FindLastContainerStartTime(pod *v1.Pod) time.Time {
 	return startTime
 }
 
+func HasPodBeenInStateForLongerThanGivenDuration(pod *v1.Pod, duration time.Duration) bool {
+	deadline := time.Now().Add(-duration)
+	lastStatusChange, err := LastStatusChange(pod)
+
+	if err != nil {
+		log.Errorf("Problem determining last state change for pod %v: %v", pod.Name, err)
+		return false
+	}
+	return lastStatusChange.Before(deadline)
+}
+
 func maxTime(a, b time.Time) time.Time {
 	if a.After(b) {
 		return a

--- a/internal/executor/util/pod_util_test.go
+++ b/internal/executor/util/pod_util_test.go
@@ -614,3 +614,45 @@ func TestCountPodsByPhase_HandlesEmpty(t *testing.T) {
 	result := CountPodsByPhase([]*v1.Pod{})
 	assert.Equal(t, result, map[string]uint32{})
 }
+
+func TestHasPodBeenInStateForLongerThanGivenDuration_ReturnsTrue(t *testing.T) {
+	now := time.Now()
+	sixSecondsAgo := now.Add(-6 * time.Second)
+
+	pod := v1.Pod{
+		Status: v1.PodStatus{
+			Conditions: []v1.PodCondition{{LastTransitionTime: metav1.NewTime(sixSecondsAgo)}},
+		},
+	}
+
+	result := HasPodBeenInStateForLongerThanGivenDuration(&pod, 5*time.Second)
+
+	assert.True(t, result)
+}
+
+func TestHasPodBeenInStateForLongerThanGivenDuration_ReturnsFalse(t *testing.T) {
+	now := time.Now()
+	threeSecondsAgo := now.Add(-3 * time.Second)
+
+	pod := v1.Pod{
+		Status: v1.PodStatus{
+			Conditions: []v1.PodCondition{{LastTransitionTime: metav1.NewTime(threeSecondsAgo)}},
+		},
+	}
+
+	result := HasPodBeenInStateForLongerThanGivenDuration(&pod, 5*time.Second)
+
+	assert.False(t, result)
+}
+
+func TestHasPodBeenInStateForLongerThanGivenDuration_ReturnsFalse_WhenNoPodStateChangesCanBeFound(t *testing.T) {
+	pod := v1.Pod{
+		Status: v1.PodStatus{
+			Conditions: []v1.PodCondition{},
+		},
+	}
+
+	result := HasPodBeenInStateForLongerThanGivenDuration(&pod, 5*time.Second)
+
+	assert.False(t, result)
+}

--- a/internal/executor/utilisation/cluster_utilisation_test.go
+++ b/internal/executor/utilisation/cluster_utilisation_test.go
@@ -10,60 +10,8 @@ import (
 
 	"github.com/G-Research/armada/internal/common"
 	util2 "github.com/G-Research/armada/internal/common/util"
-	"github.com/G-Research/armada/internal/executor/configuration"
 	"github.com/G-Research/armada/internal/executor/domain"
-	fakeContext "github.com/G-Research/armada/internal/executor/fake/context"
 )
-
-var testAppConfig = configuration.ApplicationConfiguration{ClusterId: "test", Pool: "pool"}
-
-func TestFilterAvailableProcessingNodes(t *testing.T) {
-	context := fakeContext.NewFakeClusterContext(testAppConfig, nil)
-	service := NewClusterUtilisationService(context, nil, nil, nil, nil, nil)
-
-	node := v1.Node{
-		Spec: v1.NodeSpec{
-			Unschedulable: false,
-			Taints:        nil,
-		},
-	}
-
-	result := service.isAvailableProcessingNode(&node)
-	assert.True(t, result, 1)
-}
-
-func TestIsAvailableProcessingNode_IsFalse_UnschedulableNode(t *testing.T) {
-	context := fakeContext.NewFakeClusterContext(testAppConfig, nil)
-	service := NewClusterUtilisationService(context, nil, nil, nil, nil, nil)
-
-	node := v1.Node{
-		Spec: v1.NodeSpec{
-			Unschedulable: true,
-			Taints:        nil,
-		},
-	}
-
-	result := service.isAvailableProcessingNode(&node)
-	assert.False(t, result)
-}
-
-func TestFilterAvailableProcessingNodes_IsFailse_NodeWithNoScheduleTaint(t *testing.T) {
-	context := fakeContext.NewFakeClusterContext(testAppConfig, nil)
-	service := NewClusterUtilisationService(context, nil, nil, nil, nil, nil)
-
-	taint := v1.Taint{
-		Effect: v1.TaintEffectNoSchedule,
-	}
-	node := v1.Node{
-		Spec: v1.NodeSpec{
-			Unschedulable: false,
-			Taints:        []v1.Taint{taint},
-		},
-	}
-
-	result := service.isAvailableProcessingNode(&node)
-	assert.False(t, result)
-}
 
 func TestGetAllPodsUsingResourceOnProcessingNodes_ShouldExcludePodsNotOnGivenNodes(t *testing.T) {
 	presentNodeName := "Node1"

--- a/internal/executor/utilisation/pod_utilisation.go
+++ b/internal/executor/utilisation/pod_utilisation.go
@@ -4,7 +4,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/G-Research/armada/internal/executor/node"
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -14,6 +13,7 @@ import (
 	commonUtil "github.com/G-Research/armada/internal/common/util"
 	"github.com/G-Research/armada/internal/executor/context"
 	"github.com/G-Research/armada/internal/executor/domain"
+	"github.com/G-Research/armada/internal/executor/node"
 	"github.com/G-Research/armada/internal/executor/util"
 )
 

--- a/internal/executor/utilisation/pod_utilisation_test.go
+++ b/internal/executor/utilisation/pod_utilisation_test.go
@@ -1,0 +1,125 @@
+package utilisation
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	util2 "github.com/G-Research/armada/internal/common/util"
+	"github.com/G-Research/armada/internal/executor/domain"
+)
+
+func TestGetNodesHostingActiveManagedPods(t *testing.T) {
+	node1 := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}
+	pendingPod := createPod(v1.PodPending, node1.Name, true)
+	runningPod := createPod(v1.PodRunning, node1.Name, true)
+
+	result := getNodesHostingActiveManagedPods([]*v1.Pod{pendingPod}, []*v1.Node{node1})
+	assert.Equal(t, []*v1.Node{node1}, result)
+
+	result = getNodesHostingActiveManagedPods([]*v1.Pod{runningPod}, []*v1.Node{node1})
+	assert.Equal(t, []*v1.Node{node1}, result)
+}
+
+func TestGetNodesHostingActiveManagedPods_IgnoresUnmanagedPods(t *testing.T) {
+	node1 := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}
+	pod1 := createPod(v1.PodRunning, node1.Name, false)
+
+	result := getNodesHostingActiveManagedPods([]*v1.Pod{pod1}, []*v1.Node{node1})
+	assert.Equal(t, []*v1.Node{}, result)
+}
+
+func TestGetNodesHostingActiveManagedPods_IgnoresPodsNotPresentOnGivenNode(t *testing.T) {
+	node1 := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}
+	pod1 := createPod(v1.PodRunning, "node2", true)
+
+	result := getNodesHostingActiveManagedPods([]*v1.Pod{pod1}, []*v1.Node{node1})
+	assert.Equal(t, []*v1.Node{}, result)
+}
+
+func TestGetNodesHostingActiveManagedPods_HandlesTerminatedPods(t *testing.T) {
+	node1 := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}
+	now := metav1.NewTime(time.Now())
+
+	recentlyDeletedPod := createPod(v1.PodRunning, node1.Name, true)
+	recentlyDeletedPod.DeletionTimestamp = &now
+	result := getNodesHostingActiveManagedPods([]*v1.Pod{recentlyDeletedPod}, []*v1.Node{node1})
+	assert.Equal(t, []*v1.Node{node1}, result)
+
+	olderThanGracePeriod := metav1.NewTime(time.Now().Add(-inactivePodGracePeriod).Add(-1 * time.Minute))
+	stuckInTerminatingPod := createPod(v1.PodRunning, node1.Name, true)
+	stuckInTerminatingPod.DeletionTimestamp = &olderThanGracePeriod
+	result = getNodesHostingActiveManagedPods([]*v1.Pod{stuckInTerminatingPod}, []*v1.Node{node1})
+	assert.Equal(t, []*v1.Node{}, result)
+}
+
+func TestGetNodesHostingActiveManagedPods_HandlesTerminatingPods(t *testing.T) {
+	node1 := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}
+
+	recentlySucceededPod := createPod(v1.PodSucceeded, node1.Name, true)
+	recentlySucceededPod.Status.Conditions = []v1.PodCondition{{LastTransitionTime: metav1.NewTime(time.Now())}}
+	result := getNodesHostingActiveManagedPods([]*v1.Pod{recentlySucceededPod}, []*v1.Node{node1})
+	assert.Equal(t, []*v1.Node{node1}, result)
+
+	olderThanGracePeriod := metav1.NewTime(time.Now().Add(-inactivePodGracePeriod).Add(-1 * time.Minute))
+	oldSucceededPod := createPod(v1.PodSucceeded, node1.Name, true)
+	oldSucceededPod.Status.Conditions = []v1.PodCondition{{LastTransitionTime: olderThanGracePeriod}}
+	result = getNodesHostingActiveManagedPods([]*v1.Pod{oldSucceededPod}, []*v1.Node{node1})
+	assert.Equal(t, []*v1.Node{}, result)
+
+	unknownAgeSucceededPod := createPod(v1.PodSucceeded, node1.Name, true)
+	result = getNodesHostingActiveManagedPods([]*v1.Pod{unknownAgeSucceededPod}, []*v1.Node{node1})
+	assert.Equal(t, []*v1.Node{}, result)
+
+	recentlyFailedPod := createPod(v1.PodFailed, node1.Name, true)
+	recentlyFailedPod.Status.Conditions = []v1.PodCondition{{LastTransitionTime: metav1.NewTime(time.Now())}}
+	result = getNodesHostingActiveManagedPods([]*v1.Pod{recentlyFailedPod}, []*v1.Node{node1})
+	assert.Equal(t, []*v1.Node{node1}, result)
+
+	olderThanGracePeriod = metav1.NewTime(time.Now().Add(-inactivePodGracePeriod).Add(-1 * time.Minute))
+	oldFailedPod := createPod(v1.PodFailed, node1.Name, true)
+	oldFailedPod.Status.Conditions = []v1.PodCondition{{LastTransitionTime: olderThanGracePeriod}}
+	result = getNodesHostingActiveManagedPods([]*v1.Pod{oldFailedPod}, []*v1.Node{node1})
+	assert.Equal(t, []*v1.Node{}, result)
+
+	unknownAgeFailedPod := createPod(v1.PodFailed, node1.Name, true)
+	result = getNodesHostingActiveManagedPods([]*v1.Pod{unknownAgeFailedPod}, []*v1.Node{node1})
+	assert.Equal(t, []*v1.Node{}, result)
+}
+
+func TestGetNodesHostingActiveManagedPods_HandlesEmptyInputs(t *testing.T) {
+	node1 := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}
+	pod1 := createPod(v1.PodRunning, node1.Name, true)
+
+	result := getNodesHostingActiveManagedPods([]*v1.Pod{}, []*v1.Node{})
+	assert.Equal(t, []*v1.Node{}, result)
+
+	result = getNodesHostingActiveManagedPods([]*v1.Pod{pod1}, []*v1.Node{})
+	assert.Equal(t, []*v1.Node{}, result)
+
+	result = getNodesHostingActiveManagedPods([]*v1.Pod{}, []*v1.Node{node1})
+	assert.Equal(t, []*v1.Node{}, result)
+}
+
+func createPod(phase v1.PodPhase, nodeName string, isManaged bool) *v1.Pod {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "name" + util2.NewULID(),
+		},
+		Status: v1.PodStatus{
+			Phase: phase,
+		},
+		Spec: v1.PodSpec{
+			NodeName: nodeName,
+		},
+	}
+	if isManaged {
+		pod.Labels = map[string]string{
+			domain.JobId: "jobid" + util2.NewULID(),
+		}
+	}
+	return pod
+}


### PR DESCRIPTION
No longer scraping nodes that don't allow armada pods + don't have any active armada pods on them
  - This rules out masters, untolerated tainted nodes, failed nodes

This just reduces the work Armada has to do on clusters where is only gets a small subset of the nodes