### PR TITLE
Armada server: Job Repo: UpdatePriority to more general UpdateJobs

### DIFF
--- a/internal/armada/repository/job.go
+++ b/internal/armada/repository/job.go
@@ -549,7 +549,7 @@ func (repo *RedisJobRepository) updateJobs(ids []string, mutator func(*api.Job),
 	result := map[string]string{}
 
 	for _, batch := range batchedIds {
-		batchResult, err := repo.updateJobBatchsWithRetry(batch, mutator, retries, retryDelay)
+		batchResult, err := repo.updateJobBatchWithRetry(batch, mutator, retries, retryDelay)
 		if err == nil {
 			result = util.MergeMaps(result, batchResult)
 		} else {
@@ -561,7 +561,7 @@ func (repo *RedisJobRepository) updateJobs(ids []string, mutator func(*api.Job),
 	return result, nil
 }
 
-func (repo *RedisJobRepository) updateJobBatchsWithRetry(ids []string, mutator func(*api.Job), retries int, retryDelay time.Duration) (map[string]string, error) {
+func (repo *RedisJobRepository) updateJobBatchWithRetry(ids []string, mutator func(*api.Job), retries int, retryDelay time.Duration) (map[string]string, error) {
 	for retry := 0; ; retry++ {
 		result, err := repo.updateJobBatch(ids, mutator)
 		if err != redis.TxFailedErr {

--- a/internal/armada/server/lease_test.go
+++ b/internal/armada/server/lease_test.go
@@ -255,7 +255,7 @@ func (repo *mockJobRepository) UpdateStartTime(jobId string, clusterId string, s
 	return nil
 }
 
-func (repo *mockJobRepository) UpdatePriority(jobs []*api.Job, priority float64) (map[string]string, error) {
+func (repo *mockJobRepository) UpdateJobs(ids []string, mutator func(*api.Job)) (map[string]string, error) {
 	return nil, nil
 }
 

--- a/internal/armada/server/submit.go
+++ b/internal/armada/server/submit.go
@@ -305,7 +305,15 @@ func (server *SubmitServer) reprioritizeJobs(principal authorization.Principal, 
 		return nil, err
 	}
 
-	results, err := server.jobRepository.UpdatePriority(jobs, request.NewPriority)
+	jobIds := []string{}
+	for _, job := range jobs {
+		jobIds = append(jobIds, job.Id)
+	}
+
+	results, err := server.jobRepository.UpdateJobs(jobIds, func(job *api.Job) {
+		job.Priority = request.NewPriority
+	})
+
 	if err != nil {
 		return nil, err
 	}

--- a/internal/common/util/batch.go
+++ b/internal/common/util/batch.go
@@ -1,0 +1,18 @@
+package util
+
+func Batch(elements []string, batchSize int) [][]string {
+	var batch []string
+	batchIdx := 0
+	result := [][]string{}
+	for i, e := range elements {
+		if batch == nil || batchIdx >= len(batch) {
+			batch = make([]string, Min(batchSize, len(elements)-i))
+			result = append(result, batch)
+			batchIdx = 0
+		}
+
+		batch[batchIdx] = e
+		batchIdx++
+	}
+	return result
+}

--- a/internal/common/util/batch_test.go
+++ b/internal/common/util/batch_test.go
@@ -1,0 +1,18 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBatch(t *testing.T) {
+	assert.Equal(t, [][]string{}, Batch([]string{}, 1))
+	assert.Equal(t, [][]string{{"a"}}, Batch([]string{"a"}, 1))
+	assert.Equal(t, [][]string{{"a"}}, Batch([]string{"a"}, 10))
+	assert.Equal(t, [][]string{{"a"}, {"b"}}, Batch([]string{"a", "b"}, 1))
+	assert.Equal(t, [][]string{{"a", "b"}}, Batch([]string{"a", "b"}, 2))
+	assert.Equal(t, [][]string{{"a", "b"}}, Batch([]string{"a", "b"}, 3))
+	assert.Equal(t, [][]string{{"a", "b", "c"}, {"d", "e"}}, Batch([]string{"a", "b", "c", "d", "e"}, 3))
+	assert.Equal(t, [][]string{{"a", "b", "c"}, {"d", "e", "f"}}, Batch([]string{"a", "b", "c", "d", "e", "f"}, 3))
+}

--- a/internal/common/util/math.go
+++ b/internal/common/util/math.go
@@ -1,0 +1,8 @@
+package util
+
+func Min(a, b int) int {
+	if b < a {
+		return b
+	}
+	return a
+}

--- a/internal/common/util/math_test.go
+++ b/internal/common/util/math_test.go
@@ -1,0 +1,13 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMin(t *testing.T) {
+	assert.Equal(t, 2, Min(2, 3))
+	assert.Equal(t, 2, Min(3, 2))
+	assert.Equal(t, 2, Min(2, 2))
+}

--- a/internal/common/validation/podspec_test.go
+++ b/internal/common/validation/podspec_test.go
@@ -131,9 +131,9 @@ func Test_ValidatePodSpec_WhenValidRequiredAffinitySet_Succeeds(t *testing.T) {
 	assert.Nil(t, ValidatePodSpec(podSpec))
 }
 
-func Test_ValidatePodSpec_WhenInValidRequiredAffinitySet_Fails(t *testing.T) {
+func Test_ValidatePodSpec_WhenInvalidRequiredAffinitySet_Fails(t *testing.T) {
 
-	inValidNodeSelector := &v1.NodeSelector{
+	invalidNodeSelector := &v1.NodeSelector{
 		NodeSelectorTerms: []v1.NodeSelectorTerm{
 			{
 				MatchExpressions: []v1.NodeSelectorRequirement{
@@ -150,7 +150,7 @@ func Test_ValidatePodSpec_WhenInValidRequiredAffinitySet_Fails(t *testing.T) {
 	podSpec := minimalValidPodSpec()
 	podSpec.Affinity = &v1.Affinity{
 		NodeAffinity: &v1.NodeAffinity{
-			RequiredDuringSchedulingIgnoredDuringExecution: inValidNodeSelector,
+			RequiredDuringSchedulingIgnoredDuringExecution: invalidNodeSelector,
 		},
 	}
 


### PR DESCRIPTION
Replace UpdatePriority with more general UpdateJobs which

1) Lets you update anything, not just priority
2) Uses batching plus WATCH/EXEC/MULTI with retry on optimistic locking failure

Immediate need for more general job updating: to enable adding NotIn node affinity to failed jobs to prevent retry on same node. This will be done in a separate PR.
