### PR TITLE
Fix release build

### DIFF
--- a/makefile
+++ b/makefile
@@ -21,7 +21,8 @@ build-binoculars:
 	$(gobuild) -o ./bin/binoculars cmd/binoculars/main.go
 
 build-armadactl-multiplatform:
-	go run github.com/mitchellh/gox -output="./bin/{{.OS}}-{{.Arch}}/armadactl" -arch="amd64" -os="windows linux darwin" ./cmd/armadactl/
+	go install github.com/mitchellh/gox@v1.0.1
+	${GOPATH}/bin/gox -output="./bin/{{.OS}}-{{.Arch}}/armadactl" -arch="amd64" -os="windows linux darwin" ./cmd/armadactl/
 
 ifndef RELEASE_VERSION
 override RELEASE_VERSION = UNKNOWN_VERSION


### PR DESCRIPTION
Currently `build-armadactl-multiplatform` relies on `github.com/mitchellh/gox` being present on the machine

This used to be the case as `github.com/mitchellh/gox` was in the dependencies for the project (go.sum)

However as `github.com/mitchellh/gox` isn't used by the project, it gets removed by `go mod tidy`

Now just making `build-armadactl-multiplatform` go install `github.com/mitchellh/gox@v1.0.1` before it uses it

Alterative ideas:
 - Add it back to go.mod with a comment to make sure people don't remove it
 - Add it back to go.mod and add some fake usage of it in source code, so it is "used" and go mod tidy doesn't remove it