### PR TITLE
Make job object retention period configurable

### DIFF
--- a/config/armada/config.yaml
+++ b/config/armada/config.yaml
@@ -34,6 +34,8 @@ queueManagement:
 eventsNats:
   queueGroup: "ArmadaEventRedisProcessor"
   jobStatusGroup: "ArmadaEventJobStatusProcessor"
+databaseRetention:
+  jobRetentionDuration: 168h # Specified as a Go duration
 eventRetention:
   expiryEnabled: true
   retentionDuration: 336h # Specified as a Go duration

--- a/internal/armada/configuration/types.go
+++ b/internal/armada/configuration/types.go
@@ -23,10 +23,12 @@ type ArmadaConfig struct {
 	EventsNats       NatsConfig
 	EventsRedis      redis.UniversalOptions
 
-	Scheduling      SchedulingConfig
-	QueueManagement QueueManagementConfig
-	EventRetention  EventRetentionPolicy
-	Metrics         MetricsConfig
+	Scheduling        SchedulingConfig
+	QueueManagement   QueueManagementConfig
+	DatabaseRetention DatabaseRetentionPolicy
+	EventRetention    EventRetentionPolicy
+
+	Metrics MetricsConfig
 }
 
 type SchedulingConfig struct {
@@ -42,6 +44,10 @@ type SchedulingConfig struct {
 	MaxRetries                                uint // Maximum number of retries before a Job is failed
 	ResourceScarcity                          map[string]float64
 	PoolResourceScarcity                      map[string]map[string]float64
+}
+
+type DatabaseRetentionPolicy struct {
+	JobRetentionDuration time.Duration
 }
 
 type EventRetentionPolicy struct {

--- a/internal/armada/metrics/metrics_test.go
+++ b/internal/armada/metrics/metrics_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/G-Research/armada/internal/armada/configuration"
 	"github.com/alicebob/miniredis"
 	"github.com/go-redis/redis"
 	"github.com/stretchr/testify/assert"
@@ -187,6 +188,6 @@ func withRepository(action func(r *repository.RedisJobRepository)) {
 	defer db.Close()
 
 	redisClient := redis.NewClient(&redis.Options{Addr: db.Addr()})
-	repo := repository.NewRedisJobRepository(redisClient, nil, nil)
+	repo := repository.NewRedisJobRepository(redisClient, nil, nil, configuration.DatabaseRetentionPolicy{JobRetentionDuration: time.Hour})
 	action(repo)
 }

--- a/internal/armada/server.go
+++ b/internal/armada/server.go
@@ -36,7 +36,7 @@ func Serve(config *configuration.ArmadaConfig, healthChecks *health.MultiChecker
 	db := createRedisClient(&config.Redis)
 	eventsDb := createRedisClient(&config.EventsRedis)
 
-	jobRepository := repository.NewRedisJobRepository(db, config.Scheduling.DefaultJobLimits, config.Scheduling.DefaultJobTolerations)
+	jobRepository := repository.NewRedisJobRepository(db, config.Scheduling.DefaultJobLimits, config.Scheduling.DefaultJobTolerations, config.DatabaseRetention)
 	usageRepository := repository.NewRedisUsageRepository(db)
 	queueRepository := repository.NewRedisQueueRepository(db)
 	schedulingInfoRepository := repository.NewRedisSchedulingInfoRepository(db)

--- a/internal/armada/server/submit_test.go
+++ b/internal/armada/server/submit_test.go
@@ -548,7 +548,7 @@ func withSubmitServerAndRepos(action func(s *SubmitServer, jobRepo repository.Jo
 	// using real redis instance as miniredis does not support streams
 	client := redis.NewClient(&redis.Options{Addr: "localhost:6379", DB: 10})
 
-	jobRepo := repository.NewRedisJobRepository(client, nil, nil)
+	jobRepo := repository.NewRedisJobRepository(client, nil, nil, configuration.DatabaseRetentionPolicy{JobRetentionDuration: time.Hour})
 	queueRepo := repository.NewRedisQueueRepository(client)
 	eventRepo := repository.NewRedisEventRepository(client, configuration.EventRetentionPolicy{ExpiryEnabled: false})
 	schedulingInfoRepository := repository.NewRedisSchedulingInfoRepository(client)


### PR DESCRIPTION
Currently the job object is set to expire after 7 days and that is hardcoded

I am making it configurable so users can tone this retention down to save on redis memory usage
 - This is pretty safe as this object shouldn't really be used and is mainly kept to make sure any cleanup events that may (in special cases) happen after the job finishes complete successfully