### PR TITLE
Lookout: Report errors from UnableToSchedule events

### DIFF
--- a/internal/lookout/repository/jobs_test.go
+++ b/internal/lookout/repository/jobs_test.go
@@ -139,6 +139,7 @@ func TestGetJobs_GetMultipleRunJob(t *testing.T) {
 
 		pendingTime1 := someTime.Add(time.Second)
 		unableToScheduleTime := someTime.Add(2 * time.Second)
+		unableToScheduleReason := "unable to schedule reason"
 		pendingTime2 := someTime.Add(3 * time.Second)
 		runningTime := someTime.Add(4 * time.Second)
 		succeededTime := someTime.Add(5 * time.Second)
@@ -146,7 +147,7 @@ func TestGetJobs_GetMultipleRunJob(t *testing.T) {
 		retried := NewJobSimulator(t, jobStore).
 			CreateJobAtTime(queue, someTime).
 			PendingAtTime(cluster, k8sId1, pendingTime1).
-			UnableToScheduleAtTime(cluster, k8sId1, node, unableToScheduleTime).
+			UnableToScheduleAtTime(cluster, k8sId1, node, unableToScheduleTime, unableToScheduleReason).
 			PendingAtTime(cluster, k8sId2, pendingTime2).
 			RunningAtTime(cluster, k8sId2, node, runningTime).
 			SucceededAtTime(cluster, k8sId2, node, succeededTime)
@@ -168,6 +169,7 @@ func TestGetJobs_GetMultipleRunJob(t *testing.T) {
 			Succeeded: false,
 			Created:   &pendingTime1,
 			Finished:  &unableToScheduleTime,
+			Error:     unableToScheduleReason,
 		}, jobInfo.Runs[0])
 		AssertRunInfosEquivalent(t, &lookout.RunInfo{
 			K8SId:     k8sId2,

--- a/internal/lookout/repository/queues_test.go
+++ b/internal/lookout/repository/queues_test.go
@@ -228,25 +228,25 @@ func TestGetQueueInfos_IncludeLongestRunningJob(t *testing.T) {
 		NewJobSimulator(t, jobStore).
 			CreateJobAtTime(queue, someTime.Add(10*time.Second)).
 			PendingAtTime(cluster, "a1", someTime.Add(11*time.Second)).
-			UnableToScheduleAtTime(cluster, "a1", node, someTime.Add(12*time.Second)).
+			UnableToScheduleAtTime(cluster, "a1", node, someTime.Add(12*time.Second), "error").
 			RunningAtTime(cluster, "a2", node, someTime.Add(13*time.Second))
 
 		NewJobSimulator(t, jobStore).
 			CreateJobAtTime(queue, someTime.Add(5*time.Second)).
 			PendingAtTime(cluster, "b1", someTime.Add(6*time.Second)).
-			UnableToScheduleAtTime(cluster, "b1", node, someTime.Add(7*time.Second)).
+			UnableToScheduleAtTime(cluster, "b1", node, someTime.Add(7*time.Second), "error").
 			RunningAtTime(cluster, "b2", node, someTime.Add(8*time.Second))
 
 		longestRunning := NewJobSimulator(t, jobStore).
 			CreateJobAtTime(queue, someTime.Add(time.Second)).
 			PendingAtTime(cluster, "d1", pendingTime).
-			UnableToScheduleAtTime(cluster, "d1", node, unableToScheduleTime).
+			UnableToScheduleAtTime(cluster, "d1", node, unableToScheduleTime, "error").
 			RunningAtTime(cluster, "d2", node, runningTime)
 
 		NewJobSimulator(t, jobStore).
 			CreateJobAtTime(queue, someTime).
 			RunningAtTime(cluster, "e1", node, someTime.Add(time.Second)).
-			UnableToScheduleAtTime(cluster, "e1", node, someTime.Add(2*time.Second)).
+			UnableToScheduleAtTime(cluster, "e1", node, someTime.Add(2*time.Second), "error").
 			SucceededAtTime(cluster, "e2", node, someTime.Add(3*time.Second))
 
 		NewJobSimulator(t, jobStore).
@@ -314,19 +314,19 @@ func TestGetQueueInfos_MultipleQueues(t *testing.T) {
 		NewJobSimulator(t, jobStore).
 			CreateJobAtTime(queue, someTime.Add(5*time.Second)).
 			PendingAtTime(cluster, "b1", someTime.Add(6*time.Second)).
-			UnableToScheduleAtTime(cluster, "b1", node, someTime.Add(7*time.Second)).
+			UnableToScheduleAtTime(cluster, "b1", node, someTime.Add(7*time.Second), "error").
 			RunningAtTime(cluster, "b2", node, someTime.Add(8*time.Second))
 
 		longestRunning1 := NewJobSimulator(t, jobStore).
 			CreateJobAtTime(queue, someTime).
 			PendingAtTime(cluster, "c1", queue1PendingTime).
-			UnableToScheduleAtTime(cluster, "c1", node, queue1UnableToScheduleTime).
+			UnableToScheduleAtTime(cluster, "c1", node, queue1UnableToScheduleTime, "error").
 			RunningAtTime(cluster, "c2", node, queue1RunningTime)
 
 		NewJobSimulator(t, jobStore).
 			CreateJobAtTime(queue, someTime).
 			PendingAtTime(cluster, "d1", someTime.Add(time.Second)).
-			UnableToScheduleAtTime(cluster, "d1", node, someTime.Add(2*time.Second)).
+			UnableToScheduleAtTime(cluster, "d1", node, someTime.Add(2*time.Second), "error").
 			RunningAtTime(cluster, "d2", node, someTime.Add(3*time.Second)).
 			SucceededAtTime(cluster, "d2", node, someTime.Add(4*time.Second))
 
@@ -356,7 +356,7 @@ func TestGetQueueInfos_MultipleQueues(t *testing.T) {
 		NewJobSimulator(t, jobStore).
 			CreateJobAtTime(queue2, someTime.Add(time.Second)).
 			PendingAtTime(cluster, "h1", someTime.Add(2*time.Second)).
-			UnableToScheduleAtTime(cluster, "h1", node, someTime.Add(3*time.Second)).
+			UnableToScheduleAtTime(cluster, "h1", node, someTime.Add(3*time.Second), "error").
 			RunningAtTime(cluster, "h2", node, someTime.Add(4*time.Second))
 
 		queueInfos, err := jobRepo.GetQueueInfos(ctx)

--- a/internal/lookout/repository/store.go
+++ b/internal/lookout/repository/store.go
@@ -298,7 +298,7 @@ func (r *SQLJobStore) RecordJobFailed(event *api.JobFailedEvent) error {
 		"pod_number": event.GetPodNumber(),
 		"finished":   ToUTC(event.GetCreated()),
 		"succeeded":  false,
-		"error":      fmt.Sprintf("%.2048s", event.GetReason()),
+		"error":      truncateError(event.GetReason()),
 	}
 	if event.GetNodeName() != "" {
 		jobRunRecord["node"] = event.GetNodeName()
@@ -343,6 +343,7 @@ func (r *SQLJobStore) RecordJobUnableToSchedule(event *api.JobUnableToScheduleEv
 		"pod_number":         event.GetPodNumber(),
 		"finished":           ToUTC(event.GetCreated()),
 		"unable_to_schedule": true,
+		"error":              truncateError(event.GetReason()),
 	}
 	if event.GetNodeName() != "" {
 		jobRunRecord["node"] = event.GetNodeName()
@@ -366,7 +367,7 @@ func (r *SQLJobStore) RecordJobTerminated(event *api.JobTerminatedEvent) error {
 		"pod_number": event.GetPodNumber(),
 		"finished":   ToUTC(event.GetCreated()),
 		"succeeded":  false,
-		"error":      event.Reason,
+		"error":      truncateError(event.GetReason()),
 	}
 
 	tx, err := r.db.Begin()
@@ -530,4 +531,8 @@ func getRunStateCounts(tx *goqu.TxDatabase, jobId string) *goqu.SelectDataset {
 // Avoid interpolating states
 func stateAsLiteral(state JobState) exp.LiteralExpression {
 	return goqu.L(fmt.Sprintf("%d", JobStateToIntMap[state]))
+}
+
+func truncateError(err string) string {
+	return fmt.Sprintf("%.2048s", err)
 }

--- a/internal/lookout/repository/utils_test.go
+++ b/internal/lookout/repository/utils_test.go
@@ -234,17 +234,17 @@ func (js *JobSimulator) CancelledAtTime(time time.Time) *JobSimulator {
 }
 
 func (js *JobSimulator) UnableToSchedule(cluster string, k8sId string, node string) *JobSimulator {
-	return js.UnableToScheduleAtTime(cluster, k8sId, node, time.Now())
+	return js.UnableToScheduleAtTime(cluster, k8sId, node, time.Now(), "unable to schedule reason")
 }
 
-func (js *JobSimulator) UnableToScheduleAtTime(cluster string, k8sId string, node string, time time.Time) *JobSimulator {
+func (js *JobSimulator) UnableToScheduleAtTime(cluster string, k8sId string, node string, time time.Time, reason string) *JobSimulator {
 	unableToScheduleEvent := &api.JobUnableToScheduleEvent{
 		JobId:        js.job.Id,
 		JobSetId:     js.job.JobSetId,
 		Queue:        js.job.Queue,
 		Created:      time,
 		ClusterId:    cluster,
-		Reason:       "unable to schedule reason",
+		Reason:       reason,
 		KubernetesId: k8sId,
 		NodeName:     node,
 	}


### PR DESCRIPTION
UnableToSchedule events contain a lot of useful info when pod startup fails. However this is currently not written to the lookout db. Probably just a straightforward mistake, this PR fixes it.