### PR TITLE
[issue-764] Queue name should be passed as argument in queue commands

### DIFF
--- a/cmd/armadactl/cmd/queue/create.go
+++ b/cmd/armadactl/cmd/queue/create.go
@@ -10,16 +10,13 @@ import (
 
 func Create() *cobra.Command {
 	command := &cobra.Command{
-		Use:   "queue",
+		Use:   "queue <queue_name>",
 		Short: "Create new queue",
 		Long: "Every job submitted to armada needs to be associated with queue." +
 			"\nJob priority is evaluated inside queue, queue has its own priority.",
 		SilenceUsage: true,
+		Args:         validateQueueName,
 	}
-
-	command.Flags().SortFlags = false
-	command.Flags().StringP("queueName", "n", "", "Queue name")
-	command.MarkFlagRequired("queueName")
 
 	command.Flags().Float64("priorityFactor", 1, "Set queue priority factor - lower number makes queue more important, must be > 0.")
 	command.Flags().StringSlice("owners", []string{}, "Comma separated list of queue owners, defaults to current user.")
@@ -29,10 +26,7 @@ func Create() *cobra.Command {
 	)
 
 	command.RunE = func(cmd *cobra.Command, args []string) error {
-		queueName, err := cmd.Flags().GetString("queueName")
-		if err != nil {
-			return fmt.Errorf("failed to retrieve name value: %s", err)
-		}
+		queueName := args[0]
 
 		priority, err := cmd.Flags().GetFloat64("priorityFactor")
 		if err != nil {

--- a/cmd/armadactl/cmd/queue/delete.go
+++ b/cmd/armadactl/cmd/queue/delete.go
@@ -10,21 +10,15 @@ import (
 
 func Delete() *cobra.Command {
 	command := &cobra.Command{
-		Use:          "queue",
+		Use:          "queue <queue_name>",
 		Short:        "Delete existing queue",
 		Long:         "Deletes queue if it exists, the queue needs to be empty at the time of deletion.",
 		SilenceUsage: true,
+		Args:         validateQueueName,
 	}
 
-	command.Flags().SortFlags = false
-	command.Flags().StringP("queueName", "n", "", "[required] Queue's name that will be deleted")
-	command.MarkFlagRequired("queueName")
-
 	command.RunE = func(cmd *cobra.Command, args []string) error {
-		queueName, err := cmd.Flags().GetString("queueName")
-		if err != nil {
-			return fmt.Errorf("failed to retrieve name value: %s", err)
-		}
+		queueName := args[0]
 
 		apiConnectionDetails := client.ExtractCommandlineArmadaApiConnectionDetails()
 

--- a/cmd/armadactl/cmd/queue/describe.go
+++ b/cmd/armadactl/cmd/queue/describe.go
@@ -14,20 +14,14 @@ import (
 
 func Describe() *cobra.Command {
 	command := &cobra.Command{
-		Use:   "queue",
+		Use:   "queue <queue_name>",
 		Short: "Prints out queue info.",
 		Long:  "Prints out queue info including all jobs sets where jobs are running or queued.",
+		Args:  validateQueueName,
 	}
 
-	command.Flags().SortFlags = false
-	command.Flags().StringP("queueName", "n", "", "Queue name")
-	command.MarkFlagRequired("queueName")
-
 	command.RunE = func(cmd *cobra.Command, args []string) error {
-		queueName, err := cmd.Flags().GetString("queueName")
-		if err != nil {
-			return fmt.Errorf("failed to retrieve name value: %s", err)
-		}
+		queueName := args[0]
 
 		apiConnectionDetails := client.ExtractCommandlineArmadaApiConnectionDetails()
 		conn, err := client.CreateApiConnection(apiConnectionDetails)

--- a/cmd/armadactl/cmd/queue/update.go
+++ b/cmd/armadactl/cmd/queue/update.go
@@ -10,14 +10,11 @@ import (
 
 func Update() *cobra.Command {
 	command := &cobra.Command{
-		Use:   "queue",
+		Use:   "queue <queue_name>",
 		Short: "Update existing queue",
 		Long:  "Update settings of existing queue",
+		Args:  validateQueueName,
 	}
-
-	command.Flags().SortFlags = false
-	command.Flags().StringP("queueName", "n", "", "Queue name")
-	command.MarkFlagRequired("queueName")
 
 	command.Flags().Float64("priorityFactor", 1, "Set queue priority factor - lower number makes queue more important, must be > 0.")
 	command.Flags().StringSlice("owners", []string{}, "Comma separated list of queue owners, defaults to current user.")
@@ -27,10 +24,7 @@ func Update() *cobra.Command {
 	)
 
 	command.RunE = func(cmd *cobra.Command, args []string) error {
-		queueName, err := cmd.Flags().GetString("queueName")
-		if err != nil {
-			return fmt.Errorf("failed to retrieve name value: %s", err)
-		}
+		queueName := args[0]
 
 		priority, err := cmd.Flags().GetFloat64("priorityFactor")
 		if err != nil {

--- a/cmd/armadactl/cmd/queue/util.go
+++ b/cmd/armadactl/cmd/queue/util.go
@@ -3,6 +3,8 @@ package queue
 import (
 	"fmt"
 	"strconv"
+
+	"github.com/spf13/cobra"
 )
 
 type FlagGetStringToString func(string) (map[string]string, error)
@@ -23,4 +25,15 @@ func (f FlagGetStringToString) ToFloat64(flagName string) (map[string]float64, e
 	}
 
 	return result, nil
+}
+
+func validateQueueName(cmd *cobra.Command, args []string) error {
+	switch n := len(args); {
+	case n == 0:
+		return fmt.Errorf("must provide <queue_name>")
+	case n != 1:
+		return fmt.Errorf("accepts only one argument for <queue_name>")
+	default:
+		return nil
+	}
 }


### PR DESCRIPTION
[Problem]

Queue commands:
    create queue --queueName
    delete queue --queueName
    update queue --queueName
    describe queue --queueName

These command should be in line with kubectl.
Queue name should be passed as an argument instead of flag value.

[Solution]
Remove queueName flag
Add argument validation function to validate input args

Close #764