### PR TITLE
Fix goimports in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,8 +122,8 @@ jobs:
           name: Check Go formatting
           command: |
             go install golang.org/x/tools/cmd/goimports@v0.1.1
-            goimports -l -local "github.com/G-Research/armada"
-            exit $(goimports -l -local "github.com/G-Research/armada" | wc -l)
+            goimports -l -local "github.com/G-Research/armada" .
+            exit $(goimports -l -local "github.com/G-Research/armada" . | wc -l)
 
       - run:
           name: ineffassign

--- a/cmd/armadactl/cmd/commands.go
+++ b/cmd/armadactl/cmd/commands.go
@@ -1,8 +1,9 @@
 package cmd
 
 import (
-	"github.com/G-Research/armada/cmd/armadactl/cmd/queue"
 	"github.com/spf13/cobra"
+
+	"github.com/G-Research/armada/cmd/armadactl/cmd/queue"
 )
 
 func init() {

--- a/cmd/armadactl/cmd/queue/create.go
+++ b/cmd/armadactl/cmd/queue/create.go
@@ -3,9 +3,10 @@ package queue
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/G-Research/armada/pkg/api"
 	"github.com/G-Research/armada/pkg/client"
-	"github.com/spf13/cobra"
 )
 
 func Create() *cobra.Command {

--- a/cmd/armadactl/cmd/queue/delete.go
+++ b/cmd/armadactl/cmd/queue/delete.go
@@ -3,9 +3,10 @@ package queue
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/G-Research/armada/pkg/api"
 	"github.com/G-Research/armada/pkg/client"
-	"github.com/spf13/cobra"
 )
 
 func Delete() *cobra.Command {

--- a/cmd/armadactl/cmd/queue/update.go
+++ b/cmd/armadactl/cmd/queue/update.go
@@ -3,9 +3,10 @@ package queue
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/G-Research/armada/pkg/api"
 	"github.com/G-Research/armada/pkg/client"
-	"github.com/spf13/cobra"
 )
 
 func Update() *cobra.Command {

--- a/internal/armada/metrics/metrics_test.go
+++ b/internal/armada/metrics/metrics_test.go
@@ -1,18 +1,18 @@
 package metrics
 
 import (
-	"github.com/G-Research/armada/internal/common/util"
 	"testing"
 	"time"
 
-	"github.com/G-Research/armada/internal/armada/configuration"
 	"github.com/alicebob/miniredis"
 	"github.com/go-redis/redis"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
+	"github.com/G-Research/armada/internal/armada/configuration"
 	"github.com/G-Research/armada/internal/armada/repository"
+	"github.com/G-Research/armada/internal/common/util"
 	"github.com/G-Research/armada/pkg/api"
 )
 

--- a/internal/armada/repository/job.go
+++ b/internal/armada/repository/job.go
@@ -6,12 +6,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/G-Research/armada/internal/armada/configuration"
-	"github.com/G-Research/armada/internal/common/util"
-	"github.com/G-Research/armada/pkg/api"
 	"github.com/go-redis/redis"
 	"github.com/gogo/protobuf/proto"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/G-Research/armada/internal/armada/configuration"
+	"github.com/G-Research/armada/internal/common/util"
+	"github.com/G-Research/armada/pkg/api"
 )
 
 const jobObjectPrefix = "Job:"             // {jobId}            - job protobuf object

--- a/internal/armada/repository/job_test.go
+++ b/internal/armada/repository/job_test.go
@@ -5,12 +5,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/G-Research/armada/internal/armada/configuration"
 	"github.com/go-redis/redis"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
+	"github.com/G-Research/armada/internal/armada/configuration"
 	"github.com/G-Research/armada/internal/common/util"
 	"github.com/G-Research/armada/pkg/api"
 )

--- a/internal/armada/server/avoid_node_affinity_test.go
+++ b/internal/armada/server/avoid_node_affinity_test.go
@@ -4,9 +4,10 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/G-Research/armada/pkg/api"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
+
+	"github.com/G-Research/armada/pkg/api"
 )
 
 func Test_addAvoidNodeAffinity_WhenCanBeScheduled_AddsAffinities(t *testing.T) {

--- a/internal/armada/server/submit.go
+++ b/internal/armada/server/submit.go
@@ -3,23 +3,24 @@ package server
 import (
 	"context"
 	"fmt"
-	"github.com/G-Research/armada/internal/common"
-	"github.com/G-Research/armada/internal/common/util"
-	"github.com/G-Research/armada/internal/common/validation"
+	"strings"
+	"time"
+
 	"github.com/gogo/protobuf/types"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"strings"
-	"time"
 
 	"github.com/G-Research/armada/internal/armada/configuration"
 	"github.com/G-Research/armada/internal/armada/permissions"
 	"github.com/G-Research/armada/internal/armada/repository"
+	"github.com/G-Research/armada/internal/common"
 	"github.com/G-Research/armada/internal/common/auth/authorization"
 	"github.com/G-Research/armada/internal/common/auth/permission"
+	"github.com/G-Research/armada/internal/common/util"
+	"github.com/G-Research/armada/internal/common/validation"
 	"github.com/G-Research/armada/pkg/api"
 )
 

--- a/internal/executor/application_test.go
+++ b/internal/executor/application_test.go
@@ -3,8 +3,9 @@ package executor
 import (
 	"testing"
 
-	"github.com/G-Research/armada/internal/executor/configuration"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/G-Research/armada/internal/executor/configuration"
 )
 
 func Test_ValidateConfig_When_AvoidNodeLabelsOnRetry_MissingFrom_TrackedNodeLabels_Fails(t *testing.T) {

--- a/internal/executor/service/job_lease_test.go
+++ b/internal/executor/service/job_lease_test.go
@@ -3,12 +3,12 @@ package service
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/G-Research/armada/internal/executor/configuration"
 	fakeContext "github.com/G-Research/armada/internal/executor/fake/context"
 	"github.com/G-Research/armada/pkg/api"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestJobLease_GetAvoidNodeLabels_EverythingSetUpCorrectly_ReturnsLabels(t *testing.T) {


### PR DESCRIPTION
`goimports` wasn't actually running in CircleCI, fixed it and reformatted files.