### PR TITLE
Improve error visibility of go format job on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ jobs:
           name: Check Go formatting
           command: |
             go install golang.org/x/tools/cmd/goimports@v0.1.1
-            goimports -l -local "github.com/G-Research/armada" .
+            goimports -d -local "github.com/G-Research/armada" .
             exit $(goimports -l -local "github.com/G-Research/armada" . | wc -l)
 
       - run:


### PR DESCRIPTION
[Problem]
command:

```
goimports -l -local "github.com/G-Research/armada" .
```

Only list the files that have an issue but doesn't print what the actual
issues are.

[Solution]

Replace -l flag with -d flag

```
goimports -d -local "github.com/G-Research/armada" .
```