### PR TITLE
Insert build variables into and add version command to `armadactl`

### DIFF
--- a/cmd/armadactl/build/build.go
+++ b/cmd/armadactl/build/build.go
@@ -1,0 +1,9 @@
+package build
+
+var BuildTime string
+
+var GitCommit string
+
+var ReleaseVersion string
+
+var GoVersion string

--- a/cmd/armadactl/cmd/version.go
+++ b/cmd/armadactl/cmd/version.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/G-Research/armada/cmd/armadactl/build"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print client version information",
+	Run: func(cmd *cobra.Command, args []string) {
+		w := tabwriter.NewWriter(os.Stdout, 1, 1, 1, ' ', 0)
+		fmt.Fprintf(w, "Version:\t%s\n", build.ReleaseVersion)
+		fmt.Fprintf(w, "Commit:\t%s\n", build.GitCommit)
+		fmt.Fprintf(w, "Go version:\t%s\n", build.GoVersion)
+		fmt.Fprintf(w, "Built:\t%s\n", build.BuildTime)
+		w.Flush()
+	},
+}

--- a/cmd/armadactl/cmd/version.go
+++ b/cmd/armadactl/cmd/version.go
@@ -5,8 +5,9 @@ import (
 	"os"
 	"text/tabwriter"
 
-	"github.com/G-Research/armada/cmd/armadactl/build"
 	"github.com/spf13/cobra"
+
+	"github.com/G-Research/armada/cmd/armadactl/build"
 )
 
 func init() {

--- a/makefile
+++ b/makefile
@@ -30,7 +30,7 @@ GO_VERSION = $(strip $(subst go version,,$(shell go version)))
 # Get most recent git commit (to insert into go build)
 GIT_COMMIT := $(shell git rev-list --abbrev-commit -1 HEAD)
 
-# The RELEASE_VERSION environment variable is set by circleci (to sert into go build and output filenames)
+# The RELEASE_VERSION environment variable is set by circleci (to insert into go build and output filenames)
 ifndef RELEASE_VERSION
 override RELEASE_VERSION = UNKNOWN_VERSION
 endif


### PR DESCRIPTION
Insert build variables (release version, git commit, go version, current date and time) into `go build` when building `armadactl`. This is done using linker flags; see [this](https://blog.alexellis.io/inject-build-time-vars-golang/). These variables are stored in a new sub-package of `armadactl` and can be printed with a new `version` command of `armadactl`. Designed to resemble the `docker version` command.

Example:
```bash
> ./armadactl version
Version:    UNKNOWN_VERSION
Go version: go1.17.2 windows/amd64
Commit:     b50144f
Built:      18 November 2021 12:18:47
```

Version is set to `UNKNOWN_VERSION` if the `RELEASE_VERSION` environment variable (which is set by circleci, see [here](https://github.com/G-Research/armada/blob/master/.circleci/config.yml)) is missing.

In addition, this PR adds some checks to the `makefile` to ensure that necessary executables are available before trying to build.