### PR TITLE
Added internal/fileutils package

### DIFF
--- a/internal/fileutils/fileutils.go
+++ b/internal/fileutils/fileutils.go
@@ -1,0 +1,55 @@
+package fileutils
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+)
+
+// IsFileOrDirectory returns true if path points to an existing file or directory
+// and false otherwise. Errors not satisfying errors.Is(err, fs.ErrNotExist) are
+// passed on to the caller.
+func IsFileOrDirectory(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		return false, nil
+	}
+	return false, err
+}
+
+// IsFile returns true if path points to an existing file
+// and false otherwise. Errors not satisfying errors.Is(err, fs.ErrNotExist) are
+// passed on to the caller.
+func IsFile(path string) (bool, error) {
+	fileInfo, err := os.Stat(path)
+	if err == nil {
+		if fileInfo.IsDir() {
+			return false, nil
+		}
+		return true, nil
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		return false, nil
+	}
+	return false, err
+}
+
+// IsDirectory returns true if path points to an existing directory
+// and false otherwise. Errors not satisfying errors.Is(err, fs.ErrNotExist) are
+// passed on to the caller.
+func IsDirectory(path string) (bool, error) {
+	fileInfo, err := os.Stat(path)
+	if err == nil {
+		if fileInfo.IsDir() {
+			return true, nil
+		}
+		return false, nil
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		return false, nil
+	}
+	return false, err
+}

--- a/internal/fileutils/fileutils_test.go
+++ b/internal/fileutils/fileutils_test.go
@@ -1,0 +1,157 @@
+package fileutils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIsFileOrDirectory(t *testing.T) {
+	dir := t.TempDir()
+
+	// existing directory
+	path := dir
+	exists, err := IsFileOrDirectory(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if exists != true {
+		t.Fatalf("expected true, but got false")
+	}
+
+	// non-existing directory
+	path = filepath.Join(dir, "kjdsfjkfhd")
+	exists, err = IsFileOrDirectory(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if exists != false {
+		t.Fatalf("expected false, but got true")
+	}
+
+	// existing file
+	file, err := os.CreateTemp(dir, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	file.Close()
+
+	path = file.Name()
+	exists, err = IsFileOrDirectory(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if exists != true {
+		t.Fatalf("expected true, but got false")
+	}
+
+	// non-existing file
+	path = filepath.Join(dir, "skdfsdf3")
+	exists, err = IsFileOrDirectory(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if exists != false {
+		t.Fatalf("expected false, but got true")
+	}
+}
+
+func TestIsFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// existing directory
+	path := dir
+	exists, err := IsFile(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if exists != false {
+		t.Fatalf("expected false, but got true")
+	}
+
+	// non-existing directory
+	path = filepath.Join(dir, "kjdsfjkfhd")
+	exists, err = IsFile(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if exists != false {
+		t.Fatalf("expected false, but got true")
+	}
+
+	// existing file
+	file, err := os.CreateTemp(dir, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	file.Close()
+
+	path = file.Name()
+	exists, err = IsFile(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if exists != true {
+		t.Fatalf("expected true, but got false")
+	}
+
+	// non-existing file
+	path = filepath.Join(dir, "skdfsdf3")
+	exists, err = IsFile(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if exists != false {
+		t.Fatalf("expected false, but got true")
+	}
+}
+
+func TestIsDirectory(t *testing.T) {
+	dir := t.TempDir()
+
+	// existing directory
+	path := dir
+	exists, err := IsDirectory(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if exists != true {
+		t.Fatalf("expected true, but got false")
+	}
+
+	// non-existing directory
+	path = filepath.Join(dir, "kjdsfjkfhd")
+	exists, err = IsDirectory(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if exists != false {
+		t.Fatalf("expected false, but got true")
+	}
+
+	// existing file
+	file, err := os.CreateTemp(dir, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	file.Close()
+
+	path = file.Name()
+	exists, err = IsDirectory(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if exists != false {
+		t.Fatalf("expected false, but got true")
+	}
+
+	// non-existing file
+	path = filepath.Join(dir, "skdfsdf3")
+	exists, err = IsDirectory(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if exists != false {
+		t.Fatalf("expected false, but got true")
+	}
+}


### PR DESCRIPTION
For `armadactl`, I want to raise an error if the user provides a configuration file explicitly that does not exist. This package adds a package `inetrnal/fileutils` with functions `IsFileOrDirectory(string path) (bool, error)`, `IsFile(string path) (bool, error)`, and `IsDirectory(string path) (bool, error)`.