### PR TITLE
Ensure JobFailedEvent is reported if AddJobs fails in Redis

### DIFF
--- a/internal/armada/server/lease.go
+++ b/internal/armada/server/lease.go
@@ -243,7 +243,7 @@ func (q *AggregatedQueueServer) reportFailure(jobId string, clusterId string, re
 		return err
 	}
 
-	err = reportFailed(q.eventStore, clusterId, []string{reason}, []*api.Job{job})
+	err = reportFailed(q.eventStore, clusterId, []*jobFailure{{job: job, reason: reason}})
 	if err != nil {
 		return err
 	}

--- a/internal/armada/server/lease.go
+++ b/internal/armada/server/lease.go
@@ -244,7 +244,7 @@ func (q *AggregatedQueueServer) reportFailure(jobId string, clusterId string, re
 	}
 
 	failureReason := reason
-	err = reportFailed(q.eventStore, clusterId, failureReason, job)
+	err = reportFailed(q.eventStore, clusterId, failureReason, []*api.Job{job})
 	if err != nil {
 		return err
 	}

--- a/internal/armada/server/lease.go
+++ b/internal/armada/server/lease.go
@@ -243,8 +243,7 @@ func (q *AggregatedQueueServer) reportFailure(jobId string, clusterId string, re
 		return err
 	}
 
-	failureReason := reason
-	err = reportFailed(q.eventStore, clusterId, failureReason, []*api.Job{job})
+	err = reportFailed(q.eventStore, clusterId, []string{reason}, []*api.Job{job})
 	if err != nil {
 		return err
 	}

--- a/internal/armada/server/submit.go
+++ b/internal/armada/server/submit.go
@@ -131,7 +131,7 @@ func (server *SubmitServer) SubmitJobs(ctx context.Context, req *api.JobSubmitRe
 	submissionResults, e := server.jobRepository.AddJobs(jobs)
 	if e != nil {
 		reason := fmt.Sprintf("Failed to save job in Armada: %v", e)
-		reportErr := reportFailed(server.eventStore, "", util.Multiply(reason, len(jobs)), jobs)
+		reportErr := reportFailed(server.eventStore, "", util.MultiplyString(reason, len(jobs)), jobs)
 		if reportErr != nil {
 			return nil, status.Errorf(codes.Internal, "error when reporting failure event: %v", reportErr)
 		}

--- a/internal/armada/server/submit.go
+++ b/internal/armada/server/submit.go
@@ -130,6 +130,11 @@ func (server *SubmitServer) SubmitJobs(ctx context.Context, req *api.JobSubmitRe
 
 	submissionResults, e := server.jobRepository.AddJobs(jobs)
 	if e != nil {
+		reason := fmt.Sprintf("Failed to save job in Armada: %v", e)
+		reportErr := reportFailedMultiple(server.eventStore, "", reason, jobs)
+		if reportErr != nil {
+			return nil, status.Errorf(codes.Internal, "error when reporting failure event: %v", reportErr)
+		}
 		return nil, status.Errorf(codes.Aborted, e.Error())
 	}
 

--- a/internal/armada/server/submit.go
+++ b/internal/armada/server/submit.go
@@ -131,7 +131,7 @@ func (server *SubmitServer) SubmitJobs(ctx context.Context, req *api.JobSubmitRe
 	submissionResults, e := server.jobRepository.AddJobs(jobs)
 	if e != nil {
 		reason := fmt.Sprintf("Failed to save job in Armada: %v", e)
-		reportErr := reportFailedMultiple(server.eventStore, "", reason, jobs)
+		reportErr := reportFailed(server.eventStore, "", reason, jobs)
 		if reportErr != nil {
 			return nil, status.Errorf(codes.Internal, "error when reporting failure event: %v", reportErr)
 		}

--- a/internal/armada/server/submit.go
+++ b/internal/armada/server/submit.go
@@ -153,7 +153,8 @@ func (server *SubmitServer) SubmitJobs(ctx context.Context, req *api.JobSubmitRe
 		if submissionResult.Error != nil {
 			jobResponse.Error = submissionResult.Error.Error()
 			failedJobs = append(failedJobs, jobs[i])
-			jobErrs = append(jobErrs, submissionResult.Error.Error())
+			jobErrs = append(jobErrs,
+				fmt.Sprintf("Failed to save job in Armada: %s", submissionResult.Error.Error()))
 		} else if submissionResult.DuplicateDetected {
 			doubleSubmits = append(doubleSubmits, submissionResult)
 		} else {

--- a/internal/common/util/list.go
+++ b/internal/common/util/list.go
@@ -35,11 +35,3 @@ func DeepCopyListUint32(list []uint32) []uint32 {
 	}
 	return result
 }
-
-func MultiplyString(val string, n int) []string {
-	result := make([]string, n, n)
-	for i := 0; i < n; i++ {
-		result[i] = val
-	}
-	return result
-}

--- a/internal/common/util/list.go
+++ b/internal/common/util/list.go
@@ -35,3 +35,11 @@ func DeepCopyListUint32(list []uint32) []uint32 {
 	}
 	return result
 }
+
+func Multiply(val string, n int) []string {
+	result := make([]string, n, n)
+	for i := 0; i < n; i++ {
+		result[i] = val
+	}
+	return result
+}

--- a/internal/common/util/list.go
+++ b/internal/common/util/list.go
@@ -36,7 +36,7 @@ func DeepCopyListUint32(list []uint32) []uint32 {
 	return result
 }
 
-func Multiply(val string, n int) []string {
+func MultiplyString(val string, n int) []string {
 	result := make([]string, n, n)
 	for i := 0; i < n; i++ {
 		result[i] = val


### PR DESCRIPTION
Currently, if the call to `AddJobs` fails, `JobSubmittedEvent`s still get generated for all the jobs in the submission. This makes it look like there are 'phantom jobs': `armadactl watch` shows a `JobSubmittedEvent` for each job in the failed batch, and in Lookout the jobs are forever queued.

This PR makes it so the `JobFailedEvent`s are generated for each job if the `AddJobs` call fails.