### PR TITLE
Armada server comments, todos, and a few small cleanups

### DIFF
--- a/cmd/armada/main.go
+++ b/cmd/armada/main.go
@@ -1,17 +1,14 @@
 package main
 
 import (
-	"context"
 	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
 
-	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-	"google.golang.org/grpc"
 
 	"github.com/G-Research/armada/internal/armada"
 	"github.com/G-Research/armada/internal/armada/configuration"
@@ -32,6 +29,8 @@ func main() {
 	common.ConfigureLogging()
 	common.BindCommandlineArguments()
 
+	// TODO Load relevant config in one place: don't use viper here and in the config package
+	// (currently in common).
 	var config configuration.ArmadaConfig
 	userSpecifiedConfigs := viper.GetStringSlice(CustomConfigLocation)
 	common.LoadConfig(&config, "./config/armada", userSpecifiedConfigs)
@@ -41,6 +40,7 @@ func main() {
 	stopSignal := make(chan os.Signal, 1)
 	signal.Notify(stopSignal, syscall.SIGINT, syscall.SIGTERM)
 
+	// TODO This starts a separate HTTP server. Is that intended? Should we have a single mux for everything?
 	shutdownMetricServer := common.ServeMetrics(config.MetricsPort)
 	defer shutdownMetricServer()
 
@@ -48,12 +48,13 @@ func main() {
 
 	startupCompleteCheck := health.NewStartupCompleteChecker()
 	healthChecks := health.NewMultiChecker(startupCompleteCheck)
+
+	// Register /health API endpoint
 	health.SetupHttpMux(mux, healthChecks)
 
-	shutdownGateway := serveHttp(
-		mux,
-		config.HttpPort,
-		config.GrpcPort,
+	// register gRPC API handlers in mux
+	shutdownGateway := gateway.CreateGatewayHandler(
+		config.GrpcPort, mux, "/",
 		config.CorsAllowedOrigins,
 		api.SwaggerJsonTemplate(),
 		api.RegisterSubmitHandler,
@@ -61,29 +62,20 @@ func main() {
 	)
 	defer shutdownGateway()
 
+	// start HTTP server
+	shutdownHttpServer := common.ServeHttp(config.HttpPort, mux)
+	defer shutdownHttpServer()
+
 	shutdown, wg := armada.Serve(&config, healthChecks)
 	go func() {
 		<-stopSignal
+
+		// TODO Can't be sure this will run, since there are calls to panic/os.Exit in sub-calls
 		shutdown()
 	}()
 
+	// TODO Why do we have this system?
+	// Instead, perform checks before starting services that depend on these checks being completed.
 	startupCompleteCheck.MarkComplete()
 	wg.Wait()
-}
-
-func serveHttp(
-	mux *http.ServeMux,
-	port uint16,
-	grpcPort uint16,
-	corsAllowedOrigins []string,
-	spec string,
-	handlers ...func(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error) (shutdown func()) {
-
-	shutdownGateway := gateway.CreateGatewayHandler(grpcPort, mux, "/", corsAllowedOrigins, spec, handlers...)
-	cancel := common.ServeHttp(port, mux)
-
-	return func() {
-		shutdownGateway()
-		cancel()
-	}
 }

--- a/internal/armada/repository/queue.go
+++ b/internal/armada/repository/queue.go
@@ -11,6 +11,20 @@ import (
 
 const queueHashKey = "Queue"
 
+// TODO These errors should be of a specific error type, e.g.:
+// type ErrQueueNotFound struct {
+// 	queueName string
+// }
+// func (err *ErrQueueNotFound) String() {
+// 	return fmt.Sprintf("Queue %s does not exist", err.queueName)
+// }
+// In doing so, if we wrap errors as they travel up the call stack
+// (using fmt.Errorf with the %w verb, i.e., fmt.Errorf("err %w", err))
+// and easily detect at the gRPC handler what the underlying issue is.
+// We need this since we need to create errors in the gRPC handler with the correct gRPC error code.
+// For more on error wrapping, see:
+// https://go.dev/blog/go1.13-errors
+
 var ErrQueueNotFound = errors.New("Queue does not exist")
 var ErrQueueAlreadyExists = errors.New("Queue already exists")
 
@@ -55,6 +69,7 @@ func (r *RedisQueueRepository) GetQueue(name string) (*api.Queue, error) {
 	} else if err != nil {
 		return nil, err
 	}
+
 	queue := &api.Queue{}
 	e := proto.Unmarshal([]byte(result), queue)
 	if e != nil {

--- a/internal/armada/repository/queue.go
+++ b/internal/armada/repository/queue.go
@@ -15,7 +15,7 @@ const queueHashKey = "Queue"
 // type ErrQueueNotFound struct {
 // 	queueName string
 // }
-// func (err *ErrQueueNotFound) String() {
+// func (err *ErrQueueNotFound) Error() {
 // 	return fmt.Sprintf("Queue %s does not exist", err.queueName)
 // }
 // In doing so, if we wrap errors as they travel up the call stack

--- a/internal/armada/server.go
+++ b/internal/armada/server.go
@@ -28,9 +28,16 @@ import (
 )
 
 func Serve(config *configuration.ArmadaConfig, healthChecks *health.MultiChecker) (func(), *sync.WaitGroup) {
+
+	// TODO Using an error group would be better.
+	// Since we want to shut down everything in a controlled manner in case of an irrecoverable error.
+	// Doesn't look like wg.Done() is called anywhere in this method.
+	// Either it's not called (we could be exiting using panic/os.Exit),
+	// or it's called in a sub-call.
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 
+	// TODO Return an error, don't panic.
 	err := validateArmadaConfig(config)
 	if err != nil {
 		panic(fmt.Errorf("configuration validation error: %v", err))
@@ -40,6 +47,7 @@ func Serve(config *configuration.ArmadaConfig, healthChecks *health.MultiChecker
 
 	taskManager := task.NewBackgroundTaskManager(metrics.MetricPrefix)
 
+	// TODO Redis setup code. Move into a separate function.
 	db := createRedisClient(&config.Redis)
 	eventsDb := createRedisClient(&config.EventsRedis)
 
@@ -56,6 +64,9 @@ func Serve(config *configuration.ArmadaConfig, healthChecks *health.MultiChecker
 	var eventStore repository.EventStore
 	var eventStream eventstream.EventStream
 
+	// TODO It looks like multiple backends can be provided.
+	// We should ensure that only 1 system is provided.
+	// TODO Return an error, don't panic.
 	if len(config.EventsNats.Servers) > 0 {
 		stanClient, err := eventstream.NewStanClientConnection(
 			config.EventsNats.ClusterID,
@@ -86,7 +97,7 @@ func Serve(config *configuration.ArmadaConfig, healthChecks *health.MultiChecker
 	}
 
 	// TODO: move this to task manager
-	teardown := func() {}
+	eventstreamTeardown := func() {}
 	if eventStream != nil {
 		eventStore = repository.NewEventStore(eventStream)
 
@@ -98,7 +109,9 @@ func Serve(config *configuration.ArmadaConfig, healthChecks *health.MultiChecker
 		jobStatusProcessor := repository.NewEventJobStatusProcessor(config.Events.JobStatusQueue, jobRepository, eventStream, jobStatusBatcher)
 		jobStatusProcessor.Start()
 
-		teardown = func() {
+		// TODO Teardown functions should return an error that can be logged/whatever by the caller.
+		// Not use log internally.
+		eventstreamTeardown = func() {
 			err := eventRepoBatcher.Stop()
 			if err != nil {
 				log.Errorf("failed to flush event processor buffer for redis")
@@ -116,7 +129,10 @@ func Serve(config *configuration.ArmadaConfig, healthChecks *health.MultiChecker
 		eventStore = redisEventRepository
 	}
 
-	permissions := authorization.NewPrincipalPermissionChecker(config.Auth.PermissionGroupMapping, config.Auth.PermissionScopeMapping, config.Auth.PermissionClaimMapping)
+	permissions := authorization.NewPrincipalPermissionChecker(
+		config.Auth.PermissionGroupMapping,
+		config.Auth.PermissionScopeMapping,
+		config.Auth.PermissionClaimMapping)
 
 	submitServer := server.NewSubmitServer(
 		permissions,
@@ -143,19 +159,24 @@ func Serve(config *configuration.ArmadaConfig, healthChecks *health.MultiChecker
 
 	grpc_prometheus.Register(grpcServer)
 
+	// TODO grpcCommon.Listen is supposed to call wg.Done() internally.
+	// Except, that it calls log.Fatalf first, so wg.Done() is never called.
+	// There's no clean way for grpcCommon.Listen to return an error.
 	grpcCommon.Listen(config.GrpcPort, grpcServer, wg)
 
-	return func() {
-		teardown()
+	teardown := func() {
+		eventstreamTeardown()
 		taskManager.StopAll(time.Second * 2)
 		grpcServer.GracefulStop()
-	}, wg
+	}
+	return teardown, wg
 }
 
 func createRedisClient(config *redis.UniversalOptions) redis.UniversalClient {
 	return redis.NewUniversalClient(config)
 }
 
+// TODO Is this all validation that needs to be done?
 func validateArmadaConfig(config *configuration.ArmadaConfig) error {
 	if config.CancelJobsBatchSize <= 0 {
 		return fmt.Errorf("cancel jobs batch should be greater than 0: is %d", config.CancelJobsBatchSize)

--- a/internal/armada/server.go
+++ b/internal/armada/server.go
@@ -31,9 +31,6 @@ func Serve(config *configuration.ArmadaConfig, healthChecks *health.MultiChecker
 
 	// TODO Using an error group would be better.
 	// Since we want to shut down everything in a controlled manner in case of an irrecoverable error.
-	// Doesn't look like wg.Done() is called anywhere in this method.
-	// Either it's not called (we could be exiting using panic/os.Exit),
-	// or it's called in a sub-call.
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 
@@ -49,6 +46,7 @@ func Serve(config *configuration.ArmadaConfig, healthChecks *health.MultiChecker
 	authServices := auth.ConfigureAuth(config.Auth)
 	grpcServer := grpcCommon.CreateGrpcServer(authServices)
 
+	// Allows for registering functions to be run periodically in the background
 	taskManager := task.NewBackgroundTaskManager(metrics.MetricPrefix)
 
 	// TODO Redis setup code. Move into a separate function.
@@ -184,9 +182,6 @@ func createRedisClient(config *redis.UniversalOptions) redis.UniversalClient {
 func validateArmadaConfig(config *configuration.ArmadaConfig) error {
 	if config.CancelJobsBatchSize <= 0 {
 		return fmt.Errorf("cancel jobs batch should be greater than 0: is %d", config.CancelJobsBatchSize)
-	}
-	if config.Scheduling.MaximumJobsToSchedule <= 0 {
-		return fmt.Errorf("MaximumJobsToSchedule should be greater than 0: is %d", config.Scheduling.MaximumJobsToSchedule)
 	}
 	return nil
 }

--- a/internal/armada/server.go
+++ b/internal/armada/server.go
@@ -43,7 +43,11 @@ func Serve(config *configuration.ArmadaConfig, healthChecks *health.MultiChecker
 		panic(fmt.Errorf("configuration validation error: %v", err))
 	}
 
-	grpcServer := grpcCommon.CreateGrpcServer(auth.ConfigureAuth(config.Auth))
+	// We support multiple simultaneous authentication services (e.g., username/password  OpenId).
+	// For each gRPC request, we try them all until one succeeds, at which point the process is
+	// short-circuited.
+	authServices := auth.ConfigureAuth(config.Auth)
+	grpcServer := grpcCommon.CreateGrpcServer(authServices)
 
 	taskManager := task.NewBackgroundTaskManager(metrics.MetricPrefix)
 

--- a/internal/common/grpc/gateway.go
+++ b/internal/common/grpc/gateway.go
@@ -16,6 +16,8 @@ import (
 	"github.com/G-Research/armada/internal/common/util"
 )
 
+// CreateGatewayHandler configures the gRPC API gateway
+// by registering relevant handlers with the given mux.
 func CreateGatewayHandler(
 	grpcPort uint16,
 	mux *http.ServeMux,
@@ -43,6 +45,7 @@ func CreateGatewayHandler(
 		panic(err)
 	}
 
+	// TODO this should return an error instead of calling panic
 	for _, handler := range handlers {
 		err = handler(connectionCtx, gw, conn)
 		if err != nil {

--- a/internal/common/grpc/grpc.go
+++ b/internal/common/grpc/grpc.go
@@ -22,6 +22,7 @@ import (
 	"github.com/G-Research/armada/internal/common/auth/authorization"
 )
 
+// CreateGrpcServer creates a gRPC server with Armada services registered.
 func CreateGrpcServer(authServices []authorization.AuthService) *grpc.Server {
 	unaryInterceptors := []grpc.UnaryServerInterceptor{}
 	streamInterceptors := []grpc.StreamServerInterceptor{}
@@ -57,7 +58,7 @@ func CreateGrpcServer(authServices []authorization.AuthService) *grpc.Server {
 
 func Listen(port uint16, grpcServer *grpc.Server, wg *sync.WaitGroup) {
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
-	if err != nil {
+	if err != nil { // TODO Don't call fatal, return an error.
 		log.Fatalf("failed to listen: %v", err)
 	}
 

--- a/internal/common/grpc/grpc.go
+++ b/internal/common/grpc/grpc.go
@@ -22,11 +22,20 @@ import (
 	"github.com/G-Research/armada/internal/common/auth/authorization"
 )
 
-// CreateGrpcServer creates a gRPC server with Armada services registered.
+// CreateGrpcServer creates a gRPC server (by calling grpc.NewServer) with settings specific to
+// this project, and registers services for, e.g., logging and authentication.
 func CreateGrpcServer(authServices []authorization.AuthService) *grpc.Server {
+
+	// Logging, authentication, etc. are implemented via gRPC interceptors
+	// (i.e., via functions that are called before handling the actual request).
+	// There are separate interceptors for unary and streaming gRPC calls.
 	unaryInterceptors := []grpc.UnaryServerInterceptor{}
 	streamInterceptors := []grpc.StreamServerInterceptor{}
 
+	// Logging (using logrus)
+	// By default, information contained in the request context is logged
+	// tagsExtractor pulls information out of the request payload (a protobuf) and stores it in
+	// the context, such that it is logged.
 	messageDefault := log.NewEntry(log.StandardLogger())
 	tagsExtractor := grpc_ctxtags.WithFieldExtractor(grpc_ctxtags.CodeGenRequestFieldExtractor)
 	unaryInterceptors = append(unaryInterceptors,
@@ -36,26 +45,34 @@ func CreateGrpcServer(authServices []authorization.AuthService) *grpc.Server {
 		grpc_ctxtags.StreamServerInterceptor(tagsExtractor),
 		grpc_logrus.StreamServerInterceptor(messageDefault))
 
+	// Authentication
+	// The provided authServices represents a list of services that can be used to authenticate
+	// the client (e.g., username/password and OpenId). authFunction is a combination of these.
 	authFunction := authorization.CreateMiddlewareAuthFunction(authServices)
 	unaryInterceptors = append(unaryInterceptors, grpc_auth.UnaryServerInterceptor(authFunction))
 	streamInterceptors = append(streamInterceptors, grpc_auth.StreamServerInterceptor(authFunction))
 
+	// Prometheus timeseries collection integration
 	grpc_prometheus.EnableHandlingTimeHistogram()
 	unaryInterceptors = append(unaryInterceptors, grpc_prometheus.UnaryServerInterceptor)
 	streamInterceptors = append(streamInterceptors, grpc_prometheus.StreamServerInterceptor)
 
+	// Automatically recover from panics
 	recovery := grpc_recovery.WithRecoveryHandler(panicRecoveryHandler)
 	unaryInterceptors = append(unaryInterceptors, grpc_recovery.UnaryServerInterceptor(recovery))
 	streamInterceptors = append(streamInterceptors, grpc_recovery.StreamServerInterceptor(recovery))
 
+	// Interceptors are registered at server creation
 	return grpc.NewServer(
 		grpc.KeepaliveParams(keepalive.ServerParameters{
 			MaxConnectionIdle: 5 * time.Minute,
 		}),
 		grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(streamInterceptors...)),
-		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(unaryInterceptors...)))
+		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(unaryInterceptors...)),
+	)
 }
 
+// TODO We don't need this function. Just do this at the caller.
 func Listen(port uint16, grpcServer *grpc.Server, wg *sync.WaitGroup) {
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	if err != nil { // TODO Don't call fatal, return an error.
@@ -74,6 +91,7 @@ func Listen(port uint16, grpcServer *grpc.Server, wg *sync.WaitGroup) {
 	}()
 }
 
+// This function is called whenever a gRPC handler panics.
 func panicRecoveryHandler(p interface{}) (err error) {
 	log.Errorf("Request triggered panic with cause %v \n%s", p, string(debug.Stack()))
 	return status.Errorf(codes.Internal, "Internal server error caused by %v", p)

--- a/internal/common/health/checker.go
+++ b/internal/common/health/checker.go
@@ -1,5 +1,6 @@
 package health
 
+// TODO No point in having this in a separate file. Just consolidate the health package into 1 or 2 files.
 type Checker interface {
 	Check() error
 }

--- a/internal/common/health/http_handler.go
+++ b/internal/common/health/http_handler.go
@@ -6,6 +6,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// TODO Doesn't need to exist. Just give a Checker directly.
 type CheckHttpHandler struct {
 	checker Checker
 }
@@ -16,6 +17,9 @@ func NewCheckHttpHandler(checker Checker) *CheckHttpHandler {
 	}
 }
 
+// TODO Is this really the way to do it? We could give a handler that is an anonymous function
+// handle that encloses the relevant variables.
+// In doing so, we don't need CheckHttpHandler, NewCheckHttpHandler.
 func (h *CheckHttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	err := h.checker.Check()
 	if err == nil {

--- a/internal/common/health/http_mux_setup.go
+++ b/internal/common/health/http_mux_setup.go
@@ -4,6 +4,9 @@ import (
 	"net/http"
 )
 
+// TODO This function doesn't need to exist.
+// Just return a callback function and let the caller decide what to do
+// (e.g., register it to a mux).
 func SetupHttpMux(mux *http.ServeMux, checker Checker) {
 	handler := NewCheckHttpHandler(checker)
 	mux.Handle("/health", handler)

--- a/internal/common/health/multi_checker.go
+++ b/internal/common/health/multi_checker.go
@@ -5,6 +5,10 @@ import (
 	"strings"
 )
 
+// MultiChecker combines multiple Checker instances.
+// Calls to MultiChecker.Check() calls Check() on each constituent checker
+// and returns a new error created by joining any errors returned from those calls,
+// or nil if no errors are found.
 type MultiChecker struct {
 	checkers []Checker
 }

--- a/internal/common/health/startup_complete_checker.go
+++ b/internal/common/health/startup_complete_checker.go
@@ -2,6 +2,8 @@ package health
 
 import "errors"
 
+// TODO Is the point of this system to make sure we can collect metrics (prometheus?)
+// before the server has started?
 type StartupCompleteChecker struct {
 	complete bool
 }

--- a/internal/common/startup.go
+++ b/internal/common/startup.go
@@ -31,6 +31,7 @@ func BindCommandlineArguments() {
 	}
 }
 
+// TODO Move code relating to config out of common into a new package internal/serverconfig
 func LoadConfig(config interface{}, defaultPath string, overrideConfigs []string) *viper.Viper {
 	v := viper.NewWithOptions(viper.KeyDelimiter("::"))
 	v.SetConfigName(baseConfigFileName)
@@ -88,6 +89,7 @@ func quantityDecodeHook(
 	return resource.ParseQuantity(fmt.Sprintf("%v", data))
 }
 
+// TODO Move logging-related code out of common into a new package internal/logging
 func ConfigureCommandLineLogging() {
 	commandLineFormatter := new(logging.CommandLineFormatter)
 	log.SetFormatter(commandLineFormatter)
@@ -124,6 +126,7 @@ func ServeMetricsFor(port uint16, gatherer prometheus.Gatherer) (shutdown func()
 	return ServeHttp(port, mux)
 }
 
+// ServeHttp starts a HTTP server listening on the given port.
 func ServeHttp(port uint16, mux http.Handler) (shutdown func()) {
 	srv := &http.Server{
 		Addr:    fmt.Sprintf(":%d", port),
@@ -132,9 +135,11 @@ func ServeHttp(port uint16, mux http.Handler) (shutdown func()) {
 	go func() {
 		log.Printf("Starting http server listening on %d", port)
 		if err := srv.ListenAndServe(); err != http.ErrServerClosed {
-			panic(err)
+			panic(err) // TODO Don't panic, return an error
 		}
 	}()
+	// TODO There's no need for this function to panic, since the main goroutine will exit.
+	// Instead, just log an error.
 	return func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()


### PR DESCRIPTION
This PR adds comments (docstrings, inside functions, and todos) to several files in `internal/armada`. The todo-comments are added to facilitate subsequent cleanup and refactoring work. There is also a small amount of cleanup (moving code around and changing whitespace).