### PR TITLE
Check if goimports installation succeeds in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,6 +122,12 @@ jobs:
           name: Check Go formatting
           command: |
             go install golang.org/x/tools/cmd/goimports@v0.1.1
+            if [ $? -eq 0 ]
+            then
+            else
+              echo "goimports installation failed" >&2
+              exit 1
+            fi
             goimports -d -local "github.com/G-Research/armada" .
             exit $(goimports -l -local "github.com/G-Research/armada" . | wc -l)
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,9 +122,8 @@ jobs:
           name: Check Go formatting
           command: |
             go install golang.org/x/tools/cmd/goimports@v0.1.1
-            if [ $? -eq 0 ]
+            if [ $? -ne 0 ]
             then
-            else
               echo "goimports installation failed" >&2
               exit 1
             fi


### PR DESCRIPTION
We're getting `goimports: command not found` errors in circleci. This PR adds a check to the bash code run by circleci that returns an error if `go install golang.org/x/tools/cmd/goimports@v0.1.1` returns a non-zero exit code.