### PR TITLE
Add template for JobId in Job spec

### DIFF
--- a/internal/armada/server/submit.go
+++ b/internal/armada/server/submit.go
@@ -456,6 +456,7 @@ func (server *SubmitServer) checkQueuePermission(
 
 // brought outside for mocking.
 var NewULID = util.NewULID
+var now = time.Now
 
 func (server *SubmitServer) createJobs(request *api.JobSubmitRequest, owner string, ownershipGroups []string) ([]*api.Job, error) {
 	jobs := make([]*api.Job, 0, len(request.JobRequestItems))
@@ -523,7 +524,7 @@ func (server *SubmitServer) createJobs(request *api.JobSubmitRequest, owner stri
 
 			PodSpec:                  item.PodSpec,
 			PodSpecs:                 item.PodSpecs,
-			Created:                  time.Now(),
+			Created:                  now(), // Replaced with now for mocking unit test
 			Owner:                    owner,
 			QueueOwnershipUserGroups: ownershipGroups,
 		}

--- a/internal/armada/server/submit.go
+++ b/internal/armada/server/submit.go
@@ -455,7 +455,7 @@ func (server *SubmitServer) checkQueuePermission(
 }
 
 // brought outside for mocking.
-var NewULID = util.NewULID
+var newULID = util.NewULID
 var now = time.Now
 
 func (server *SubmitServer) createJobs(request *api.JobSubmitRequest, owner string, ownershipGroups []string) ([]*api.Job, error) {
@@ -505,7 +505,7 @@ func (server *SubmitServer) createJobs(request *api.JobSubmitRequest, owner stri
 			}
 		}
 
-		jobId := NewULID()
+		jobId := newULID()
 		j := &api.Job{
 			Id:       jobId,
 			ClientId: item.ClientId,
@@ -535,10 +535,10 @@ func (server *SubmitServer) createJobs(request *api.JobSubmitRequest, owner stri
 }
 
 func enrichText(text map[string]string, jobId string) map[string]string {
-	returnText := util.DeepCopy(text)
+	returnText := make(map[string]string, len(text))
 
-	for key, value := range returnText {
-		returnText[key] = strings.Replace(value, "{JobId}", jobId, -1)
+	for key, value := range text {
+		returnText[key] = strings.ReplaceAll(value, "{JobId}", jobId)
 	}
 
 	return returnText

--- a/internal/armada/server/submit.go
+++ b/internal/armada/server/submit.go
@@ -539,7 +539,7 @@ func (server *SubmitServer) createJobsObjects(request *api.JobSubmitRequest, own
 
 func enrichText(labels map[string]string, jobId string) {
 	for key, value := range labels {
-		value := strings.ReplaceAll(value, "{{JobId}}", ` \z`) // \z cannot be entered manually, hence it's use
+		value := strings.ReplaceAll(value, "{{JobId}}", ` \z`) // \z cannot be entered manually, hence its use
 		value = strings.ReplaceAll(value, "{JobId}", jobId)
 		labels[key] = strings.ReplaceAll(value, ` \z`, "JobId")
 	}

--- a/internal/armada/server/submit.go
+++ b/internal/armada/server/submit.go
@@ -454,11 +454,12 @@ func (server *SubmitServer) checkQueuePermission(
 	return nil, groups
 }
 
-// brought outside for mocking.
-var newULID = util.NewULID
-var now = time.Now
-
 func (server *SubmitServer) createJobs(request *api.JobSubmitRequest, owner string, ownershipGroups []string) ([]*api.Job, error) {
+	return server.createJobsObjects(request, owner, ownershipGroups, time.Now, util.NewULID)
+}
+
+func (server *SubmitServer) createJobsObjects(request *api.JobSubmitRequest, owner string, ownershipGroups []string,
+	getTime func() time.Time, getUlid func() string) ([]*api.Job, error) {
 	jobs := make([]*api.Job, 0, len(request.JobRequestItems))
 
 	if request.JobSetId == "" {
@@ -505,7 +506,7 @@ func (server *SubmitServer) createJobs(request *api.JobSubmitRequest, owner stri
 			}
 		}
 
-		jobId := newULID()
+		jobId := getUlid()
 		enrichText(item.Labels, jobId)
 		enrichText(item.Annotations, jobId)
 		j := &api.Job{
@@ -526,7 +527,7 @@ func (server *SubmitServer) createJobs(request *api.JobSubmitRequest, owner stri
 
 			PodSpec:                  item.PodSpec,
 			PodSpecs:                 item.PodSpecs,
-			Created:                  now(), // Replaced with now for mocking unit test
+			Created:                  getTime(), // Replaced with now for mocking unit test
 			Owner:                    owner,
 			QueueOwnershipUserGroups: ownershipGroups,
 		}

--- a/internal/armada/server/submit.go
+++ b/internal/armada/server/submit.go
@@ -539,7 +539,9 @@ func (server *SubmitServer) createJobsObjects(request *api.JobSubmitRequest, own
 
 func enrichText(labels map[string]string, jobId string) {
 	for key, value := range labels {
-		labels[key] = strings.ReplaceAll(value, "{JobId}", jobId)
+		value := strings.ReplaceAll(value, "{{JobId}}", ` \z`) // \z cannot be entered manually, hence it's use
+		value = strings.ReplaceAll(value, "{JobId}", jobId)
+		labels[key] = strings.ReplaceAll(value, ` \z`, "JobId")
 	}
 }
 

--- a/internal/armada/server/submit.go
+++ b/internal/armada/server/submit.go
@@ -506,6 +506,8 @@ func (server *SubmitServer) createJobs(request *api.JobSubmitRequest, owner stri
 		}
 
 		jobId := newULID()
+		enrichText(item.Labels, jobId)
+		enrichText(item.Annotations, jobId)
 		j := &api.Job{
 			Id:       jobId,
 			ClientId: item.ClientId,
@@ -513,8 +515,8 @@ func (server *SubmitServer) createJobs(request *api.JobSubmitRequest, owner stri
 			JobSetId: request.JobSetId,
 
 			Namespace:   namespace,
-			Labels:      enrichText(item.Labels, jobId),
-			Annotations: enrichText(item.Annotations, jobId),
+			Labels:      item.Labels,
+			Annotations: item.Annotations,
 
 			RequiredNodeLabels: item.RequiredNodeLabels,
 			Ingress:            item.Ingress,
@@ -534,14 +536,10 @@ func (server *SubmitServer) createJobs(request *api.JobSubmitRequest, owner stri
 	return jobs, nil
 }
 
-func enrichText(text map[string]string, jobId string) map[string]string {
-	returnText := make(map[string]string, len(text))
-
-	for key, value := range text {
-		returnText[key] = strings.ReplaceAll(value, "{JobId}", jobId)
+func enrichText(labels map[string]string, jobId string) {
+	for key, value := range labels {
+		labels[key] = strings.ReplaceAll(value, "{JobId}", jobId)
 	}
-
-	return returnText
 }
 
 func (server *SubmitServer) applyDefaultsToPodSpec(spec *v1.PodSpec) {

--- a/internal/armada/server/submit_test.go
+++ b/internal/armada/server/submit_test.go
@@ -734,7 +734,7 @@ func TestSubmitServer_CreateJobs_WithJobIdReplacement(t *testing.T) {
 		return timeNow
 	}
 
-	NewULID = func() string {
+	newULID = func() string {
 		return "test-ulid"
 	}
 
@@ -826,15 +826,14 @@ func TestSubmitServer_CreateJobs_WithJobIdReplacement(t *testing.T) {
 			},
 		},
 	}
-	owner := "test"
 	ownershipGroups := make([]string, 0)
 	withSubmitServer(func(s *SubmitServer, events repository.EventRepository) {
-		output, err := s.createJobs(request, owner, ownershipGroups)
-		fmt.Println(err)
+		output, err := s.createJobs(request, "test", ownershipGroups)
+		assert.NoError(t, err)
 		assert.Equal(t, expected, output)
 	})
 
 	// Replace mocked functions
-	NewULID = util.NewULID
+	newULID = util.NewULID
 	now = time.Now
 }

--- a/internal/armada/server/submit_test.go
+++ b/internal/armada/server/submit_test.go
@@ -730,11 +730,10 @@ func withSubmitServerAndRepos(action func(s *SubmitServer, jobRepo repository.Jo
 
 func TestSubmitServer_CreateJobs_WithJobIdReplacement(t *testing.T) {
 	timeNow := time.Now()
-	now = func() time.Time {
+	mockNow := func() time.Time {
 		return timeNow
 	}
-
-	newULID = func() string {
+	mockNewULID := func() string {
 		return "test-ulid"
 	}
 
@@ -755,7 +754,7 @@ func TestSubmitServer_CreateJobs_WithJobIdReplacement(t *testing.T) {
 
 			Priority: 1,
 
-			Created: now(),
+			Created: mockNow(),
 			PodSpecs: []*v1.PodSpec{
 				{
 					Containers: []v1.Container{
@@ -828,12 +827,8 @@ func TestSubmitServer_CreateJobs_WithJobIdReplacement(t *testing.T) {
 	}
 	ownershipGroups := make([]string, 0)
 	withSubmitServer(func(s *SubmitServer, events repository.EventRepository) {
-		output, err := s.createJobs(request, "test", ownershipGroups)
+		output, err := s.createJobsObjects(request, "test", ownershipGroups, mockNow, mockNewULID)
 		assert.NoError(t, err)
 		assert.Equal(t, expected, output)
 	})
-
-	// Replace mocked functions
-	newULID = util.NewULID
-	now = time.Now
 }

--- a/internal/common/validation/podspec.go
+++ b/internal/common/validation/podspec.go
@@ -56,13 +56,13 @@ func ValidatePodSpec(spec *v1.PodSpec, schedulingSpec *configuration.SchedulingC
 func validateContainerResource(
 	resourceSpec v1.ResourceList,
 	minJobResources v1.ResourceList,
-	container_name string,
-	requestOrLimit string,
+	containerName string,
+	requestType string,
 ) error {
 	for rc, containerRsc := range resourceSpec {
 		serverRsc, nonEmpty := minJobResources[rc]
 		if nonEmpty && containerRsc.Value() < serverRsc.Value() {
-			return fmt.Errorf("[validateContainerResource] container %q %s %s (%s) below server minimum (%s)", container_name, rc, requestOrLimit, &containerRsc, &serverRsc)
+			return fmt.Errorf("[validateContainerResource] container %q %s %s (%s) below server minimum (%s)", containerName, rc, requestType, &containerRsc, &serverRsc)
 		}
 	}
 	return nil


### PR DESCRIPTION
This change allows a job spec annotation or label to contain {JobId}, which gets templated out with the actual JobId on submission.