### PR TITLE
[INTERNAL] move Armada CI to GitHub actions #675

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,42 +1,191 @@
-name: Deploy GH Pages
+name: CI
 
-on:
+defaults:
+  run:
+    shell: bash
+
+env:
+  GO111MODULE: "on"
+  GOPATH: "/home/runner/work/armada/armada/go"
+  GOCACHE: "/home/runner/.cache/go-build"
+  KUBECONFIG: "/home/runner/work/armada/armada/go/src/github.com/G-Research/armada/e2e/setup/config"
+  GOVERSION: "1.16"
+
+on: 
   push:
-    branches: 
-      - master 
-    paths:
+    branches:
+      - '*'
+    pull_request:
+      branches:
+        - master
+    tags-ignore:
+      - '**'
+    paths-ignore:
       - 'docs/*.md'
       - 'docs/quickstart'
       - '*.md'
+      - '**/release.yml'
+      - '**/pages.yml'
 
 jobs:
-  deploy-gh-pages:
-    runs-on: ubuntu-latest
+  code_styles:
+    name: Code style
+    runs-on: ubuntu-20.04
     steps:
-      - name: Checkout master
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GOVERSION }}
+      - name: Checkout code into the Go module directory
         uses: actions/checkout@v2
         with:
-          path: master
+          path: ${{ env.GOPATH }}/src/github.com/G-Research/armada
 
-      - name: Checkout gh-pages branch
+      - name: Check Go formatting
+        run: |
+          go install golang.org/x/tools/cmd/goimports@v0.1.1
+          if [ $(goimports -l -local "github.com/G-Research/armada" | wc -l) -eq 0 ]; then exit 0; else exit 1; fi
+
+      - name: Run ineffassign
+        run: |
+          cd /tmp
+          go get -u github.com/gordonklaus/ineffassign
+          cd ${{ env.GOPATH }}/src/github.com/G-Research/armada
+          ineffassign ./...
+        working-directory: ${{ env.GOPATH }}/src/github.com/G-Research/armada
+          
+      - name: Check TypeScript formatting
+        run: |
+          npm ci && npm run fmt || exit 1
+          exit $(git status -s -uno | wc -l)
+        working-directory: ${{ env.GOPATH }}/src/github.com/G-Research/armada/internal/lookout/ui
+
+      - name: Check generated files
+        run: |
+          make proto
+          git status -s -uno
+          git --no-pager diff
+          git status -s -uno
+          exit $(git status -s -uno | wc -l)
+        working-directory: ${{ env.GOPATH }}/src/github.com/G-Research/armada
+
+  test:
+    name: Test
+    needs: [code_styles]
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GOVERSION }}
+      - name: Checkout code into the Go module directory
         uses: actions/checkout@v2
         with:
-          ref: 'gh-pages'
-          path: gh-pages
-    
-      - name: Copy site files
-        run: |
-          cp master/docs/*.md gh-pages/
-          cp -r master/docs/quickstart gh-pages/_pages
-          cp master/CODE_OF_CONDUCT.md master/CONTRIBUTING.md gh-pages/_pages/
+          path: ${{ env.GOPATH }}/src/github.com/G-Research/armada
+            
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+            /home/runner/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
-      - name: Commit GH Pages
-        run: |
-          cd gh-pages
-          git config user.name armada-admin
-          git config user.email admin@armadaproject.io
-          git add . _pages
-          git diff --quiet && git diff --staged --quiet || git commit -m "Updating Github Pages branch with latest Master changes"
-          git push
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run tests
+        run: make tests
+        working-directory: ${{ env.GOPATH }}/src/github.com/G-Research/armada
+
+      - name: Check go.sum
+        run: cat go.sum
+        working-directory: ${{ env.GOPATH }}/src/github.com/G-Research/armada
+
+  build:
+    name: Build
+    needs: [test] 
+    runs-on: ubuntu-20.04
+    env:
+      DOCKERHUB_PASS: ${{ secrets.DOCKERHUB_PASS }}
+      DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GOVERSION }}
+      - name: Checkout code into the Go module directory
+        uses: actions/checkout@v2
+        with:
+          path: ${{ env.GOPATH }}/src/github.com/G-Research/armada
+
+      - name: Build & Run e2e tests
+        run: make tests-e2e
+        working-directory: ${{ env.GOPATH }}/src/github.com/G-Research/armada
+
+      - name: Delete cluster
+        if: always()
+        run: make e2e-delete-cluster
+        working-directory: ${{ env.GOPATH }}/src/github.com/G-Research/armada
+
+      - name: Check go.sum
+        run: cat go.sum
+        working-directory: ${{ env.GOPATH }}/src/github.com/G-Research/armada
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+            /home/runner/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Archive production artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: armadactl
+          path: |
+            ${{ env.GOPATH }}/src/github.com/G-Research/armada/bin/armadactl
+
+      - name: Push Dev Image
+        run: | 
+          if [ -z "${DOCKERHUB_USER}" ] 
+            then
+              echo "Do not push image inside fork."
+              exit 0
+          fi
+
+          TAG=${GITHUB_SHA}
+          BRANCH=${GITHUB_REF##*/}
+
+          if [ ${BRANCH} != master ]
+            then
+              TAG=branch-$(echo -n ${BRANCH} | sed 's|/|-|g')-${GITHUB_SHA}
+          fi
+
+          echo ${DOCKERHUB_PASS} | docker login -u ${DOCKERHUB_USER} --password-stdin
+
+          docker tag armada gresearchdev/armada-server-dev:${TAG}
+          docker push gresearchdev/armada-server-dev:${TAG}
+
+          docker tag armada-executor gresearchdev/armada-executor-dev:${TAG}
+          docker push gresearchdev/armada-executor-dev:${TAG}
+
+          docker tag armadactl gresearchdev/armada-armadactl-dev:${TAG}
+          docker push gresearchdev/armada-armadactl-dev:${TAG}
+
+          docker tag armada-load-tester gresearchdev/armada-load-tester-dev:${TAG}
+          docker push gresearchdev/armada-load-tester-dev:${TAG}
+
+          docker tag armada-fakeexecutor gresearchdev/armada-fakeexecutor-dev:${TAG}
+          docker push gresearchdev/armada-fakeexecutor-dev:${TAG}
+
+          docker tag armada-lookout gresearchdev/armada-lookout-dev:${TAG}
+          docker push gresearchdev/armada-lookout-dev:${TAG}
+          
+          docker tag armada-binoculars gresearchdev/armada-binoculars-dev:${TAG}
+          docker push gresearchdev/armada-binoculars-dev:${TAG}
+
+          rm -v /home/runner/.docker/config.json
+        working-directory: ${{ env.GOPATH }}/src/github.com/G-Research/armada

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,5 @@
 name: CI
 
-defaults:
-  run:
-    shell: bash
-
 env:
   GO111MODULE: "on"
   GOPATH: "/home/runner/work/armada/armada/go"
@@ -48,7 +44,6 @@ jobs:
 
       - name: Run ineffassign
         run: |
-          cd /tmp
           go get -u github.com/gordonklaus/ineffassign
           cd ${{ env.GOPATH }}/src/github.com/G-Research/armada
           ineffassign ./...

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,41 @@
+name: Pages
+
+on:
+  push:
+    branches: 
+      - master 
+    paths:
+      - 'docs/*.md'
+      - 'docs/quickstart'
+      - '*.md'
+
+jobs:
+  deploy-gh-pages:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v2
+        with:
+          path: master
+
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v2
+        with:
+          ref: 'gh-pages'
+          path: gh-pages
+
+      - name: Copy site files
+        run: |
+          cp master/docs/*.md gh-pages/
+          cp -r master/docs/quickstart gh-pages/_pages
+          cp master/CODE_OF_CONDUCT.md master/CONTRIBUTING.md gh-pages/_pages/
+      - name: Commit GH Pages
+        run: |
+          cd gh-pages
+          git config user.name armada-admin
+          git config user.email admin@armadaproject.io
+          git add . _pages
+          git diff --quiet && git diff --staged --quiet || git commit -m "Updating Github Pages branch with latest Master changes"
+          git push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,166 @@
+name: Release
+
+env:
+  GO111MODULE: "on"
+  GOPATH: "/home/runner/work/armada/armada/go"
+  GOCACHE: "/home/runner/.cache/go-build"
+
+on: 
+  push:
+    tags: 
+      - 'v*'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-20.04
+    env:
+      GO111MODULE: "on"
+      DOCKERHUB_PASS: ${{ secrets.DOCKERHUB_PASS }}
+      DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+    steps:
+      - name: Checkout code into the Go module directory
+        uses: actions/checkout@v2
+        with:
+          path: ${{ env.GOPATH }}/src/github.com/G-Research/armada
+      
+      - name: Build armadactl release artifacts
+        run: |
+          TAG=${GITHUB_REF##*/}
+          make build-armadactl-release RELEASE_VERSION=${TAG}
+        working-directory: ${{ env.GOPATH }}/src/github.com/G-Research/armada
+
+      - name: Archive production artifacts  
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: ${{ env.GOPATH }}/src/github.com/G-Research/armada/dist/*
+
+      #### Publish release
+      - name: Upload artifacts to Github release
+        uses: ncipollo/release-action@v1.8.6
+        with:
+          artifacts: "${{ env.GOPATH }}/src/github.com/G-Research/armada/dist/*"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.event.release.tag_name }} 
+
+      - name: Push Release Image
+        run: |
+          if [ -z "${DOCKERHUB_USER}" ]
+            then
+              echo "Do not push image inside fork."
+              exit 0
+          fi
+
+          TAG=${GITHUB_SHA}
+          RELEASE_TAG=${GITHUB_REF##*/}
+
+          echo ${DOCKERHUB_PASS} | docker login -u ${DOCKERHUB_USER} --password-stdin
+
+
+          docker pull gresearchdev/armada-server-dev:${TAG}
+          docker tag gresearchdev/armada-server-dev:${TAG} gresearchdev/armada-server:${RELEASE_TAG}
+          docker push gresearchdev/armada-server:${RELEASE_TAG}
+
+          docker pull gresearchdev/armada-executor-dev:${TAG}
+          docker tag gresearchdev/armada-executor-dev:${TAG} gresearchdev/armada-executor:${RELEASE_TAG}
+          docker push gresearchdev/armada-executor:${RELEASE_TAG}
+
+          docker pull gresearchdev/armada-armadactl-dev:${TAG}
+          docker tag gresearchdev/armada-armadactl-dev:${TAG} gresearchdev/armada-armadactl:${RELEASE_TAG}
+          docker push gresearchdev/armada-armadactl:${RELEASE_TAG}
+
+          docker pull gresearchdev/armada-lookout-dev:${TAG}
+          docker tag gresearchdev/armada-lookout-dev:${TAG} gresearchdev/armada-lookout:${RELEASE_TAG}
+          docker push gresearchdev/armada-lookout:${RELEASE_TAG}
+
+          docker pull gresearchdev/armada-binoculars-dev:${TAG}
+          docker tag gresearchdev/armada-binoculars-dev:${TAG} gresearchdev/armada-binoculars:${RELEASE_TAG}
+          docker push gresearchdev/armada-binoculars:${RELEASE_TAG}
+
+          rm -v /home/runner/.docker/config.json
+        working-directory: ${{ env.GOPATH }}/src/github.com/G-Research/armada
+
+  update-charts:
+    needs: [release]
+    name: Publish Armada charts
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout Armada
+        uses: actions/checkout@v2
+        with:
+          path: ${{ env.GOPATH }}/src/github.com/G-Research/armada
+
+      - name: Clone chart repo, update version and image tag to match current $RELEASE_TAG
+        run: |
+          mkdir -p ${{ env.GOPATH }}/src/github.com/G-Research/charts
+          mkdir -p $HOME/.ssh && echo "dummy" > $HOME/.ssh/known_hosts
+          
+          echo "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==" > $HOME/.ssh/known_hosts
+          eval "$(ssh-agent -s)"
+          echo -e "${{ secrets.ARMADA_CHART_UPDATE_KEY }}" | ssh-add - > /dev/null
+          git clone -q git@github.com:G-Research/charts.git charts/
+          cd charts/
+          git remote -v
+
+          RELEASE_TAG=${GITHUB_REF##*/}
+          echo release version is $RELEASE_TAG
+          find ../armada \( -name "Chart.yaml" -o -name "values.yaml" \) -exec sed -i s/LATEST/$RELEASE_TAG/ {} +
+
+          helm package ../armada/deployment/armada/ -d armada/
+          helm package ../armada/deployment/executor -d armada/
+          helm package ../armada/deployment/executor-cluster-monitoring/ -d armada/
+          helm package ../armada/deployment/lookout/ -d armada/
+          helm package ../armada/deployment/lookout-migration/ -d armada/
+          helm package ../armada/deployment/binoculars/ -d armada/
+          helm repo index .
+        working-directory: ${{ env.GOPATH }}/src/github.com/G-Research
+
+      - name: Commit and push updated charts
+        run: |
+          RELEASE_TAG=${GITHUB_REF##*/}
+          cd charts
+          git checkout -b github-armada_$RELEASE_TAG
+          git add ./armada index.yaml
+          git -c user.name='GR OSS' -c user.email=github@gr-oss.io commit -qam "Pushing new helm charts at version $RELEASE_TAG"
+          eval "$(ssh-agent -s)"
+          echo -e "${{ secrets.ARMADA_CHART_UPDATE_KEY }}" | ssh-add - > /dev/null
+          git push -q origin HEAD
+        working-directory: ${{ env.GOPATH }}/src/github.com/G-Research/charts
+
+  release-dotnet-client:
+    name: Release DotNet client
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: ${{ env.GOPATH }}/src/github.com/G-Research/armada
+
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.0.101' 
+          source-url: "https://api.nuget.org/v3/index.json"
+        env:
+          NUGET_AUTH_TOKEN: ${{ secrets.NUGET_API_KEY }}
+
+      - name: Release dotnet client
+        run: |
+          RELEASE_TAG_RAW=${GITHUB_REF##*/}
+          RELEASE_TAG=${RELEASE_TAG_RAW:1}
+
+          echo $RELEASE_TAG
+          cat /home/runner/work/armada/nuget.config
+          dotnet pack client/DotNet/Armada.Client/Armada.Client.csproj -c Release -p:PackageVersion=${RELEASE_TAG} -o ./bin/client/DotNet
+          dotnet nuget push ./bin/client/DotNet/G-Research.Armada.Client.${RELEASE_TAG}.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
+        working-directory: ${{ env.GOPATH }}/src/github.com/G-Research/armada
+
+      - name: Archive production artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: ${{ env.GOPATH }}/src/github.com/G-Research/armada/bin/client/DotNet/*

--- a/deployment/armada/templates/ingress.yaml
+++ b/deployment/armada/templates/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Values.ingress.nameOverride | default (include "armada.name" .) }}
@@ -25,9 +25,12 @@ spec:
     http:
       paths:
         - path: /
+          pathType: "Prefix"
           backend:
-            serviceName: {{ include "armada.name" $root }}
-            servicePort: {{ $root.Values.applicationConfig.grpcPort }}
+            service:
+              name: {{ include "armada.name" $root }}
+              port: 
+                number: {{ $root.Values.applicationConfig.grpcPort }}
   {{ end }}
   tls:
     - hosts:

--- a/deployment/armada/templates/ingressrest.yaml
+++ b/deployment/armada/templates/ingressrest.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Values.ingress.nameOverride | default (include "armada.name" .) }}-rest
@@ -25,9 +25,12 @@ spec:
     http:
       paths:
         - path: /api(/|$)(.*)
+          pathType: "Prefix"
           backend:
-            serviceName: {{ include "armada.name" $root }}
-            servicePort: {{ $root.Values.applicationConfig.httpPort }}
+            service:
+              name: {{ include "armada.name" $root }}
+              port: 
+                number: {{ $root.Values.applicationConfig.httpPort }}
   {{ end }}
   tls:
     - hosts:

--- a/deployment/binoculars/templates/ingress.yaml
+++ b/deployment/binoculars/templates/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "binoculars.name" . }}
@@ -25,9 +25,12 @@ spec:
     http:
       paths:
         - path: /
+          pathType: "Prefix"
           backend:
-            serviceName: {{ include "binoculars.name" $root }}
-            servicePort: {{ $root.Values.applicationConfig.grpcPort }}
+            service:
+              name: {{ include "binoculars.name" $root }}
+              port: 
+                number: {{ $root.Values.applicationConfig.grpcPort }}
   {{ end }}
   tls:
     - hosts:

--- a/deployment/binoculars/templates/ingressrest.yaml
+++ b/deployment/binoculars/templates/ingressrest.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "binoculars.name" . }}-rest
@@ -25,9 +25,12 @@ spec:
     http:
       paths:
         - path: /api(/|$)(.*)
+          pathType: "Prefix"
           backend:
-            serviceName: {{ include "binoculars.name" $root }}
-            servicePort: {{ $root.Values.applicationConfig.httpPort }}
+            service:
+              name: {{ include "binoculars.name" $root }}
+              port:
+                number: {{ $root.Values.applicationConfig.httpPort }}
   {{ end }}
   tls:
     - hosts:

--- a/deployment/lookout/templates/ingressweb.yaml
+++ b/deployment/lookout/templates/ingressweb.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "lookout.name" . }}-web
@@ -24,9 +24,12 @@ spec:
     http:
       paths:
         - path: /
+          pathType: "Prefix"
           backend:
-            serviceName: {{ include "lookout.name" $root }}
-            servicePort: {{ $root.Values.applicationConfig.httpPort }}
+            service:
+              name: {{ include "lookout.name" $root }}
+              port: 
+                number: {{ $root.Values.applicationConfig.httpPort }}
   {{ end }}
   tls:
     - hosts:

--- a/e2e/setup/armada-server-e2e-values.yaml
+++ b/e2e/setup/armada-server-e2e-values.yaml
@@ -1,0 +1,39 @@
+ingressClass: "nginx"
+clusterIssuer: "dummy-value"
+hostnames:
+  - "dummy-value"
+replicas: 1
+
+applicationConfig:
+  redis:
+    addrs:
+      - "redis-master.default.svc.cluster.local:6379"
+  eventsRedis:
+    addrs:
+      - "redis-master.default.svc.cluster.local:6379"
+  eventsNats:
+    servers:
+      - nats://nats:4222
+    clusterID: nats
+    subject: ArmadaTest
+    queueGroup: ArmadaEventRedisProcessor
+  auth:
+    basicAuth:
+      enableAuthentication: false
+    anonymousAuth: true
+    permissionGroupMapping:
+      submit_jobs: ["everyone"]
+      submit_any_jobs: ["everyone"]
+      create_queue: ["everyone"]
+      delete_queue: ["everyone"]
+      cancel_jobs: ["everyone"]
+      cancel_any_jobs: ["everyone"]
+      reprioritize_jobs: ["everyone"]
+      reprioritize_any_jobs: ["everyone"]
+      watch_all_events: ["everyone"]
+      execute_jobs: ["everyone"]
+
+prometheus:
+  enabled: false
+
+nodePort: 30000

--- a/e2e/setup/executor-e2e-values.yaml
+++ b/e2e/setup/executor-e2e-values.yaml
@@ -1,0 +1,15 @@
+ingressClass: "nginx"
+clusterIssuer: "dummy-value"
+hostnames:
+  - "dummy-value"
+
+applicationConfig:
+  apiConnection:
+    armadaUrl: "armada:50051"
+    forceNoTls: true
+  kubernetes:
+    impersonateUsers: true
+    stuckPodExpiry: 15s
+
+prometheus:
+  enabled: false

--- a/e2e/setup/kind-confg-server.yaml
+++ b/e2e/setup/kind-confg-server.yaml
@@ -1,0 +1,8 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: e2e
+nodes:
+- role: control-plane
+  extraPortMappings:
+  - containerPort: 30000
+    hostPort: 50051


### PR DESCRIPTION
The goal of this PR is to migrate from Circle CI to GitHub Actions as primary CI tools for publishing, building & testing Armada code

- 'translate' all actions and steps from CircleCI to GitHub action with supporting original requirements
- improve `e2e` tests by creating a cluster and using existing helm charts
  - update `ingress` templates to support `networking.k8s.io/v1` 
  - used `kind` with `1.21` k8s version to setup k8s cluster for e2e tests

#### GitHub action build staus with working examples can be followed here:
 - Branch: https://github.com/ljubon/armada/tree/feature/WIP-CI-GithubAction
 - GitHub Actions latest status: 
     - Build: https://github.com/ljubon/armada/actions?query=branch%3Afeature%2FWIP-CI-GithubAction
     - Publish (tag): https://github.com/ljubon/armada/actions?query=branch%3Av0.5.18
     - Charts repo PR: 
       - https://github.com/ljubon/charts/actions?query=branch%3Agithub-armada_v0.5.18
       - https://github.com/ljubon/charts/pull/105 



#### ===> Pre-Merged action required <===
Create secrets with the following names below, matching corresponding values used in CircleCI

- `NUGET_API_KEY`
- `ARMADA_CHART_UPDATE_KEY`
- `DOCKERHUB_PASS`
- `DOCKERHUB_USER`