### PR TITLE
Fix for lookout losing job on reprioritization.

### DIFF
--- a/internal/lookout/repository/store.go
+++ b/internal/lookout/repository/store.go
@@ -491,8 +491,9 @@ func determineJobState(tx *goqu.TxDatabase) exp.CaseExpression {
 			From("run_states"), stateAsLiteral(JobPending)).
 		When(tx.Select(goqu.I("run_states.running").Gt(0)).
 			From("run_states"), stateAsLiteral(JobRunning)).
-		When(tx.Select(goqu.I("run_states.succeeded").Eq(goqu.I("run_states.total"))).
-			From("run_states"), stateAsLiteral(JobSucceeded)).
+		When(goqu.And(
+			tx.Select(goqu.I("run_states.total").Gt(0)).From("run_states"),
+			tx.Select(goqu.I("run_states.succeeded").Eq(goqu.I("run_states.total"))).From("run_states")), stateAsLiteral(JobSucceeded)).
 		Else(stateAsLiteral(JobQueued))
 }
 

--- a/internal/lookout/repository/store_test.go
+++ b/internal/lookout/repository/store_test.go
@@ -833,6 +833,8 @@ func Test_JobUpdatedEvent(t *testing.T) {
 
 			assert.Equal(t, newPriority, getPriority(t, db, jobId))
 			assert.Equal(t, 0.0, getPriority(t, db, otherJobId))
+			assert.Equal(t, JobStateToIntMap[JobQueued], selectInt(t, db,
+				fmt.Sprintf("SELECT state FROM job WHERE job_id = '%s'", jobId)))
 
 			job := getJob(t, db, jobId)
 			assert.Equal(t, newPriority, job.Priority)


### PR DESCRIPTION
If you reprioritize a pending job in Lookout, the job will disappear from the UI, even though the job itself is reprioritized correctly and runs normally in Armada.  This is due to the folowing sequence of events.

* The reprioritization triggers a JobUpdated event.
* Lookout processes the JobUpdated event and updates the Job's status to Done even though it should still be Pending.
* As lookout thinks the Job is done, it removes it from the UI.

This change fixes the processing done by lookout such that the job remains in pending
