### PR TITLE
adding interceptors for embedding ids in gRPC requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
 	github.com/prometheus/client_golang v1.11.0
 	github.com/rakyll/statik v0.1.7
+	github.com/renstrom/shortuuid v3.0.0+incompatible // indirect
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5

--- a/go.mod
+++ b/go.mod
@@ -22,8 +22,8 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/protobuf v1.5.2
 	github.com/gomodule/redigo v2.0.0+incompatible // indirect
-	github.com/google/go-cmp v0.5.6 // indirect
-	github.com/google/uuid v1.1.2 // indirect
+	github.com/google/go-cmp v0.5.6
+	github.com/google/uuid v1.1.2
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
@@ -43,7 +43,7 @@ require (
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
 	github.com/prometheus/client_golang v1.11.0
 	github.com/rakyll/statik v0.1.7
-	github.com/renstrom/shortuuid v3.0.0+incompatible // indirect
+	github.com/renstrom/shortuuid v3.0.0+incompatible
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -629,8 +629,6 @@ github.com/mitchellh/mapstructure v1.4.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.4.2 h1:6h7AQ0yhTcIsmFmnAwQls75jp2Gzs4iB8W7pjMO+rqo=
 github.com/mitchellh/mapstructure v1.4.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-github.com/mitchellh/mapstructure v1.4.3 h1:OVowDSCllw/YjdLkam3/sm7wEtOy59d8ndGgCcyj8cs=
-github.com/mitchellh/mapstructure v1.4.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/sys/mountinfo v0.4.1/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
 github.com/moby/term v0.0.0-20201216013528-df9cb8a40635/go.mod h1:FBS0z0QWA44HXygs7VXDUOGoN/1TV3RuWkLO04am3wc=

--- a/go.sum
+++ b/go.sum
@@ -753,6 +753,8 @@ github.com/prometheus/procfs v0.7.1/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rakyll/statik v0.1.7 h1:OF3QCZUuyPxuGEP7B4ypUa7sB/iHtqOTDYZXGM8KOdQ=
 github.com/rakyll/statik v0.1.7/go.mod h1:AlZONWzMtEnMs7W4e/1LURLiI49pIMmp6V9Unghqrcc=
+github.com/renstrom/shortuuid v3.0.0+incompatible h1:F6T1U7bWlI3FTV+JE8HyeR7bkTeYZJntqQLA9ST4HOQ=
+github.com/renstrom/shortuuid v3.0.0+incompatible/go.mod h1:n18Ycpn8DijG+h/lLBQVnGKv1BCtTeXo8KKSbBOrQ8c=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/internal/common/requestid/interceptors.go
+++ b/internal/common/requestid/interceptors.go
@@ -1,0 +1,70 @@
+package requestid
+
+import (
+	"context"
+
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	"github.com/renstrom/shortuuid"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// Request IDs are embedded in HTTP headers using this key.
+// This is the standard key used for request Ids. For example, opentelemetry uses the same one.
+const MetadataKey = "x-request-id"
+
+// FromContext returns the request Id embedded in gRPC metadata stored in a context,
+// if one is available. The second return value is true if the operation was successful.
+func FromContext(ctx context.Context) (string, bool) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return "", false
+	}
+
+	ids, ok := md[MetadataKey]
+	if !ok || len(ids) == 0 {
+		return "", false
+	}
+
+	return ids[0], true
+}
+
+// AddToIncomingContext returns a new context derived from ctx that is annotated with an Id.
+// The Id is stored in the request gRPC metadata. If ctx already has an Id, it is overwritten.
+// The second return value is true if the operation was successful.
+func AddToIncomingContext(ctx context.Context, id string) (context.Context, bool) {
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		md.Set(MetadataKey, id)
+		return metadata.NewIncomingContext(ctx, md), true
+	}
+	return ctx, false
+}
+
+// UnaryServerInterceptor returns an interceptor that annotates incoming gRPC requests with an Id.
+// Ids are stored in the gRPC request metadata and are generated using github.com/renstrom/shortuuid.
+// If replace is false, this is only done for requests that do not already have an Id.
+func UnaryServerInterceptor(replace bool) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		if _, ok := FromContext(ctx); !ok || replace {
+			id := shortuuid.New()
+			ctx, _ = AddToIncomingContext(ctx, id) // If the operation fails, the original context is returned
+		}
+		return handler(ctx, req)
+	}
+}
+
+// StreamServerInterceptor returns an interceptor that annotates incoming gRPC requests with an Id.
+// Ids are stored in the gRPC request metadata and are generated using github.com/renstrom/shortuuid.
+// If replace is false, this is only done for requests that do not already have an Id.
+func StreamServerInterceptor(replace bool) grpc.StreamServerInterceptor {
+	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		ctx := stream.Context()
+		if _, ok := FromContext(ctx); !ok || replace {
+			id := shortuuid.New()
+			ctx, _ = AddToIncomingContext(ctx, id) // If the operation fails, the original context is returned
+		}
+		wrapped := grpc_middleware.WrapServerStream(stream)
+		wrapped.WrappedContext = ctx
+		return handler(srv, wrapped)
+	}
+}

--- a/internal/common/requestid/interceptors_test.go
+++ b/internal/common/requestid/interceptors_test.go
@@ -1,0 +1,170 @@
+package requestid
+
+import (
+	"context"
+	"testing"
+
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	"github.com/renstrom/shortuuid"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestAddGet(t *testing.T) {
+
+	ctx := context.Background()
+	ctx = metadata.NewIncomingContext(ctx, metadata.New(map[string]string{}))
+
+	// Test adding and getting an id
+	id := shortuuid.New()
+	ctx, ok := AddToIncomingContext(ctx, id)
+	if !ok {
+		t.Fatal("error adding id to context")
+	}
+
+	readId, ok := FromContext(ctx)
+	if !ok {
+		t.Fatal("error getting id from context")
+	}
+	if readId != id {
+		t.Fatalf("expected %q, but got %q", id, readId)
+	}
+
+	// Test overwriting the id
+	id = shortuuid.New()
+	ctx, ok = AddToIncomingContext(ctx, id)
+	if !ok {
+		t.Fatal("error overwriting id")
+	}
+
+	readId, ok = FromContext(ctx)
+	if !ok {
+		t.Fatal("error getting overwritten id from context")
+	}
+	if readId != id {
+		t.Fatalf("expected new id to be %q, but got %q", id, readId)
+	}
+}
+
+func TestUnaryServerInterceptor(t *testing.T) {
+	ctx := context.Background()
+	ctx = metadata.NewIncomingContext(ctx, metadata.New(map[string]string{}))
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		id, ok := FromContext(ctx)
+		if !ok {
+			t.Fatal("error getting id from context")
+		}
+		if id == "" {
+			t.Fatalf("got the empty string as id")
+		}
+		return nil, nil
+	}
+
+	replace := false
+	f := UnaryServerInterceptor(replace)
+	f(ctx, nil, nil, handler)
+
+	replace = true
+	f = UnaryServerInterceptor(replace)
+	f(ctx, nil, nil, handler)
+}
+
+func TestUnaryServerInterceptorWithExisting(t *testing.T) {
+	var replace bool
+	id := shortuuid.New()
+	ctx := context.Background()
+	ctx = metadata.NewIncomingContext(ctx, metadata.New(map[string]string{}))
+	ctx, ok := AddToIncomingContext(ctx, id)
+	if !ok {
+		t.Fatal("error adding id to context")
+	}
+
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		readId, ok := FromContext(ctx)
+		if !ok {
+			t.Fatal("error getting id from context")
+		}
+		if id == "" {
+			t.Fatal("got the empty string as id")
+		}
+		if replace && readId == id {
+			t.Fatal("existing id was not replaced")
+		}
+		if !replace && readId != id {
+			t.Fatal("existing id was replaced")
+		}
+		return nil, nil
+	}
+
+	replace = false
+	f := UnaryServerInterceptor(replace)
+	f(ctx, nil, nil, handler)
+
+	replace = true
+	f = UnaryServerInterceptor(replace)
+	f(ctx, nil, nil, handler)
+}
+
+func TestStreamServerInterceptor(t *testing.T) {
+	ctx := context.Background()
+	ctx = metadata.NewIncomingContext(ctx, metadata.New(map[string]string{}))
+	stream := &grpc_middleware.WrappedServerStream{}
+	stream.WrappedContext = ctx
+	handler := func(srv interface{}, stream grpc.ServerStream) error {
+		ctx := stream.Context()
+		id, ok := FromContext(ctx)
+		if !ok {
+			t.Fatal("error getting id from context")
+		}
+		if id == "" {
+			t.Fatalf("got the empty string as id")
+		}
+		return nil
+	}
+
+	replace := false
+	f := StreamServerInterceptor(replace)
+	f(nil, stream, nil, handler)
+
+	replace = true
+	f = StreamServerInterceptor(replace)
+	f(nil, stream, nil, handler)
+}
+
+func TestStreamServerInterceptorWithExisting(t *testing.T) {
+	var replace bool
+	id := shortuuid.New()
+	ctx := context.Background()
+	ctx = metadata.NewIncomingContext(ctx, metadata.New(map[string]string{}))
+	ctx, ok := AddToIncomingContext(ctx, id)
+	if !ok {
+		t.Fatal("error adding id to context")
+	}
+	stream := &grpc_middleware.WrappedServerStream{}
+	stream.WrappedContext = ctx
+	handler := func(srv interface{}, stream grpc.ServerStream) error {
+		ctx := stream.Context()
+		readId, ok := FromContext(ctx)
+		if !ok {
+			t.Fatal("error getting id from context")
+		}
+		if id == "" {
+			t.Fatal("got the empty string as id")
+		}
+		if replace && readId == id {
+			t.Fatal("existing id was not replaced")
+		}
+		if !replace && readId != id {
+			t.Fatal("existing id was replaced")
+		}
+		return nil
+	}
+
+	replace = false
+	f := StreamServerInterceptor(replace)
+	f(nil, stream, nil, handler)
+
+	replace = true
+	f = StreamServerInterceptor(replace)
+	f(nil, stream, nil, handler)
+}


### PR DESCRIPTION
This PR adds interceptors for embedding ids in gRPC requests in a manner that is compatible with, e.g., OpenTelemetry. The ids are embedded in the gRPC metadata, which is part of the request context.