### PR TITLE
Interceptors for adding request id and stack trace fields to request-scoped logrus loggers

### DIFF
--- a/internal/common/logging/interceptors.go
+++ b/internal/common/logging/interceptors.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/G-Research/armada/internal/common/requestid"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus/ctxlogrus"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
+
+	"github.com/G-Research/armada/internal/common/requestid"
 )
 
 // UnaryServerInterceptor returns an interceptor that adds the request id as a

--- a/internal/common/logging/interceptors.go
+++ b/internal/common/logging/interceptors.go
@@ -1,0 +1,46 @@
+package logging
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/G-Research/armada/internal/common/requestid"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus/ctxlogrus"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+)
+
+// UnaryServerInterceptor returns an interceptor that adds the request id as a
+// field to the logrus logger embedded in the context. If an error occurs in the handler,
+// it also adds a stack trace.
+func UnaryServerInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		if id, ok := requestid.FromContext(ctx); ok {
+			ctxlogrus.AddFields(ctx, logrus.Fields{requestid.MetadataKey: id})
+		}
+		rv, err := handler(ctx, req)
+		if err != nil {
+			// %+v prints a stack trace for pkg/errors errors
+			ctxlogrus.AddFields(ctx, logrus.Fields{"errorVerbose": fmt.Sprintf("%+v", err)})
+		}
+		return rv, err
+	}
+}
+
+// StreamServerInterceptor returns an interceptor that adds the request id as a
+// field to the logrus logger embedded in the context. If an error occurs in the handler,
+// it also adds a stack trace.
+func StreamServerInterceptor() grpc.StreamServerInterceptor {
+	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		ctx := stream.Context()
+		if id, ok := requestid.FromContext(ctx); ok {
+			ctxlogrus.AddFields(ctx, logrus.Fields{requestid.MetadataKey: id})
+		}
+		err := handler(srv, stream)
+		if err != nil {
+			// %+v prints a stack trace for pkg/errors errors
+			ctxlogrus.AddFields(ctx, logrus.Fields{"errorVerbose": fmt.Sprintf("%+v", err)})
+		}
+		return err
+	}
+}

--- a/internal/common/logging/interceptors_test.go
+++ b/internal/common/logging/interceptors_test.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"testing"
 
-	"github.com/G-Research/armada/internal/common/requestid"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus/ctxlogrus"
 	"github.com/renstrom/shortuuid"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
+
+	"github.com/G-Research/armada/internal/common/requestid"
 )
 
 func TestUnaryServerInterceptor(t *testing.T) {

--- a/internal/common/logging/interceptors_test.go
+++ b/internal/common/logging/interceptors_test.go
@@ -1,0 +1,69 @@
+package logging
+
+import (
+	"context"
+	"testing"
+
+	"github.com/G-Research/armada/internal/common/requestid"
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus/ctxlogrus"
+	"github.com/renstrom/shortuuid"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestUnaryServerInterceptor(t *testing.T) {
+	ctx := context.Background()
+	ctx = metadata.NewIncomingContext(ctx, metadata.New(map[string]string{}))
+	id := shortuuid.New()
+	ctx, ok := requestid.AddToIncomingContext(ctx, id)
+	if !ok {
+		t.Fatal("error adding request id to context")
+	}
+	logger := logrus.New()
+	entry := logrus.NewEntry(logger)
+	ctx = ctxlogrus.ToContext(ctx, entry)
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		entry := ctxlogrus.Extract(ctx)
+		for _, field := range entry.Data {
+			if s, ok := field.(string); ok && s == id {
+				return nil, nil
+			}
+		}
+		t.Fatal("request id was not added as a logger field")
+		return nil, nil
+	}
+
+	f := UnaryServerInterceptor()
+	f(ctx, nil, nil, handler)
+}
+
+func TestStreamServerInterceptor(t *testing.T) {
+	ctx := context.Background()
+	ctx = metadata.NewIncomingContext(ctx, metadata.New(map[string]string{}))
+	id := shortuuid.New()
+	ctx, ok := requestid.AddToIncomingContext(ctx, id)
+	if !ok {
+		t.Fatal("error adding request id to context")
+	}
+	logger := logrus.New()
+	entry := logrus.NewEntry(logger)
+	ctx = ctxlogrus.ToContext(ctx, entry)
+	stream := &grpc_middleware.WrappedServerStream{}
+	stream.WrappedContext = ctx
+	handler := func(srv interface{}, stream grpc.ServerStream) error {
+		ctx := stream.Context()
+		entry := ctxlogrus.Extract(ctx)
+		for _, field := range entry.Data {
+			if s, ok := field.(string); ok && s == id {
+				return nil
+			}
+		}
+		t.Fatal("request id was not added as a logger field")
+		return nil
+	}
+
+	f := StreamServerInterceptor()
+	f(nil, stream, nil, handler)
+}


### PR DESCRIPTION
This PR adds interceptors that automatically enrich loggers embedded in a context with a request id and a stack trace recorded via pkg/errors.