### PR TITLE
Use a headless service for ingresses

### DIFF
--- a/internal/executor/util/kubernetes_object.go
+++ b/internal/executor/util/kubernetes_object.go
@@ -24,8 +24,7 @@ func CreateService(job *api.Job, pod *v1.Pod, ports []v1.ServicePort, ingSvcType
 	}
 
 	clusterIP := ""
-
-	if ingSvcType == Headless {
+	if ingSvcType == Headless || ingSvcType == Ingress {
 		clusterIP = "None"
 	}
 

--- a/internal/executor/util/kubernetes_objects_test.go
+++ b/internal/executor/util/kubernetes_objects_test.go
@@ -298,7 +298,7 @@ func TestCreateService_Ingress(t *testing.T) {
 				"armada_pod_number": "0",
 				"armada_queue_id":   "test_queue_id",
 			},
-			Type: "ClusterIP",
+			Type:      "ClusterIP",
 			ClusterIP: "None",
 		},
 	}

--- a/internal/executor/util/kubernetes_objects_test.go
+++ b/internal/executor/util/kubernetes_objects_test.go
@@ -299,6 +299,7 @@ func TestCreateService_Ingress(t *testing.T) {
 				"armada_queue_id":   "test_queue_id",
 			},
 			Type: "ClusterIP",
+			ClusterIP: "None",
 		},
 	}
 	assert.Equal(t, createdService, expected)


### PR DESCRIPTION
Ingresses don't need to be backed by a ClusterIP service, a headless one works fine.

Given we've been running out of ClusterIP addresses at GR, let's just use a headless service.