### PR TITLE
Fix armada-load-tester config flag redefinition

### DIFF
--- a/cmd/armada-load-tester/cmd/root.go
+++ b/cmd/armada-load-tester/cmd/root.go
@@ -11,7 +11,6 @@ import (
 
 func init() {
 	cobra.OnInitialize(initConfig)
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.armadactl.yaml)")
 	client.AddArmadaApiConnectionCommandlineArgs(rootCmd)
 }
 


### PR DESCRIPTION
Currently always fails as the `--config` flag is defined twice: once in `root.go`, and once in `AddArmadaApiConnectionCommandlineArgs`.