### PR TITLE
Change ingress generation to generate one less subdomain

### DIFF
--- a/internal/executor/util/kubernetes_object.go
+++ b/internal/executor/util/kubernetes_object.go
@@ -93,7 +93,7 @@ func CreateIngress(
 		if !contains(jobConfig, uint32(servicePort.Port)) {
 			continue
 		}
-		host := fmt.Sprintf("%s.%s.%s.%s", servicePort.Name, pod.Name, pod.Namespace, executorIngressConfig.HostnameSuffix)
+		host := fmt.Sprintf("%s-%s.%s.%s", servicePort.Name, pod.Name, pod.Namespace, executorIngressConfig.HostnameSuffix)
 		tlsHosts = append(tlsHosts, host)
 
 		path := networking.IngressRule{

--- a/internal/executor/util/kubernetes_objects_test.go
+++ b/internal/executor/util/kubernetes_objects_test.go
@@ -181,7 +181,7 @@ func TestCreateIngress_Basic(t *testing.T) {
 		TLS: []networking.IngressTLS{},
 		Rules: []networking.IngressRule{
 			{
-				Host: "testPort.testPod.testNamespace.testSuffix",
+				Host: "testPort-testPod.testNamespace.testSuffix",
 				IngressRuleValue: networking.IngressRuleValue{
 					HTTP: &networking.HTTPIngressRuleValue{
 						Paths: []networking.HTTPIngressPath{
@@ -224,14 +224,14 @@ func TestCreateIngress_TLS(t *testing.T) {
 		TLS: []networking.IngressTLS{
 			{
 				Hosts: []string{
-					"testPort.testPod.testNamespace.testSuffix",
+					"testPort-testPod.testNamespace.testSuffix",
 				},
 				SecretName: "testNamespace-ingress-tls-certificate",
 			},
 		},
 		Rules: []networking.IngressRule{
 			{
-				Host: "testPort.testPod.testNamespace.testSuffix",
+				Host: "testPort-testPod.testNamespace.testSuffix",
 				IngressRuleValue: networking.IngressRuleValue{
 					HTTP: &networking.HTTPIngressRuleValue{
 						Paths: []networking.HTTPIngressPath{


### PR DESCRIPTION
Wildcard certs can only manage one subdomain matching. This change combines the container port name and the armada pod name into one subdomain to allow for wildcard matching.