### PR TITLE
Find armadactl config in the same folder was kubectl

### DIFF
--- a/pkg/client/command_line.go
+++ b/pkg/client/command_line.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v2"
+	"k8s.io/client-go/util/homedir"
 
 	"github.com/G-Research/armada/internal/fileutils"
 )
@@ -77,9 +78,9 @@ func LoadCommandlineArgsFromConfigFile(cfgFile string) error {
 		}
 		viper.SetConfigFile(cfgFile)
 	} else {
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			return fmt.Errorf("[LoadCommandlineArgsFromConfigFile] error getting user home directory: %s", err)
+		homeDir := homedir.HomeDir()
+		if homeDir == "" {
+			return fmt.Errorf("[LoadCommandlineArgsFromConfigFile] unable to determine home directory")
 		}
 		viper.AddConfigPath(homeDir)
 		viper.SetConfigName(".armadactl")

--- a/pkg/client/command_line.go
+++ b/pkg/client/command_line.go
@@ -79,7 +79,7 @@ func LoadCommandlineArgsFromConfigFile(cfgFile string) error {
 		viper.SetConfigFile(cfgFile)
 	} else {
 		homeDir, err := homedir.Dir()
-		if homeDir == "" {
+		if err != nil {
 			return fmt.Errorf("[LoadCommandlineArgsFromConfigFile] error getting home directory: %s", err)
 		}
 		viper.AddConfigPath(homeDir)

--- a/pkg/client/command_line.go
+++ b/pkg/client/command_line.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v2"
-	"k8s.io/client-go/util/homedir"
 
 	"github.com/G-Research/armada/internal/fileutils"
 )
@@ -78,9 +78,9 @@ func LoadCommandlineArgsFromConfigFile(cfgFile string) error {
 		}
 		viper.SetConfigFile(cfgFile)
 	} else {
-		homeDir := homedir.HomeDir()
+		homeDir, err := homedir.Dir()
 		if homeDir == "" {
-			return fmt.Errorf("[LoadCommandlineArgsFromConfigFile] unable to determine home directory")
+			return fmt.Errorf("[LoadCommandlineArgsFromConfigFile] error getting home directory: %s", err)
 		}
 		viper.AddConfigPath(homeDir)
 		viper.SetConfigName(".armadactl")


### PR DESCRIPTION
We recently changed the way we find the homedir when looking for `.armadactl.yaml` to the user home dir

The issue with this is it can be quite different to the way kubectl finds its configuration

Swapping back to what we used to use, as this is much more consistent with kubectl
 - This change is pretty much a noop for linux