### PR TITLE
Remove accelerator logging

### DIFF
--- a/internal/executor/utilisation/pod_utilisation.go
+++ b/internal/executor/utilisation/pod_utilisation.go
@@ -186,7 +186,6 @@ func (q *KubeletPodUtilisationService) updatePodStats(podStats *v1alpha1.PodStat
 	// add custom metrics for gpu
 	for _, c := range podStats.Containers {
 		for _, a := range c.Accelerators {
-			log.Infof("Detected accelerator: %s %s", a.Make, a.Model)
 			accelerator = true
 			acceleratorDutyCycles += int64(a.DutyCycle)
 			acceleratorUsedMemory += int64(a.MemoryUsed)


### PR DESCRIPTION
This log line gets called for every pod using an accelerator on the cluster, every 5 seconds (configured by `queueUsageDataRefreshInterval`)

This causes massive spam for little to no benefit