### PR TITLE
Only report jobs done once their state has been reported

### DIFF
--- a/internal/executor/service/util.go
+++ b/internal/executor/service/util.go
@@ -46,7 +46,7 @@ func jobShouldBeRenewed(job *job.RunningJob) bool {
 
 func shouldBeReportedDone(job *job.RunningJob) bool {
 	for _, pod := range job.ActivePods {
-		if util.IsInTerminalState(pod) && !util.IsReportedDone(pod) {
+		if util.IsInTerminalState(pod) && util.HasCurrentStateBeenReported(pod) && !util.IsReportedDone(pod) {
 			return true
 		}
 	}


### PR DESCRIPTION
Normally the state gets reported instantly so this is already true 99% of the time.

However if reporting the state goes wrong, we shouldn't report the job as done
 - Otherwise the server will tell the executor to kill the pod when it tries to maintain the lease

In all other places we make sure the JobEvent has been reported first before reporting done, so we should do that here too

This will only really impact edge cases and most of the time this will already be true