### PR TITLE
[quickstart]: bitami/postgresql updated variable

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -135,7 +135,7 @@ EXECUTOR_1_IP=$(kubectl get nodes quickstart-armada-executor-1-worker -o jsonpat
 kind export kubeconfig --name=quickstart-armada-server
 
 # Install postgres
-helm install postgres bitnami/postgresql --set postgresqlPassword=psw
+helm install postgres bitnami/postgresql --set auth.postgresPassword=psw
 
 # Run database migration
 helm install lookout-migration gresearch/armada-lookout-migration -f docs/quickstart/lookout-values.yaml


### PR DESCRIPTION
The official chart seems to of changed the location of the postgresPassword variable and so people can't set the password during the quickstart guide. Tested this locally

```bash
$ helm template postgres bitnami/postgresql --set auth.postgresPassword=test | grep "postgres-password:" | awk '{print $2}' | tr -d '"' | base64 -d
test
```