### PR TITLE
Log job submit API deduplication

### DIFF
--- a/e2e/pulsar_test/pulsar_test.go
+++ b/e2e/pulsar_test/pulsar_test.go
@@ -135,6 +135,12 @@ func TestDedup(t *testing.T) {
 			return nil
 		}
 
+		numEventsExpected := len(res.JobResponseItems) * 6
+		_, err = receiveJobSetSequences(ctx, consumer, armadaQueueName, req.JobSetId, numEventsExpected, 10*time.Second)
+		if err != nil {
+			return err
+		}
+
 		// The second time, all jobs should be rejected.
 		req = createJobSubmitRequestWithClientId(numJobs, clientId)
 		ctxWithTimeout, _ = context.WithTimeout(context.Background(), time.Second)
@@ -145,6 +151,12 @@ func TestDedup(t *testing.T) {
 
 		if ok := assert.Equal(t, 0, len(res.JobResponseItems)); !ok {
 			return nil
+		}
+
+		numEventsExpected = len(res.JobResponseItems) * 6
+		_, err = receiveJobSetSequences(ctx, consumer, armadaQueueName, req.JobSetId, numEventsExpected, 10*time.Second)
+		if err != nil {
+			return err
 		}
 
 		// Check for partial rejection
@@ -159,6 +171,12 @@ func TestDedup(t *testing.T) {
 
 		if ok := assert.Equal(t, numJobs, len(res.JobResponseItems)); !ok {
 			return nil
+		}
+
+		numEventsExpected = len(res.JobResponseItems) * 6
+		_, err = receiveJobSetSequences(ctx, consumer, armadaQueueName, req.JobSetId, numEventsExpected, 10*time.Second)
+		if err != nil {
+			return err
 		}
 
 		return nil

--- a/e2e/pulsar_test/pulsar_test.go
+++ b/e2e/pulsar_test/pulsar_test.go
@@ -124,7 +124,7 @@ func TestDedup(t *testing.T) {
 		clientId := uuid.New().String()
 		originalJobIds := make([]string, numJobs)
 
-		// The first time, all jobs should be submitted.
+		// The first time, all jobs should be submitted as-is.
 		req := createJobSubmitRequestWithClientId(numJobs, clientId)
 		ctxWithTimeout, _ := context.WithTimeout(context.Background(), time.Second)
 		res, err := client.SubmitJobs(ctxWithTimeout, req)
@@ -146,7 +146,7 @@ func TestDedup(t *testing.T) {
 			return err
 		}
 
-		// The second time, all jobs should be rejected.
+		// The second time, job ids should be replaced with the original ids.
 		req = createJobSubmitRequestWithClientId(numJobs, clientId)
 		ctxWithTimeout, _ = context.WithTimeout(context.Background(), time.Second)
 		res, err = client.SubmitJobs(ctxWithTimeout, req)
@@ -168,7 +168,7 @@ func TestDedup(t *testing.T) {
 			return err
 		}
 
-		// Check for partial rejection
+		// Here, some ids should be replaced and some should be new.
 		req = createJobSubmitRequestWithClientId(numJobs, clientId)
 		req2 := createJobSubmitRequestWithClientId(numJobs, uuid.New().String())
 		req.JobRequestItems = append(req.JobRequestItems, req2.JobRequestItems...)

--- a/e2e/pulsar_test/pulsar_test.go
+++ b/e2e/pulsar_test/pulsar_test.go
@@ -72,7 +72,7 @@ func TestPublishReceive(t *testing.T) {
 // Test that submitting many jobs results in the correct sequence of Pulsar message being produced for each job.
 func TestSubmitJobs(t *testing.T) {
 	err := withSetup(func(ctx context.Context, client api.SubmitClient, producer pulsar.Producer, consumer pulsar.Consumer) error {
-		numJobs := 1
+		numJobs := 2
 		req := createJobSubmitRequest(numJobs)
 		ctxWithTimeout, _ := context.WithTimeout(context.Background(), time.Second)
 		res, err := client.SubmitJobs(ctxWithTimeout, req)
@@ -111,6 +111,54 @@ func TestSubmitJobs(t *testing.T) {
 			if ok := isSequencef(t, expected, actual, "Event sequence error; printing diff:\n%s", cmp.Diff(expected, actual)); !ok {
 				return nil
 			}
+		}
+
+		return nil
+	})
+	assert.NoError(t, err)
+}
+
+func TestDedup(t *testing.T) {
+	err := withSetup(func(ctx context.Context, client api.SubmitClient, producer pulsar.Producer, consumer pulsar.Consumer) error {
+		numJobs := 2
+		clientId := uuid.New().String()
+
+		// The first time, all jobs should be submitted.
+		req := createJobSubmitRequestWithClientId(numJobs, clientId)
+		ctxWithTimeout, _ := context.WithTimeout(context.Background(), time.Second)
+		res, err := client.SubmitJobs(ctxWithTimeout, req)
+		if err != nil {
+			return err
+		}
+
+		if ok := assert.Equal(t, numJobs, len(res.JobResponseItems)); !ok {
+			return nil
+		}
+
+		// The second time, all jobs should be rejected.
+		req = createJobSubmitRequestWithClientId(numJobs, clientId)
+		ctxWithTimeout, _ = context.WithTimeout(context.Background(), time.Second)
+		res, err = client.SubmitJobs(ctxWithTimeout, req)
+		if err != nil {
+			return err
+		}
+
+		if ok := assert.Equal(t, 0, len(res.JobResponseItems)); !ok {
+			return nil
+		}
+
+		// Check for partial rejection
+		req = createJobSubmitRequestWithClientId(numJobs, clientId)
+		req2 := createJobSubmitRequestWithClientId(numJobs, uuid.New().String())
+		req.JobRequestItems = append(req.JobRequestItems, req2.JobRequestItems...)
+		ctxWithTimeout, _ = context.WithTimeout(context.Background(), time.Second)
+		res, err = client.SubmitJobs(ctxWithTimeout, req)
+		if err != nil {
+			return err
+		}
+
+		if ok := assert.Equal(t, numJobs, len(res.JobResponseItems)); !ok {
+			return nil
 		}
 
 		return nil
@@ -678,14 +726,23 @@ func filterOutStandaloneIngressInfo(sequence *armadaevents.EventSequence) (*arma
 
 // Create a job submit request for testing.
 func createJobSubmitRequest(numJobs int) *api.JobSubmitRequest {
+	return createJobSubmitRequestWithClientId(numJobs, uuid.New().String())
+}
+
+// Create a job submit request for testing.
+func createJobSubmitRequestWithClientId(numJobs int, clientId string) *api.JobSubmitRequest {
 	cpu, _ := resource.ParseQuantity("80m")
 	memory, _ := resource.ParseQuantity("50Mi")
 	items := make([]*api.JobSubmitRequestItem, numJobs, numJobs)
 	for i := 0; i < numJobs; i++ {
+		itemClientId := clientId
+		if itemClientId != "" {
+			itemClientId = fmt.Sprintf("%s-%d", itemClientId, i)
+		}
 		items[i] = &api.JobSubmitRequestItem{
 			Namespace: userNamespace,
 			Priority:  1,
-			ClientId:  uuid.New().String(), // So we can test that we get back the right thing
+			ClientId:  itemClientId,
 			PodSpec: &v1.PodSpec{
 				Containers: []v1.Container{
 					{

--- a/e2e/setup/pulsar/armada-config.yaml
+++ b/e2e/setup/pulsar/armada-config.yaml
@@ -7,14 +7,14 @@ pulsar:
   hostnameSuffix: "svc"
   certNameSuffix: "ingress-tls-certificate"
   dedupTable: pulsar_submit_dedup
-  postgres:
-    maxOpenConns: 100
-    maxIdleConns: 25
-    connMaxLifetime: 30m
-    connection:
-      host: postgres
-      port: 5432
-      user: postgres
-      password: psw
-      dbname: postgres
-      sslmode: disable
+postgres:
+  maxOpenConns: 100
+  maxIdleConns: 25
+  connMaxLifetime: 30m
+  connection:
+    host: postgres
+    port: 5432
+    user: postgres
+    password: psw
+    dbname: postgres
+    sslmode: disable  

--- a/e2e/setup/pulsar/armada-config.yaml
+++ b/e2e/setup/pulsar/armada-config.yaml
@@ -6,3 +6,15 @@ pulsar:
   pulsarFromPulsarSubscription: "PulsarFromPulsar"
   hostnameSuffix: "svc"
   certNameSuffix: "ingress-tls-certificate"
+  dedupTable: pulsar_submit_dedup
+  postgres:
+    maxOpenConns: 100
+    maxIdleConns: 25
+    connMaxLifetime: 30m
+    connection:
+      host: postgres
+      port: 5432
+      user: postgres
+      password: psw
+      dbname: postgres
+      sslmode: disable

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/hashicorp/golang-lru v0.5.4
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/instrumenta/kubeval v0.0.0-20190918223246-8d013ec9fc56
 	github.com/jackc/pgconn v1.11.0

--- a/internal/armada/configuration/types.go
+++ b/internal/armada/configuration/types.go
@@ -68,7 +68,8 @@ type PulsarConfig struct {
 	CertNameSuffix string
 	Annotations    map[string]string
 	// Settings for deduplication, which relies on a postgres server.
-	DedupPostgresConfig PostgresConfig
+	Postgres   PostgresConfig
+	DedupTable string
 }
 
 type SchedulingConfig struct {

--- a/internal/armada/configuration/types.go
+++ b/internal/armada/configuration/types.go
@@ -32,6 +32,7 @@ type ArmadaConfig struct {
 	DatabaseRetention DatabaseRetentionPolicy
 	EventRetention    EventRetentionPolicy
 	Pulsar            PulsarConfig
+	Postgres          PostgresConfig // Used for Pulsar submit API deduplication
 
 	Metrics MetricsConfig
 }
@@ -68,7 +69,6 @@ type PulsarConfig struct {
 	CertNameSuffix string
 	Annotations    map[string]string
 	// Settings for deduplication, which relies on a postgres server.
-	Postgres   PostgresConfig
 	DedupTable string
 }
 

--- a/internal/armada/configuration/types.go
+++ b/internal/armada/configuration/types.go
@@ -7,12 +7,12 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/G-Research/armada/internal/common"
-	"github.com/G-Research/armada/internal/common/auth/configuration"
+	authconfig "github.com/G-Research/armada/internal/common/auth/configuration"
 	"github.com/G-Research/armada/pkg/client/queue"
 )
 
 type ArmadaConfig struct {
-	Auth configuration.AuthConfig
+	Auth authconfig.AuthConfig
 
 	GrpcPort           uint16
 	HttpPort           uint16
@@ -67,6 +67,8 @@ type PulsarConfig struct {
 	HostnameSuffix string
 	CertNameSuffix string
 	Annotations    map[string]string
+	// Settings for deduplication, which relies on a postgres server.
+	DedupPostgresConfig PostgresConfig
 }
 
 type SchedulingConfig struct {
@@ -109,6 +111,13 @@ type EventsConfig struct {
 	ProcessorBatchSize             int           // Maximum event batch size
 	ProcessorMaxTimeBetweenBatches time.Duration // Maximum time between batches
 	ProcessorTimeout               time.Duration // Timeout for reporting event or stopping batcher before erroring out
+}
+
+type PostgresConfig struct {
+	MaxOpenConns    int
+	MaxIdleConns    int
+	ConnMaxLifetime time.Duration
+	Connection      map[string]string
 }
 
 type NatsConfig struct {

--- a/internal/armada/server.go
+++ b/internal/armada/server.go
@@ -199,9 +199,9 @@ func Serve(config *configuration.ArmadaConfig, healthChecks *health.MultiChecker
 		submitServerToRegister = pulsarSubmitServer
 
 		// If postgres details were provided, enable deduplication.
-		if config.Pulsar.DedupTable != "" && config.Pulsar.Postgres.Connection != nil {
+		if config.Pulsar.DedupTable != "" {
 			log.Info("Pulsar submit API deduplication enabled")
-			db, err := postgres.OpenPgxPool(config.Pulsar.Postgres)
+			db, err := postgres.OpenPgxPool(config.Postgres)
 			if err != nil {
 				panic(err)
 			}

--- a/internal/armada/server.go
+++ b/internal/armada/server.go
@@ -205,7 +205,7 @@ func Serve(config *configuration.ArmadaConfig, healthChecks *health.MultiChecker
 			if err != nil {
 				panic(err)
 			}
-			store, err := pgkeyvalue.New(db, config.Pulsar.DedupTable)
+			store, err := pgkeyvalue.New(db, 1000000, config.Pulsar.DedupTable)
 			if err != nil {
 				panic(err)
 			}

--- a/internal/armada/server.go
+++ b/internal/armada/server.go
@@ -199,8 +199,6 @@ func Serve(config *configuration.ArmadaConfig, healthChecks *health.MultiChecker
 		submitServerToRegister = pulsarSubmitServer
 
 		// If postgres details were provided, enable deduplication.
-		log.Infof("DedupTable: %s\n", config.Pulsar.DedupTable)
-		log.Infof("Postgres: %+v\n", config.Pulsar.Postgres)
 		if config.Pulsar.DedupTable != "" && config.Pulsar.Postgres.Connection != nil {
 			log.Info("Pulsar submit API deduplication enabled")
 			db, err := postgres.OpenPgxPool(config.Pulsar.Postgres)

--- a/internal/armada/server/reporting.go
+++ b/internal/armada/server/reporting.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/G-Research/armada/internal/armada/repository"
@@ -56,6 +57,22 @@ func reportDuplicateDetected(repository repository.EventStore, results []*reposi
 		return fmt.Errorf("[reportDuplicateDetected] error reporting events: %w", err)
 	}
 
+	return nil
+}
+
+func reportDuplicateFoundEvents(repository repository.EventStore, events []*api.JobDuplicateFoundEvent) error {
+	apiEvents := make([]*api.EventMessage, len(events))
+	for i, event := range events {
+		event, err := api.Wrap(event)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		apiEvents[i] = event
+	}
+	err := repository.ReportEvents(apiEvents)
+	if err != nil {
+		return errors.WithStack(err)
+	}
 	return nil
 }
 

--- a/internal/armada/server/submit_to_log.go
+++ b/internal/armada/server/submit_to_log.go
@@ -224,8 +224,9 @@ func (srv *PulsarSubmitServer) removeDuplicateSubmissions(ctx context.Context, q
 		// ok=true indicates insertion was successful,
 		// whereas ok=false indicates the key already exists
 		// (i.e., this submission is a duplicate).
-		ok, err := srv.KVStore.AddKey(ctx, string(combinedHash[:]))
-		if err == nil {
+		dedupKey := fmt.Sprintf("%x", combinedHash)
+		ok, err := srv.KVStore.AddKey(ctx, dedupKey)
+		if err != nil {
 			return nil, errors.WithStack(err)
 		}
 		if ok {

--- a/internal/armada/server/submit_to_log.go
+++ b/internal/armada/server/submit_to_log.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"crypto/sha1"
 	"fmt"
 	"time"
 
@@ -21,6 +22,7 @@ import (
 	"github.com/G-Research/armada/internal/common/eventutil"
 	"github.com/G-Research/armada/internal/common/requestid"
 	executorconfig "github.com/G-Research/armada/internal/executor/configuration"
+	"github.com/G-Research/armada/internal/pgkeyvalue"
 	"github.com/G-Research/armada/internal/pulsarutils/pulsarrequestid"
 	"github.com/G-Research/armada/pkg/api"
 	"github.com/G-Research/armada/pkg/armadaevents"
@@ -44,6 +46,7 @@ type PulsarSubmitServer struct {
 	SubmitServer *SubmitServer
 	// Used to create k8s objects from the submitted ingresses and services.
 	IngressConfig *executorconfig.IngressConfiguration
+	KVStore       *pgkeyvalue.PGKeyValueStore
 }
 
 // TODO: Add input validation to make sure messages can be inserted to the database.
@@ -54,6 +57,52 @@ func (srv *PulsarSubmitServer) SubmitJobs(ctx context.Context, req *api.JobSubmi
 	if err != nil {
 		return nil, err
 	}
+
+	// Filter out job requests with previously seen client ids.
+	// For storage efficiency, we store hashes instead of user-provided strings.
+	// For computational efficiency, we create a lookup table to avoid computing the same hash twice.
+	// Client ids are namespaced by queue. Hence, we hash the client id together with the queue.
+	jobSubmitRequestItems := make([]*api.JobSubmitRequestItem, 0, len(req.JobRequestItems))
+	combinedHashData := make([]byte, 40)
+	queueHash := sha1.Sum([]byte(req.Queue))
+	for i, b := range queueHash {
+		combinedHashData[i] = b
+	}
+	combinedHhashFromClientId := make(map[string][20]byte)
+	for _, item := range req.JobRequestItems {
+
+		// Empty ClientId indicates no deduplication.
+		if item.ClientId == "" {
+			jobSubmitRequestItems = append(jobSubmitRequestItems, item)
+			continue
+		}
+
+		// Otherwise hash the ClientId (or get it from the table, if possible).
+		combinedHash, ok := combinedHhashFromClientId[item.ClientId]
+		if !ok {
+			clientIdHash := sha1.Sum([]byte(item.ClientId))
+
+			// Compute the combined hash.
+			for i, b := range clientIdHash {
+				combinedHashData[i+20] = b
+			}
+			combinedHash = sha1.Sum(combinedHashData)
+			combinedHhashFromClientId[item.ClientId] = combinedHash
+		}
+
+		// Check if we've seen the hash before.
+		// ok=true indicates insertion was successful,
+		// whereas ok=false indicates the key already exists
+		// (i.e., this submission is a duplicate).
+		ok, err := srv.KVStore.AddKey(ctx, string(combinedHash[:]))
+		if err == nil {
+			return nil, errors.WithStack(err)
+		}
+		if ok {
+			jobSubmitRequestItems = append(jobSubmitRequestItems, item)
+		}
+	}
+	req.JobRequestItems = jobSubmitRequestItems
 
 	// Prepare an event sequence to be submitted to the log
 	sequence := &armadaevents.EventSequence{

--- a/internal/lookout/configuration/types.go
+++ b/internal/lookout/configuration/types.go
@@ -23,13 +23,6 @@ type LookoutUIConfig struct {
 	JobsAutoRefreshMs     int
 }
 
-type PostgresConfig struct {
-	MaxOpenConns    int
-	MaxIdleConns    int
-	ConnMaxLifetime time.Duration
-	Connection      map[string]string
-}
-
 type PrunerConfig struct {
 	DaysToKeep int
 	BatchSize  int
@@ -45,14 +38,14 @@ type LookoutConfiguration struct {
 	EventQueue             string
 	Nats                   NatsConfig
 	Jetstream              configuration.JetstreamConfig
-	Postgres               PostgresConfig
+	Postgres               configuration.PostgresConfig
 	PrunerConfig           PrunerConfig
 	DisableEventProcessing bool
 }
 
 type LookoutIngesterConfiguration struct {
 	// Database configuration
-	Postgres PostgresConfig
+	Postgres configuration.PostgresConfig
 	// General Pulsar configuration
 	Pulsar configuration.PulsarConfig
 	// Pulsar subscription name

--- a/internal/lookout/metrics/db_metrics_provider.go
+++ b/internal/lookout/metrics/db_metrics_provider.go
@@ -3,7 +3,7 @@ package metrics
 import (
 	"database/sql"
 
-	"github.com/G-Research/armada/internal/lookout/configuration"
+	"github.com/G-Research/armada/internal/armada/configuration"
 )
 
 type LookoutDbMetricsProvider interface {

--- a/internal/lookout/postgres/postgres.go
+++ b/internal/lookout/postgres/postgres.go
@@ -8,7 +8,7 @@ import (
 	"github.com/jackc/pgx/v4/pgxpool"
 	_ "github.com/jackc/pgx/v4/stdlib"
 
-	"github.com/G-Research/armada/internal/lookout/configuration"
+	"github.com/G-Research/armada/internal/armada/configuration"
 )
 
 func Open(config configuration.PostgresConfig) (*sql.DB, error) {

--- a/internal/lookout/repository/job_pruner_test.go
+++ b/internal/lookout/repository/job_pruner_test.go
@@ -82,7 +82,7 @@ func queryForIds(t *testing.T, db *sql.DB, table string) []string {
 }
 
 func withPopulatedDatabase(t *testing.T, action func(db *sql.DB)) {
-	testutil.WithDatabase(t, func(db *sql.DB) {
+	err := testutil.WithDatabase(func(db *sql.DB) error {
 		for i := 0; i < 10; i++ {
 			jobId := fmt.Sprintf("job-%v", i)
 			runId := fmt.Sprintf("job-%v-run", i)
@@ -112,5 +112,7 @@ func withPopulatedDatabase(t *testing.T, action func(db *sql.DB)) {
 			assert.NoError(t, err4)
 		}
 		action(db)
+		return nil
 	})
+	assert.NoError(t, err)
 }

--- a/internal/lookout/repository/store_test.go
+++ b/internal/lookout/repository/store_test.go
@@ -946,7 +946,9 @@ func selectNullString(t *testing.T, db *goqu.Database, query string) sql.NullStr
 }
 
 func withDatabase(t *testing.T, action func(*goqu.Database)) {
-	testutil.WithDatabase(t, func(testDb *sql.DB) {
+	err := testutil.WithDatabase(func(testDb *sql.DB) error {
 		action(goqu.New("postgres", testDb))
+		return nil
 	})
+	assert.NoError(t, err)
 }

--- a/internal/lookoutingester/lookoutdb/insertion_test.go
+++ b/internal/lookoutingester/lookoutdb/insertion_test.go
@@ -200,7 +200,7 @@ var expectedJobRunContainer = JobRunContainerRow{
 }
 
 func TestCreateJobsBatch(t *testing.T) {
-	testutil.WithDatabasePgx(t, func(db *pgxpool.Pool) {
+	err := testutil.WithDatabasePgx(func(db *pgxpool.Pool) error {
 		// Insert
 		err := CreateJobsBatch(ctx.Background(), db, defaultInstructionSet().JobsToCreate)
 		assert.Nil(t, err)
@@ -221,11 +221,13 @@ func TestCreateJobsBatch(t *testing.T) {
 		err = CreateJobsBatch(ctx.Background(), db, append(defaultInstructionSet().JobsToCreate, invalidJob))
 		assert.Error(t, err)
 		assertNoRows(t, db, "job")
+		return nil
 	})
+	assert.NoError(t, err)
 }
 
 func TestUpdateJobsBatch(t *testing.T) {
-	testutil.WithDatabasePgx(t, func(db *pgxpool.Pool) {
+	err := testutil.WithDatabasePgx(func(db *pgxpool.Pool) error {
 		// Insert
 		err := CreateJobsBatch(ctx.Background(), db, defaultInstructionSet().JobsToCreate)
 		assert.Nil(t, err)
@@ -252,11 +254,13 @@ func TestUpdateJobsBatch(t *testing.T) {
 		assert.Error(t, err)
 		job = getJob(t, db, jobIdString)
 		assert.Equal(t, expectedJobAfterSubmit, job)
+		return nil
 	})
+	assert.NoError(t, err)
 }
 
 func TestUpdateJobsScalar(t *testing.T) {
-	testutil.WithDatabasePgx(t, func(db *pgxpool.Pool) {
+	err := testutil.WithDatabasePgx(func(db *pgxpool.Pool) error {
 		// Insert
 		err := CreateJobsBatch(ctx.Background(), db, defaultInstructionSet().JobsToCreate)
 		assert.Nil(t, err)
@@ -281,11 +285,13 @@ func TestUpdateJobsScalar(t *testing.T) {
 		UpdateJobsScalar(ctx.Background(), db, append(defaultInstructionSet().JobsToUpdate, invalidUpdate))
 		job = getJob(t, db, jobIdString)
 		assert.Equal(t, expectedJobAfterUpdate, job)
+		return nil
 	})
+	assert.NoError(t, err)
 }
 
 func TestCreateJobsScalar(t *testing.T) {
-	testutil.WithDatabasePgx(t, func(db *pgxpool.Pool) {
+	err := testutil.WithDatabasePgx(func(db *pgxpool.Pool) error {
 
 		// Simple create
 		CreateJobsScalar(ctx.Background(), db, defaultInstructionSet().JobsToCreate)
@@ -305,11 +311,13 @@ func TestCreateJobsScalar(t *testing.T) {
 		CreateJobsScalar(ctx.Background(), db, append(defaultInstructionSet().JobsToCreate, invalidJob))
 		job = getJob(t, db, jobIdString)
 		assert.Equal(t, expectedJobAfterSubmit, job)
+		return nil
 	})
+	assert.NoError(t, err)
 }
 
 func TestCreateJobRunsBatch(t *testing.T) {
-	testutil.WithDatabasePgx(t, func(db *pgxpool.Pool) {
+	err := testutil.WithDatabasePgx(func(db *pgxpool.Pool) error {
 
 		// Need to make sure we have a job so we can satisfy PK
 		err := CreateJobsBatch(ctx.Background(), db, defaultInstructionSet().JobsToCreate)
@@ -335,11 +343,13 @@ func TestCreateJobRunsBatch(t *testing.T) {
 		err = CreateJobRunsBatch(ctx.Background(), db, append(defaultInstructionSet().JobRunsToCreate, invalidRun))
 		assert.Error(t, err)
 		assertNoRows(t, db, "job_run")
+		return nil
 	})
+	assert.NoError(t, err)
 }
 
 func TestCreateJobRunsScalar(t *testing.T) {
-	testutil.WithDatabasePgx(t, func(db *pgxpool.Pool) {
+	err := testutil.WithDatabasePgx(func(db *pgxpool.Pool) error {
 
 		// Need to make sure we have a job so we can satisfy PK
 		err := CreateJobsBatch(ctx.Background(), db, defaultInstructionSet().JobsToCreate)
@@ -363,11 +373,13 @@ func TestCreateJobRunsScalar(t *testing.T) {
 		CreateJobRunsScalar(ctx.Background(), db, append(defaultInstructionSet().JobRunsToCreate, invalidRun))
 		job = getJobRun(t, db, runIdString)
 		assert.Equal(t, expectedJobRun, job)
+		return nil
 	})
+	assert.NoError(t, err)
 }
 
 func TestUpdateJobRunsBatch(t *testing.T) {
-	testutil.WithDatabasePgx(t, func(db *pgxpool.Pool) {
+	err := testutil.WithDatabasePgx(func(db *pgxpool.Pool) error {
 
 		// Need to make sure we have a job and run
 		err := CreateJobsBatch(ctx.Background(), db, defaultInstructionSet().JobsToCreate)
@@ -400,11 +412,13 @@ func TestUpdateJobRunsBatch(t *testing.T) {
 		assert.Error(t, err)
 		run = getJobRun(t, db, runIdString)
 		assert.Equal(t, expectedJobRun, run)
+		return nil
 	})
+	assert.NoError(t, err)
 }
 
 func TestUpdateJobRunsScalar(t *testing.T) {
-	testutil.WithDatabasePgx(t, func(db *pgxpool.Pool) {
+	err := testutil.WithDatabasePgx(func(db *pgxpool.Pool) error {
 
 		// Need to make sure we have a job and run
 		err := CreateJobsBatch(ctx.Background(), db, defaultInstructionSet().JobsToCreate)
@@ -436,11 +450,13 @@ func TestUpdateJobRunsScalar(t *testing.T) {
 		UpdateJobRunsScalar(ctx.Background(), db, append(defaultInstructionSet().JobRunsToUpdate, invalidRun))
 		run = getJobRun(t, db, runIdString)
 		assert.Equal(t, expectedJobRunAfterUpdate, run)
+		return nil
 	})
+	assert.NoError(t, err)
 }
 
 func TestCreateUserAnnotationsBatch(t *testing.T) {
-	testutil.WithDatabasePgx(t, func(db *pgxpool.Pool) {
+	err := testutil.WithDatabasePgx(func(db *pgxpool.Pool) error {
 
 		// Need to make sure we have a job
 		err := CreateJobsBatch(ctx.Background(), db, defaultInstructionSet().JobsToCreate)
@@ -466,21 +482,25 @@ func TestCreateUserAnnotationsBatch(t *testing.T) {
 		err = CreateUserAnnotationsBatch(ctx.Background(), db, append(defaultInstructionSet().UserAnnotationsToCreate, invalidAnnotation))
 		assert.Error(t, err)
 		assertNoRows(t, db, "user_annotation_lookup")
+		return nil
 	})
+	assert.NoError(t, err)
 }
 
 func TestEmptyUpdate(t *testing.T) {
-	testutil.WithDatabasePgx(t, func(db *pgxpool.Pool) {
+	err := testutil.WithDatabasePgx(func(db *pgxpool.Pool) error {
 		Update(ctx.Background(), db, &model.InstructionSet{})
 		assertNoRows(t, db, "job")
 		assertNoRows(t, db, "job_run")
 		assertNoRows(t, db, "user_annotation_lookup")
 		assertNoRows(t, db, "job_run_container")
+		return nil
 	})
+	assert.NoError(t, err)
 }
 
 func TestCreateUserAnnotationsScalar(t *testing.T) {
-	testutil.WithDatabasePgx(t, func(db *pgxpool.Pool) {
+	err := testutil.WithDatabasePgx(func(db *pgxpool.Pool) error {
 
 		// Need to make sure we have a job
 		err := CreateJobsBatch(ctx.Background(), db, defaultInstructionSet().JobsToCreate)
@@ -504,12 +524,13 @@ func TestCreateUserAnnotationsScalar(t *testing.T) {
 		CreateUserAnnotationsScalar(ctx.Background(), db, append(defaultInstructionSet().UserAnnotationsToCreate, invalidAnnotation))
 		annotation = getUserAnnotationLookup(t, db, jobIdString)
 		assert.Equal(t, expectedUserAnnotation, annotation)
+		return nil
 	})
+	assert.NoError(t, err)
 }
 
 func TestUpdate(t *testing.T) {
-
-	testutil.WithDatabasePgx(t, func(db *pgxpool.Pool) {
+	err := testutil.WithDatabasePgx(func(db *pgxpool.Pool) error {
 		// Do the update
 		Update(ctx.Background(), db, defaultInstructionSet())
 
@@ -522,7 +543,9 @@ func TestUpdate(t *testing.T) {
 		assert.Equal(t, expectedJobRunAfterUpdate, jobRun)
 		assert.Equal(t, expectedJobRunContainer, container)
 		assert.Equal(t, expectedUserAnnotation, annotation)
+		return nil
 	})
+	assert.NoError(t, err)
 }
 
 func TestConflateJobUpdates(T *testing.T) {

--- a/internal/pgkeyvalue/pgkeyvalue.go
+++ b/internal/pgkeyvalue/pgkeyvalue.go
@@ -29,7 +29,7 @@ type PGKeyValueStore struct {
 	tableName string
 }
 
-func New(db *pgxpool.Pool, tableName string) (*PGKeyValueStore, error) {
+func New(db *pgxpool.Pool, cacheSize int, tableName string) (*PGKeyValueStore, error) {
 	if db == nil {
 		return nil, errors.WithStack(&armadaerrors.ErrInvalidArgument{
 			Name:    "db",
@@ -44,7 +44,7 @@ func New(db *pgxpool.Pool, tableName string) (*PGKeyValueStore, error) {
 			Message: "TableName must be non-empty",
 		})
 	}
-	cache, err := simplelru.NewLRU(100, nil)
+	cache, err := simplelru.NewLRU(cacheSize, nil)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/internal/pgkeyvalue/pgkeyvalue.go
+++ b/internal/pgkeyvalue/pgkeyvalue.go
@@ -69,9 +69,9 @@ func (c *PGKeyValueStore) Add(ctx context.Context, key string, value []byte) (bo
 	return ok, err
 }
 
-// AddKey is equivalent to Add(ctx, key, []byte{}).
+// AddKey is equivalent to Add(ctx, key, nil).
 func (c *PGKeyValueStore) AddKey(ctx context.Context, key string) (bool, error) {
-	return c.Add(ctx, key, []byte{})
+	return c.Add(ctx, key, nil)
 }
 
 func (c *PGKeyValueStore) createTable(ctx context.Context) error {

--- a/internal/pgkeyvalue/pgkeyvalue.go
+++ b/internal/pgkeyvalue/pgkeyvalue.go
@@ -1,0 +1,202 @@
+package pgkeyvalue
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/G-Research/armada/internal/common/armadaerrors"
+	"github.com/G-Research/armada/internal/common/logging"
+	"github.com/hashicorp/golang-lru/simplelru"
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// PGKeyValueStore is a time-limited key-value store backed by postgres with a local LRU cache.
+// The store is write-only, i.e., writing to an existing key will return an error (of type *armadaerrors.ErrAlreadyExists).
+// Keys can only be deleted by running the cleanup function.
+// Deleting keys does not cause caches to update, i.e., nodes may have an inconsistent view if keys are deleted.
+type PGKeyValueStore struct {
+	// For performance, keys are cached locally.
+	cache *simplelru.LRU
+	// Postgres connection.
+	db *pgxpool.Pool
+	// Name of the postgres table used for storage.
+	tableName string
+}
+
+func New(db *pgxpool.Pool, tableName string) (*PGKeyValueStore, error) {
+	if db == nil {
+		return nil, errors.WithStack(&armadaerrors.ErrInvalidArgument{
+			Name:    "db",
+			Value:   db,
+			Message: "db must be non-nil",
+		})
+	}
+	if tableName == "" {
+		return nil, errors.WithStack(&armadaerrors.ErrInvalidArgument{
+			Name:    "TableName",
+			Value:   tableName,
+			Message: "TableName must be non-empty",
+		})
+	}
+	cache, err := simplelru.NewLRU(100, nil)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return &PGKeyValueStore{
+		cache:     cache,
+		db:        db,
+		tableName: tableName,
+	}, nil
+}
+
+// Add adds a key-value pair. Returns *armadaerror.ErrAlreadyExists if the key already exists.
+// The posgres table backing the key-value storage is created automatically if it doesn't already exist.
+func (c *PGKeyValueStore) Add(ctx context.Context, key string, value []byte) error {
+	err := c.add(ctx, key, value)
+
+	// If the table doesn't exist, create it and try again.
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == "42P01" { // Relation doesn't exist; create it.
+		c.createTable(ctx)
+		err = c.add(ctx, key, value)
+	}
+
+	return err
+}
+
+// AddKey is equivalent to Add(ctx, key, []byte{}).
+func (c *PGKeyValueStore) AddKey(ctx context.Context, key string) error {
+	return c.Add(ctx, key, []byte{})
+}
+
+func (c *PGKeyValueStore) createTable(ctx context.Context) error {
+	var pgErr *pgconn.PgError
+	_, err := c.db.Exec(ctx, fmt.Sprintf("create table %s (key text primary key, value bytea, inserted timestamp not null);", c.tableName))
+	if errors.As(err, &pgErr) && pgErr.Code == "42P07" { // Relation already exists (i.e., someone else just created it), which is fine.
+		return nil
+	}
+	return err
+}
+
+func (c *PGKeyValueStore) add(ctx context.Context, key string, value []byte) error {
+
+	// Overwriting isn't allowed.
+	if _, ok := c.cache.Get(key); ok {
+		return errors.WithStack(&armadaerrors.ErrAlreadyExists{
+			Type:  "Postgres key-value",
+			Value: key,
+		})
+	}
+
+	// Otherwise, get and set the key in a transaction.
+	var exists *bool
+	err := c.db.BeginTxFunc(ctx, pgx.TxOptions{}, func(tx pgx.Tx) error {
+
+		// Check if the key already exists in postgres.
+		sql := fmt.Sprintf("select exists(select 1 from %s where key=$1) AS \"exists\"", c.tableName)
+		err := tx.QueryRow(ctx, sql, key).Scan(&exists)
+		if err != nil {
+			return err
+		}
+
+		// Only write the key-value pair if it doesn't already exist (overwriting not allowed).
+		if !*exists {
+			sql = fmt.Sprintf("insert into %s (key, value, inserted) values ($1, $2, now());", c.tableName)
+			_, err := tx.Exec(ctx, sql, key, value)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+
+	// We need to return on error (in particular, tx rollback)
+	// to avoid writing to the cache after failing to write to postgres.
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	// Return an error if the key already exists.
+	if *exists {
+		return errors.WithStack(&armadaerrors.ErrAlreadyExists{
+			Type:  "Postgres key-value pair",
+			Value: key,
+		})
+	} else {
+		c.cache.Add(key, value)
+	}
+
+	return nil
+}
+
+// Get returns the value associated with the provided key,
+// or &armadaerrors.ErrNotFound if the key can't be found.
+func (c *PGKeyValueStore) Get(ctx context.Context, key string) ([]byte, error) {
+
+	// First check the local cache.
+	if value, ok := c.cache.Get(key); ok {
+		return value.([]byte), nil
+	}
+
+	// Otherwise, check postgres.
+	var exists bool
+	var value *[]byte
+	sql := fmt.Sprintf("select value from %s where key=$1", c.tableName)
+	err := c.db.QueryRow(ctx, sql, key).Scan(&value)
+	if errors.Is(err, pgx.ErrNoRows) {
+		exists = false
+	} else if err != nil {
+		return nil, errors.WithStack(err)
+	} else {
+		exists = true
+	}
+
+	if !exists {
+		return nil, errors.WithStack(&armadaerrors.ErrNotFound{
+			Type:  "Postgres key-value pair",
+			Value: key,
+		})
+	}
+
+	return *value, nil
+}
+
+// Cleanup removes all key-value pairs older than lifespan.
+func (c *PGKeyValueStore) Cleanup(ctx context.Context, lifespan time.Duration) error {
+	sql := fmt.Sprintf("delete from %s where (inserted <= (now() - $1::interval));", c.tableName)
+	_, err := c.db.Exec(ctx, sql, lifespan)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}
+
+// PeriodicCleanup automatically runs the cleanup job every interval until the provided context is cancelled.
+func (c *PGKeyValueStore) PeriodicCleanup(ctx context.Context, interval time.Duration, lifespan time.Duration) {
+	log := logrus.StandardLogger().WithField("service", "PGKeyValueStoreCleanup")
+	log.Info("service started")
+	ticker := time.NewTicker(interval)
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				ticker.Stop()
+				return
+			case <-ticker.C:
+				start := time.Now()
+				err := c.Cleanup(ctx, lifespan)
+				if err != nil {
+					logging.WithStacktrace(log, err).WithField("delay", time.Since(start)).Warn("cleanup failed")
+				} else {
+					log.WithField("delay", time.Since(start)).Info("cleanup succeeded")
+				}
+			}
+		}
+	}()
+}

--- a/internal/pgkeyvalue/pgkeyvalue.go
+++ b/internal/pgkeyvalue/pgkeyvalue.go
@@ -5,14 +5,15 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/G-Research/armada/internal/common/armadaerrors"
-	"github.com/G-Research/armada/internal/common/logging"
 	"github.com/hashicorp/golang-lru/simplelru"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
+	"github.com/G-Research/armada/internal/common/armadaerrors"
+	"github.com/G-Research/armada/internal/common/logging"
 )
 
 // PGKeyValueStore is a time-limited key-value store backed by postgres with a local LRU cache.

--- a/internal/pgkeyvalue/pgkeyvalue.go
+++ b/internal/pgkeyvalue/pgkeyvalue.go
@@ -171,7 +171,8 @@ func (c *PGKeyValueStore) Cleanup(ctx context.Context, lifespan time.Duration) e
 	return nil
 }
 
-// PeriodicCleanup automatically runs the cleanup job every interval until the provided context is cancelled.
+// PeriodicCleanup starts a goroutine that automatically runs the cleanup job
+// every interval until the provided context is cancelled.
 func (c *PGKeyValueStore) PeriodicCleanup(ctx context.Context, interval time.Duration, lifespan time.Duration) {
 	log := logrus.StandardLogger().WithField("service", "PGKeyValueStoreCleanup")
 	log.Info("service started")

--- a/internal/pgkeyvalue/pgkeyvalue_test.go
+++ b/internal/pgkeyvalue/pgkeyvalue_test.go
@@ -5,10 +5,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/G-Research/armada/internal/common/armadaerrors"
-	"github.com/G-Research/armada/internal/lookout/testutil"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/G-Research/armada/internal/common/armadaerrors"
+	"github.com/G-Research/armada/internal/lookout/testutil"
 )
 
 func TestAdd(t *testing.T) {
@@ -88,7 +89,7 @@ func TestAddGet(t *testing.T) {
 
 		// Getting another value should return *armadaerrors.ErrNotFound
 		var targetErr *armadaerrors.ErrNotFound
-		actual, err = store.Get(context.Background(), "bar")
+		_, err = store.Get(context.Background(), "bar")
 		assert.ErrorAs(t, err, &targetErr)
 
 		// Purging the cache should still return the same value for foo

--- a/internal/pgkeyvalue/pgkeyvalue_test.go
+++ b/internal/pgkeyvalue/pgkeyvalue_test.go
@@ -144,5 +144,36 @@ func TestCleanup(t *testing.T) {
 		store.cache.Purge()
 		_, err = store.Get(context.Background(), "bar")
 		assert.NoError(t, err)
+
+		// Test the automatic cleanup
+		ok, err = store.Add(context.Background(), "baz", expected)
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+		assert.True(t, ok)
+
+		// Start the cleanup job to run a quick interval.
+		// Then try adding baz twice more to make sure it gets cleaned up both times.
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		store.PeriodicCleanup(ctx, time.Microsecond, time.Microsecond)
+
+		time.Sleep(100 * time.Millisecond)
+		store.cache.Purge()
+
+		ok, err = store.Add(context.Background(), "baz", expected)
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+		assert.True(t, ok)
+
+		time.Sleep(100 * time.Millisecond)
+		store.cache.Purge()
+
+		ok, err = store.Add(context.Background(), "baz", expected)
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+		assert.True(t, ok)
 	})
 }

--- a/internal/pgkeyvalue/pgkeyvalue_test.go
+++ b/internal/pgkeyvalue/pgkeyvalue_test.go
@@ -183,3 +183,17 @@ func TestCleanup(t *testing.T) {
 	})
 	assert.NoError(t, err)
 }
+
+func BenchmarkStore(b *testing.B) {
+	err := testutil.WithDatabasePgx(func(db *pgxpool.Pool) error {
+		store, err := New(db, "cachetable")
+		if !assert.NoError(b, err) {
+			b.FailNow()
+		}
+		for i := 0; i < b.N; i++ {
+			store.AddKey(context.Background(), "foo")
+		}
+		return nil
+	})
+	assert.NoError(b, err)
+}

--- a/internal/pgkeyvalue/pgkeyvalue_test.go
+++ b/internal/pgkeyvalue/pgkeyvalue_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAdd(t *testing.T) {
-	testutil.WithDatabasePgx(t, func(db *pgxpool.Pool) {
+	err := testutil.WithDatabasePgx(func(db *pgxpool.Pool) error {
 		store, err := New(db, "cachetable")
 		if !assert.NoError(t, err) {
 			t.FailNow()
@@ -59,11 +59,13 @@ func TestAdd(t *testing.T) {
 			t.FailNow()
 		}
 		assert.False(t, ok)
+		return nil
 	})
+	assert.NoError(t, err)
 }
 
 func TestAddGet(t *testing.T) {
-	testutil.WithDatabasePgx(t, func(db *pgxpool.Pool) {
+	err := testutil.WithDatabasePgx(func(db *pgxpool.Pool) error {
 		store, err := New(db, "cachetable")
 		if !assert.NoError(t, err) {
 			t.FailNow()
@@ -96,11 +98,13 @@ func TestAddGet(t *testing.T) {
 			t.FailNow()
 		}
 		assert.Equal(t, expected, actual)
+		return nil
 	})
+	assert.NoError(t, err)
 }
 
 func TestCleanup(t *testing.T) {
-	testutil.WithDatabasePgx(t, func(db *pgxpool.Pool) {
+	err := testutil.WithDatabasePgx(func(db *pgxpool.Pool) error {
 		store, err := New(db, "cachetable")
 		if !assert.NoError(t, err) {
 			t.FailNow()
@@ -175,5 +179,7 @@ func TestCleanup(t *testing.T) {
 			t.FailNow()
 		}
 		assert.True(t, ok)
+		return nil
 	})
+	assert.NoError(t, err)
 }

--- a/internal/pgkeyvalue/pgkeyvalue_test.go
+++ b/internal/pgkeyvalue/pgkeyvalue_test.go
@@ -1,0 +1,125 @@
+package pgkeyvalue
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/G-Research/armada/internal/common/armadaerrors"
+	"github.com/G-Research/armada/internal/lookout/testutil"
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAdd(t *testing.T) {
+	testutil.WithDatabasePgx(t, func(db *pgxpool.Pool) {
+		cache, err := New(db, "cachetable")
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		// Adding a key for the first time should insert into both the local cache and postgres.
+		err = cache.Add(context.Background(), "foo", []byte{0, 1, 2})
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		// The second time we add the key, we should get an error.
+		var targetErr *armadaerrors.ErrAlreadyExists
+		err = cache.Add(context.Background(), "foo", []byte{0, 1, 2})
+		assert.ErrorAs(t, err, &targetErr)
+
+		// Adding another key should succeed.
+		err = cache.Add(context.Background(), "bar", []byte{0, 1, 2})
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		// Clear the local cache to verify that it queries postgres.
+		cache.cache.Purge()
+		err = cache.Add(context.Background(), "foo", []byte{0, 1, 2})
+		assert.ErrorAs(t, err, &targetErr)
+	})
+}
+
+func TestAddGet(t *testing.T) {
+	testutil.WithDatabasePgx(t, func(db *pgxpool.Pool) {
+		cache, err := New(db, "cachetable")
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		// Adding a key for the first time should insert into both the local cache and postgres.
+		expected := []byte{0, 1, 2}
+		err = cache.Add(context.Background(), "foo", expected)
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		// Get should return the same value
+		actual, err := cache.Get(context.Background(), "foo")
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+		assert.Equal(t, expected, actual)
+
+		// Getting another value should return *armadaerrors.ErrNotFound
+		var targetErr *armadaerrors.ErrNotFound
+		actual, err = cache.Get(context.Background(), "bar")
+		assert.ErrorAs(t, err, &targetErr)
+
+		// Purging the cache should still return the same value for foo
+		cache.cache.Purge()
+		actual, err = cache.Get(context.Background(), "foo")
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+		assert.Equal(t, expected, actual)
+	})
+}
+
+func TestCleanup(t *testing.T) {
+	testutil.WithDatabasePgx(t, func(db *pgxpool.Pool) {
+		cache, err := New(db, "cachetable")
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		// Adding a key for the first time should insert into both the local cache and postgres,
+		// and return false (since the key didn't already exist).
+		expected := []byte{0, 1, 2}
+		err = cache.Add(context.Background(), "foo", expected)
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		// Run the cleanup.
+		err = cache.Cleanup(context.Background(), 0*time.Second)
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		// Purge the cache to ensure the next get will query postgres.
+		cache.cache.Purge()
+
+		// The key should've been cleaned up and get should return an error.
+		var targetErr *armadaerrors.ErrNotFound
+		_, err = cache.Get(context.Background(), "foo")
+		assert.ErrorAs(t, err, &targetErr)
+
+		// Add another key
+		err = cache.Add(context.Background(), "bar", expected)
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		// The cleanup shouldn't delete this key
+		err = cache.Cleanup(context.Background(), time.Hour)
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+		cache.cache.Purge()
+		_, err = cache.Get(context.Background(), "bar")
+		assert.NoError(t, err)
+	})
+}

--- a/internal/pgkeyvalue/pgkeyvalue_test.go
+++ b/internal/pgkeyvalue/pgkeyvalue_test.go
@@ -46,6 +46,19 @@ func TestAdd(t *testing.T) {
 			t.FailNow()
 		}
 		assert.False(t, ok)
+
+		// Test AddKey
+		ok, err = store.AddKey(context.Background(), "baz")
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+		assert.True(t, ok)
+
+		ok, err = store.AddKey(context.Background(), "baz")
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+		assert.False(t, ok)
 	})
 }
 

--- a/internal/pgkeyvalue/pgkeyvalue_test.go
+++ b/internal/pgkeyvalue/pgkeyvalue_test.go
@@ -13,8 +13,9 @@ import (
 )
 
 func TestAdd(t *testing.T) {
+	cacheSize := 100
 	err := testutil.WithDatabasePgx(func(db *pgxpool.Pool) error {
-		store, err := New(db, "cachetable")
+		store, err := New(db, cacheSize, "cachetable")
 		if !assert.NoError(t, err) {
 			t.FailNow()
 		}
@@ -66,8 +67,9 @@ func TestAdd(t *testing.T) {
 }
 
 func TestAddGet(t *testing.T) {
+	cacheSize := 100
 	err := testutil.WithDatabasePgx(func(db *pgxpool.Pool) error {
-		store, err := New(db, "cachetable")
+		store, err := New(db, cacheSize, "cachetable")
 		if !assert.NoError(t, err) {
 			t.FailNow()
 		}
@@ -105,8 +107,9 @@ func TestAddGet(t *testing.T) {
 }
 
 func TestCleanup(t *testing.T) {
+	cacheSize := 100
 	err := testutil.WithDatabasePgx(func(db *pgxpool.Pool) error {
-		store, err := New(db, "cachetable")
+		store, err := New(db, cacheSize, "cachetable")
 		if !assert.NoError(t, err) {
 			t.FailNow()
 		}
@@ -186,8 +189,9 @@ func TestCleanup(t *testing.T) {
 }
 
 func BenchmarkStore(b *testing.B) {
+	cacheSize := 100
 	err := testutil.WithDatabasePgx(func(db *pgxpool.Pool) error {
-		store, err := New(db, "cachetable")
+		store, err := New(db, cacheSize, "cachetable")
 		if !assert.NoError(b, err) {
 			b.FailNow()
 		}

--- a/makefile
+++ b/makefile
@@ -187,6 +187,12 @@ tests-teardown:
 	docker rm -f redis postgres || true
 
 .ONESHELL:
+tests-no-setup:
+	$(GO_TEST_CMD) go test -v ./internal... 2>&1 | tee test_reports/internal.txt
+	$(GO_TEST_CMD) go test -v ./pkg... 2>&1 | tee test_reports/pkg.txt
+	$(GO_TEST_CMD) go test -v ./cmd... 2>&1 | tee test_reports/cmd.txt
+
+.ONESHELL:
 tests:
 	mkdir -p test_reports
 	docker run -d --name=redis --network=host -p=6379:6379 redis:6.2.6


### PR DESCRIPTION
This PR adds job submission deduplication to the log submit API. It also adds a key-value store backed by Postgres, which is used for the deduplication.