### PR TITLE
Make Lookout not error if Job JSON is not able to be parsed

### DIFF
--- a/internal/lookout/repository/jobs.go
+++ b/internal/lookout/repository/jobs.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/doug-martin/goqu/v9"
 	"github.com/doug-martin/goqu/v9/exp"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/G-Research/armada/pkg/api"
 	"github.com/G-Research/armada/pkg/api/lookout"
@@ -256,7 +257,7 @@ func makeJobFromRow(row *JobRow) (*api.Job, error) {
 	jobJson := ParseNullString(row.JobJson)
 	err := json.Unmarshal([]byte(jobJson), &jobFromJson)
 	if err != nil {
-		return nil, fmt.Errorf("error while parsing job %s json: %v", ParseNullString(row.JobId), err)
+		log.Errorf("error while parsing job %s json: %v", ParseNullString(row.JobId), err)
 	}
 
 	return &api.Job{


### PR DESCRIPTION
Currently no jobs are displayed in Lookout if one of the jobs is failed to be parsed. We avoid this by ignoring the error.