### PR TITLE
Add select all functionality lookout jobsets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,7 +192,7 @@ jobs:
           keys:
             - go-mod-v3-{{ checksum "go.sum" }}
 
-      - run: # no-op if we restored from cache
+      - run:
           name: Download dependencies
           command: |
             curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
@@ -285,6 +285,14 @@ jobs:
             - go-mod-v3-{{ checksum "go.sum" }}
 
       - run:
+          name: Download dependencies
+          command: |
+            curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+            chmod +x kubectl
+            mv kubectl /home/circleci/bin/
+            make download # no-op if we restored from cache
+
+      - run:
           name: Build armadactl release artifacts
           command: make build-armadactl-release RELEASE_VERSION=${CIRCLE_TAG}
 
@@ -340,6 +348,18 @@ jobs:
     working_directory: /go/src/github.com/G-Research/armada
     steps:
       - checkout
+
+      - restore_cache: # restore dependencies
+          keys:
+            - go-mod-v3-{{ checksum "go.sum" }}
+
+      - run:
+          name: Download dependencies
+          command: |
+            curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+            chmod +x kubectl
+            mv kubectl /home/circleci/bin/
+            make download # no-op if we restored from cache
 
       - run:
           name: Release dotnet client

--- a/internal/lookout/ui/package-lock.json
+++ b/internal/lookout/ui/package-lock.json
@@ -1732,6 +1732,7 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
+        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -7298,7 +7299,8 @@
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -11171,6 +11173,7 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
+        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",
@@ -16254,6 +16257,7 @@
         "eslint-webpack-plugin": "^2.5.2",
         "file-loader": "6.1.1",
         "fs-extra": "^9.0.1",
+        "fsevents": "^2.1.3",
         "html-webpack-plugin": "4.5.0",
         "identity-obj-proxy": "3.0.0",
         "jest": "26.6.0",
@@ -19441,8 +19445,10 @@
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.5.tgz",
       "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
       "dependencies": {
+        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0"
+        "neo-async": "^2.5.0",
+        "watchpack-chokidar2": "^2.0.1"
       },
       "optionalDependencies": {
         "chokidar": "^3.4.1",
@@ -19927,6 +19933,7 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",

--- a/internal/lookout/ui/src/components/CheckboxHeaderRow.tsx
+++ b/internal/lookout/ui/src/components/CheckboxHeaderRow.tsx
@@ -9,7 +9,9 @@ import "./Row.css"
 
 export type CheckboxHeaderRowProps = {
   deselectEnabled: boolean
+  disabledOnEmpty: boolean
   onDeselectAllClick: () => void
+  onSelectAllClick: () => void
 } & TableHeaderRowProps
 
 export default function CheckboxHeaderRow(props: CheckboxHeaderRowProps) {
@@ -18,9 +20,9 @@ export default function CheckboxHeaderRow(props: CheckboxHeaderRowProps) {
       <div className="select-box" style={{ width: CHECKBOX_WIDTH }}>
         <Checkbox
           checked={props.deselectEnabled}
-          disabled={!props.deselectEnabled}
+          disabled={!props.deselectEnabled && props.disabledOnEmpty}
           indeterminate={props.deselectEnabled}
-          onClick={props.onDeselectAllClick}
+          onClick={props.deselectEnabled ? props.onDeselectAllClick : props.onSelectAllClick}
         />
       </div>
       {props.columns}

--- a/internal/lookout/ui/src/components/CheckboxHeaderRow.tsx
+++ b/internal/lookout/ui/src/components/CheckboxHeaderRow.tsx
@@ -8,10 +8,9 @@ import { CHECKBOX_WIDTH } from "./CheckboxRow"
 import "./Row.css"
 
 export type CheckboxHeaderRowProps = {
-  deselectEnabled: boolean
-  disabledOnEmpty: boolean
-  onDeselectAllClick: () => void
-  onSelectAllClick: () => void
+  checked: boolean
+  disabled: boolean
+  onClick: () => void
 } & TableHeaderRowProps
 
 export default function CheckboxHeaderRow(props: CheckboxHeaderRowProps) {
@@ -19,10 +18,10 @@ export default function CheckboxHeaderRow(props: CheckboxHeaderRowProps) {
     <div className={props.className} style={props.style}>
       <div className="select-box" style={{ width: CHECKBOX_WIDTH }}>
         <Checkbox
-          checked={props.deselectEnabled}
-          disabled={!props.deselectEnabled && props.disabledOnEmpty}
-          indeterminate={props.deselectEnabled}
-          onClick={props.deselectEnabled ? props.onDeselectAllClick : props.onSelectAllClick}
+          checked={props.checked}
+          disabled={props.disabled}
+          indeterminate={props.checked}
+          onClick={props.onClick}
         />
       </div>
       {props.columns}

--- a/internal/lookout/ui/src/components/job-sets/JobSetTable.tsx
+++ b/internal/lookout/ui/src/components/job-sets/JobSetTable.tsx
@@ -64,12 +64,13 @@ export default function JobSetTable(props: JobSetTableProps) {
           )
         }}
         headerRowRenderer={(tableHeaderRowProps) => {
+          const deselectEnabled = props.selectedJobSets.size > 0
+          const disabledOnEmpty = props.jobSets.length == 0
           return (
             <CheckboxHeaderRow
-              deselectEnabled={props.selectedJobSets.size > 0}
-              disabledOnEmpty={props.jobSets.length == 0}
-              onDeselectAllClick={() => props.onDeselectAllClick()}
-              onSelectAllClick={() => props.onSelectAllClick()}
+              checked={deselectEnabled}
+              disabled={!deselectEnabled && disabledOnEmpty}
+              onClick={deselectEnabled ? () => props.onDeselectAllClick() : props.onSelectAllClick}
               {...tableHeaderRowProps}
             />
           )

--- a/internal/lookout/ui/src/components/job-sets/JobSetTable.tsx
+++ b/internal/lookout/ui/src/components/job-sets/JobSetTable.tsx
@@ -21,6 +21,7 @@ interface JobSetTableProps {
   onSelectJobSet: (index: number, selected: boolean) => void
   onShiftSelectJobSet: (index: number, selected: boolean) => void
   onDeselectAllClick: () => void
+  onSelectAllClick: () => void
   onOrderChange: (newestFirst: boolean) => void
 }
 
@@ -66,7 +67,9 @@ export default function JobSetTable(props: JobSetTableProps) {
           return (
             <CheckboxHeaderRow
               deselectEnabled={props.selectedJobSets.size > 0}
+              disabledOnEmpty={props.jobSets.length == 0}
               onDeselectAllClick={() => props.onDeselectAllClick()}
+              onSelectAllClick={() => props.onSelectAllClick()}
               {...tableHeaderRowProps}
             />
           )

--- a/internal/lookout/ui/src/components/job-sets/JobSetTable.tsx
+++ b/internal/lookout/ui/src/components/job-sets/JobSetTable.tsx
@@ -64,13 +64,13 @@ export default function JobSetTable(props: JobSetTableProps) {
           )
         }}
         headerRowRenderer={(tableHeaderRowProps) => {
-          const deselectEnabled = props.selectedJobSets.size > 0
-          const disabledOnEmpty = props.jobSets.length == 0
+          const jobSetsAreSelected = props.selectedJobSets.size > 0
+          const noJobSetsArePresent = props.jobSets.length == 0
           return (
             <CheckboxHeaderRow
-              checked={deselectEnabled}
-              disabled={!deselectEnabled && disabledOnEmpty}
-              onClick={deselectEnabled ? () => props.onDeselectAllClick() : props.onSelectAllClick}
+              checked={jobSetsAreSelected}
+              disabled={!jobSetsAreSelected && noJobSetsArePresent}
+              onClick={jobSetsAreSelected ? () => props.onDeselectAllClick() : props.onSelectAllClick}
               {...tableHeaderRowProps}
             />
           )

--- a/internal/lookout/ui/src/components/job-sets/JobSets.tsx
+++ b/internal/lookout/ui/src/components/job-sets/JobSets.tsx
@@ -45,6 +45,7 @@ interface JobSetsProps {
   onSelectJobSet: (index: number, selected: boolean) => void
   onShiftSelectJobSet: (index: number, selected: boolean) => void
   onDeselectAllClick: () => void
+  onSelectAllClick: () => void
   onCancelJobSetsClick: () => void
   onToggleAutoRefresh: (autoRefresh: boolean) => void
   onReprioritizeJobSetsClick: () => void
@@ -76,6 +77,7 @@ export default function JobSets(props: JobSetsProps) {
       onSelectJobSet={props.onSelectJobSet}
       onShiftSelectJobSet={props.onShiftSelectJobSet}
       onDeselectAllClick={props.onDeselectAllClick}
+      onSelectAllClick={props.onSelectAllClick}
       onOrderChange={props.onOrderChange}
     />
   )

--- a/internal/lookout/ui/src/components/jobs/Jobs.tsx
+++ b/internal/lookout/ui/src/components/jobs/Jobs.tsx
@@ -155,12 +155,12 @@ export default class Jobs extends React.Component<JobsProps, Record<string, neve
                         )
                       }}
                       headerRowRenderer={(tableHeaderRowProps) => {
+                        const deselectEnabled = this.props.selectedJobs.size > 0
                         return (
                           <CheckboxHeaderRow
-                            deselectEnabled={this.props.selectedJobs.size > 0}
-                            disabledOnEmpty={true}
-                            onDeselectAllClick={this.props.onDeselectAllClick}
-                            onSelectAllClick={() => void 0}
+                            checked={deselectEnabled}
+                            disabled={!deselectEnabled}
+                            onClick={() => this.props.onDeselectAllClick()}
                             {...tableHeaderRowProps}
                           />
                         )

--- a/internal/lookout/ui/src/components/jobs/Jobs.tsx
+++ b/internal/lookout/ui/src/components/jobs/Jobs.tsx
@@ -158,7 +158,9 @@ export default class Jobs extends React.Component<JobsProps, Record<string, neve
                         return (
                           <CheckboxHeaderRow
                             deselectEnabled={this.props.selectedJobs.size > 0}
+                            disabledOnEmpty={true}
                             onDeselectAllClick={this.props.onDeselectAllClick}
+                            onSelectAllClick={() => void 0}
                             {...tableHeaderRowProps}
                           />
                         )

--- a/internal/lookout/ui/src/components/jobs/Jobs.tsx
+++ b/internal/lookout/ui/src/components/jobs/Jobs.tsx
@@ -155,11 +155,11 @@ export default class Jobs extends React.Component<JobsProps, Record<string, neve
                         )
                       }}
                       headerRowRenderer={(tableHeaderRowProps) => {
-                        const deselectEnabled = this.props.selectedJobs.size > 0
+                        const jobsAreSelected = this.props.selectedJobs.size > 0
                         return (
                           <CheckboxHeaderRow
-                            checked={deselectEnabled}
-                            disabled={!deselectEnabled}
+                            checked={jobsAreSelected}
+                            disabled={!jobsAreSelected}
                             onClick={() => this.props.onDeselectAllClick()}
                             {...tableHeaderRowProps}
                           />

--- a/internal/lookout/ui/src/containers/JobSetsContainer.tsx
+++ b/internal/lookout/ui/src/containers/JobSetsContainer.tsx
@@ -73,6 +73,7 @@ class JobSetsContainer extends React.Component<JobSetsContainerProps, JobSetsCon
     this.selectJobSet = this.selectJobSet.bind(this)
     this.shiftSelectJobSet = this.shiftSelectJobSet.bind(this)
     this.deselectAll = this.deselectAll.bind(this)
+    this.selectAll = this.selectAll.bind(this)
 
     this.openCancelJobSets = this.openCancelJobSets.bind(this)
     this.openReprioritizeJobSets = this.openReprioritizeJobSets.bind(this)
@@ -173,6 +174,17 @@ class JobSetsContainer extends React.Component<JobSetsContainerProps, JobSetsCon
     this.setState({
       ...this.state,
       selectedJobSets: new Map<string, JobSet>(),
+      lastSelectedIndex: 0,
+    })
+  }
+
+  selectAll() {
+    const selected = new Map<string, JobSet>()
+    this.state.jobSets.forEach((jobSet) => selected.set(jobSet.jobSetId, jobSet))
+
+    this.setState({
+      ...this.state,
+      selectedJobSets: selected,
       lastSelectedIndex: 0,
     })
   }
@@ -301,6 +313,7 @@ class JobSetsContainer extends React.Component<JobSetsContainerProps, JobSetsCon
           onSelectJobSet={this.selectJobSet}
           onShiftSelectJobSet={this.shiftSelectJobSet}
           onDeselectAllClick={this.deselectAll}
+          onSelectAllClick={this.selectAll}
           onCancelJobSetsClick={() => this.openCancelJobSets(true)}
           onToggleAutoRefresh={this.toggleAutoRefresh}
           onReprioritizeJobSetsClick={() => this.openReprioritizeJobSets(true)}


### PR DESCRIPTION
This PR changes the header checkbox on the jobset table to select all when no jobsets are selected rather than being greyed out.