### PR TITLE
Lookout Ingester Fixes Following Testing

### DIFF
--- a/internal/lookoutingester/instructions/instructions.go
+++ b/internal/lookoutingester/instructions/instructions.go
@@ -101,7 +101,7 @@ func ConvertMsg(ctx context.Context, msg *model.ConsumerMessage, compressor Comp
 			messageLogger.Warnf("Ignoring event")
 		}
 		if err != nil {
-			messageLogger.Warnf("Could not convert event at index %d.", idx)
+			messageLogger.Warnf("Could not convert event at index %d. %+v", idx, err)
 		}
 	}
 	return updateInstructions
@@ -369,7 +369,8 @@ func handleJobRunErrors(ts time.Time, event *armadaevents.JobRunErrors, update *
 		for _, e := range event.GetErrors() {
 			podError := e.GetPodError()
 			if podError != nil && e.Terminal {
-				jobRun.Error = pointer.String(podError.GetMessage())
+				truncatedMsg := truncate(podError.GetMessage(), 2048)
+				jobRun.Error = pointer.String(truncatedMsg)
 				for _, containerError := range podError.ContainerErrors {
 					update.JobRunContainersToCreate = append(update.JobRunContainersToCreate, &model.CreateJobRunContainerInstruction{
 						RunId:         jobRun.RunId,
@@ -396,4 +397,11 @@ func getNode(resources []*armadaevents.KubernetesResourceInfo) (string, int) {
 		}
 	}
 	return "UNKNOWN", -1
+}
+
+func truncate(s string, max int) string {
+	if max > len(s) {
+		return s
+	}
+	return s[:max]
 }

--- a/internal/lookoutingester/instructions/instructions_test.go
+++ b/internal/lookoutingester/instructions/instructions_test.go
@@ -2,6 +2,7 @@ package instructions
 
 import (
 	"encoding/json"
+	"fmt"
 	"math/rand"
 	"testing"
 	"time"
@@ -333,6 +334,15 @@ func TestCancelled(t *testing.T) {
 		MessageIds:   []*model.ConsumerMessageId{{msg.Message.ID(), msg.ConsumerId}},
 	}
 	assert.Equal(t, expected, instructions)
+}
+
+func TestFoo(t *testing.T) {
+	var s string = ""
+	fmt.Println(s[:3])
+	s = "abc"
+	fmt.Println(s[:3])
+	s = "abcd"
+	fmt.Println(s[:3])
 }
 
 func TestReprioritised(t *testing.T) {

--- a/internal/lookoutingester/instructions/instructions_test.go
+++ b/internal/lookoutingester/instructions/instructions_test.go
@@ -2,7 +2,6 @@ package instructions
 
 import (
 	"encoding/json"
-	"fmt"
 	"math/rand"
 	"testing"
 	"time"
@@ -334,15 +333,6 @@ func TestCancelled(t *testing.T) {
 		MessageIds:   []*model.ConsumerMessageId{{msg.Message.ID(), msg.ConsumerId}},
 	}
 	assert.Equal(t, expected, instructions)
-}
-
-func TestFoo(t *testing.T) {
-	var s string = ""
-	fmt.Println(s[:3])
-	s = "abc"
-	fmt.Println(s[:3])
-	s = "abcd"
-	fmt.Println(s[:3])
 }
 
 func TestReprioritised(t *testing.T) {

--- a/internal/lookoutingester/instructions/instructions_test.go
+++ b/internal/lookoutingester/instructions/instructions_test.go
@@ -368,6 +368,12 @@ func TestInvalidEvent(t *testing.T) {
 	assert.Equal(t, expected, instructions)
 }
 
+func TestTruncate(t *testing.T) {
+	assert.Equal(t, "", truncate("", 3))
+	assert.Equal(t, "abc", truncate("abc", 3))
+	assert.Equal(t, "abc", truncate("abcd", 3))
+}
+
 // This message is invalid as it has no payload
 // Assert that the update just contains the messageId so we can ack it
 func TestInvalidMessage(t *testing.T) {

--- a/internal/lookoutingester/lookoutdb/insertion.go
+++ b/internal/lookoutingester/lookoutdb/insertion.go
@@ -510,7 +510,7 @@ func CreateJobRunContainersBatch(ctx context.Context, db *pgxpool.Pool, instruct
 		createTmp := func(tx pgx.Tx) error {
 			_, err := tx.Exec(ctx, fmt.Sprintf(`
 				CREATE TEMPORARY TABLE %s (
-				  run_id  varchar(32),
+				  run_id  varchar(36),
                   container_name  varchar(512),
 				  exit_code integer
 				) ON COMMIT DROP;`, tmpTable))


### PR DESCRIPTION
- Error messages should be trimmed to 2048 chars so they fit in the database
- Staging table for JobRunContainers should have a run_id of 36 bytes, not 32
- Log out the full error message when we can't convert a message to instructions.