### PR TITLE
Better Logging In LookoutIngester

### DIFF
--- a/internal/lookoutingester/instructions/instructions_test.go
+++ b/internal/lookoutingester/instructions/instructions_test.go
@@ -347,14 +347,10 @@ func TestReprioritised(t *testing.T) {
 
 func TestInvalidEvent(t *testing.T) {
 
-	// This event is invalid as it references a job that doesn't exist
-	nonExistingJob, _ := armadaevents.ProtoUuidFromUlidString("01f3j0g1md6qx7z5qb148qnh4r")
+	// This event is invalid as it doesn't have a job id or a run id
 	invalidEvent := &armadaevents.EventSequence_Event{
-		Event: &armadaevents.EventSequence_Event_JobRunLeased{
-			JobRunLeased: &armadaevents.JobRunLeased{
-				JobId:      nonExistingJob,
-				ExecutorId: executorId,
-			},
+		Event: &armadaevents.EventSequence_Event_JobRunRunning{
+			JobRunRunning: &armadaevents.JobRunRunning{},
 		},
 	}
 

--- a/internal/lookoutingester/pulsario/pulsar.go
+++ b/internal/lookoutingester/pulsario/pulsar.go
@@ -76,9 +76,8 @@ func Receive(ctx context.Context, consumer pulsar.Consumer, consumerId int, buff
 					time.Sleep(backoffTime)
 					continue
 				}
-				lastMessageId = msg.ID()
-				lastPublishTime = msg.PublishTime()
 				numReceived++
+				lastPublishTime = msg.PublishTime()
 				lastMessageId = msg.ID()
 				log.Debugf("Recevied message %s", lastMessageId)
 				out <- &model.ConsumerMessage{

--- a/internal/lookoutingester/pulsario/pulsar.go
+++ b/internal/lookoutingester/pulsario/pulsar.go
@@ -25,10 +25,31 @@ var log = logrus.NewEntry(logrus.StandardLogger())
 func Receive(ctx context.Context, consumer pulsar.Consumer, consumerId int, bufferSize int, receiveTimeout time.Duration, backoffTime time.Duration) chan *model.ConsumerMessage {
 	out := make(chan *model.ConsumerMessage, bufferSize)
 	go func() {
+
+		// Periodically log the number of processed messages.
+		logInterval := 60 * time.Second
+		lastLogged := time.Now()
+		numReceived := 0
 		var lastMessageId pulsar.MessageID
+		lastMessageId = nil
+		lastPublishTime := time.Now()
 
 		// Run until ctx is cancelled.
 		for {
+
+			// Periodic logging.
+			if time.Since(lastLogged) > logInterval {
+				log.WithFields(
+					logrus.Fields{
+						"received":      numReceived,
+						"interval":      logInterval,
+						"lastMessageId": lastMessageId,
+						"timeLag":       time.Now().Sub(lastPublishTime),
+					},
+				).Info("message statistics")
+				numReceived = 0
+				lastLogged = time.Now()
+			}
 
 			// Exit if the context has been cancelled. Otherwise, get a message from Pulsar.
 			select {
@@ -55,8 +76,11 @@ func Receive(ctx context.Context, consumer pulsar.Consumer, consumerId int, buff
 					time.Sleep(backoffTime)
 					continue
 				}
-				log.Debugf("Recevied message %s", msg.ID())
 				lastMessageId = msg.ID()
+				lastPublishTime = msg.PublishTime()
+				numReceived++
+				lastMessageId = msg.ID()
+				log.Debugf("Recevied message %s", lastMessageId)
 				out <- &model.ConsumerMessage{
 					Message:    msg,
 					ConsumerId: consumerId,


### PR DESCRIPTION
I've added a periodic logger in the pulsar receive code (similar to that in `submit_from_log`) so that we can see that we're actually receiving pulsar messages.