### PR TITLE
Install kubectl in /usr/local/bin for release job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,7 +289,7 @@ jobs:
           command: |
             curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
             chmod +x kubectl
-            mv kubectl /home/circleci/bin/
+            sudo mv kubectl /usr/local/bin/
             make download # no-op if we restored from cache
 
       - run:


### PR DESCRIPTION
This job runs in a container, for which we need to use a different path.