### PR TITLE
Store Jobs in JobSet by Queue:JobSet Pair: add storage

### DIFF
--- a/internal/armada/repository/job.go
+++ b/internal/armada/repository/job.go
@@ -205,6 +205,9 @@ func (repo *RedisJobRepository) DeleteJobs(jobs []*api.Job) (map[*api.Job]error,
 		deletionResult.deleteJobSetIndexResult = pipe.SRem(jobSetPrefix+job.JobSetId, job.Id)
 		deletionResult.deleteJobRetriesResult = pipe.Del(jobRetriesPrefix + job.Id)
 
+		// Don't care if deletion fails during compatibility period
+		pipe.SRem(jobSetPrefix+job.Queue+keySeparator+job.JobSetId, job.Id)
+
 		if !deletionResult.expiryAlreadySet {
 			deletionResult.setJobExpiryResult = pipe.Expire(jobObjectPrefix+job.Id, repo.retentionPolicy.JobRetentionDuration)
 		}
@@ -1039,7 +1042,12 @@ func (repo *RedisJobRepository) leaseJobs(clusterId string, jobs []*api.Job) ([]
 
 func addJob(db redis.Cmdable, job *api.Job, jobData *[]byte) *redis.Cmd {
 	return addJobScript.Run(db,
-		[]string{jobQueuePrefix + job.Queue, jobObjectPrefix + job.Id, jobSetPrefix + job.JobSetId, jobClientIdPrefix + job.Queue + keySeparator + job.ClientId},
+		[]string{
+			jobQueuePrefix + job.Queue,
+			jobObjectPrefix + job.Id,
+			jobSetPrefix + job.JobSetId,
+			jobSetPrefix + job.Queue + keySeparator + job.JobSetId,
+			jobClientIdPrefix + job.Queue + keySeparator + job.ClientId},
 		job.Id, job.Priority, *jobData, job.ClientId)
 }
 
@@ -1049,7 +1057,8 @@ var addJobScript = redis.NewScript(`
 local queueKey = KEYS[1]
 local jobKey = KEYS[2]
 local jobSetKey = KEYS[3]
-local jobClientIdKey = KEYS[4]
+local jobSetQueueKey = KEYS[4]
+local jobClientIdKey = KEYS[5]
 
 local jobId = ARGV[1]
 local jobPriority = ARGV[2]
@@ -1066,6 +1075,7 @@ end
 
 redis.call('SET', jobKey, jobData)
 redis.call('SADD', jobSetKey, jobId)
+redis.call('SADD', jobSetQueueKey, jobId)
 redis.call('ZADD', queueKey, jobPriority, jobId)
 
 return jobId


### PR DESCRIPTION
We currently store a mapping from JobSet -> set of JobIds in that JobSet in Redis in Armada.

This however means that if multiple Queues have the same JobSet name, then Jobs from different Queues will be stored under the same key in Redis.

As such we want to make sure that the key is a Queue:JobSet pair instead. This would make JobCancellation easier, as in order to cancel all Jobs in a JobSet, we currently have to load all Job ids in a queue and filter out those in the specified JobSet.

This is the first step of the migration to avoid breaking existing setups, which allows for storing Job ids in JobSets using both methods.