### PR TITLE
Improve Watch in dotnet client to handle network failures better

### DIFF
--- a/client/DotNet/Armada.Client.Test/Tests.cs
+++ b/client/DotNet/Armada.Client.Test/Tests.cs
@@ -103,7 +103,7 @@ namespace GResearch.Armada.Client.Test
                 {
                     new V1Container
                     {
-                        Name = "Container1",
+                        Name = "container1",
                         Image = "index.docker.io/library/ubuntu:latest",
                         Args = new[] {"sleep", "10s"},
                         SecurityContext = new V1SecurityContext {RunAsUser = 1000},

--- a/client/DotNet/Armada.Client/Client.cs
+++ b/client/DotNet/Armada.Client/Client.cs
@@ -77,7 +77,7 @@ namespace GResearch.Armada.Client
 
     public partial class ArmadaClient : IArmadaClient
     {
-        private const int WatchInactivityTimeoutSeconds = 15;
+        private const int WatchInactivityTimeoutSeconds = 600;
         private const string NoLine = "NoLine";
         
         public async Task<IEnumerable<StreamResponse<ApiEventStreamMessage>>> GetJobEventsStream(

--- a/client/DotNet/Armada.Client/Client.cs
+++ b/client/DotNet/Armada.Client/Client.cs
@@ -116,53 +116,58 @@ namespace GResearch.Armada.Client
             var failCount = 0;
             while (!ct.IsCancellationRequested)
             {
-                try
+                using (var jobSetEventRequestCts = CancellationTokenSource.CreateLinkedTokenSource(ct))
                 {
-                    var jobSetEventRequestCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
                     jobSetEventRequestCts.CancelAfter(TimeSpan.FromSeconds(WatchInactivityTimeoutSeconds));
-                    using (var fileResponse = await GetJobSetEventsCoreAsync(queue, jobSetId,
-                        new ApiJobSetRequest {FromMessageId = fromMessageId, Watch = true}, jobSetEventRequestCts.Token))
-                    using (var reader = new StreamReader(fileResponse.Stream))
+                    try
                     {
-                        try
+                        using (var fileResponse = await GetJobSetEventsCoreAsync(queue, jobSetId,
+                            new ApiJobSetRequest {FromMessageId = fromMessageId, Watch = true},
+                            jobSetEventRequestCts.Token))
+                        using (var reader = new StreamReader(fileResponse.Stream))
                         {
-                            failCount = 0;
-                            while (!ct.IsCancellationRequested)
+                            try
                             {
-                                var inactivityCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-                                inactivityCts.CancelAfter(TimeSpan.FromSeconds(WatchInactivityTimeoutSeconds));
-                                
-                                var line = await ReadLineAsyncWithCancellation(reader, inactivityCts.Token);
+                                failCount = 0;
+                                while (!ct.IsCancellationRequested)
+                                {
+                                    using (var inactivityCts = CancellationTokenSource.CreateLinkedTokenSource(ct))
+                                    {
+                                        inactivityCts.CancelAfter(TimeSpan.FromSeconds(WatchInactivityTimeoutSeconds));
+                                        var line = await ReadLineAsyncWithCancellation(reader, inactivityCts.Token);
 
-                                if (string.Equals(line, NoLine) || inactivityCts.IsCancellationRequested)
-                                {
-                                    reader.Dispose();
-                                    break;
-                                }
-                                var (newMessageId, eventMessage) = ProcessEventLine(fromMessageId, line);
-                                fromMessageId = newMessageId;
-                                if (eventMessage != null)
-                                {
-                                    onMessage(eventMessage);
+                                        if (string.Equals(line, NoLine) || inactivityCts.IsCancellationRequested)
+                                        {
+                                            reader.Dispose();
+                                            break;
+                                        }
+
+                                        var (newMessageId, eventMessage) = ProcessEventLine(fromMessageId, line);
+                                        fromMessageId = newMessageId;
+                                        if (eventMessage != null)
+                                        {
+                                            onMessage(eventMessage);
+                                        }
+                                    }
                                 }
                             }
-                        }
-                        catch (IOException)
-                        {
-                            // Stream was probably closed by the server, continue to reconnect
+                            catch (IOException)
+                            {
+                                // Stream was probably closed by the server, continue to reconnect
+                            }
                         }
                     }
-                }
-                catch (TaskCanceledException)
-                {
-                    // Server closed the connection, continue to reconnect
-                }
-                catch (Exception e)
-                {
-                    failCount++;
-                    onException?.Invoke(e);
-                    // gradually back off
-                    await Task.Delay(TimeSpan.FromSeconds(Math.Min(300, Math.Pow(2 ,failCount))), ct);
+                    catch (TaskCanceledException)
+                    {
+                        // Server closed the connection, continue to reconnect
+                    }
+                    catch (Exception e)
+                    {
+                        failCount++;
+                        onException?.Invoke(e);
+                        // gradually back off
+                        await Task.Delay(TimeSpan.FromSeconds(Math.Min(300, Math.Pow(2, failCount))), ct);
+                    }
                 }
             }
         }
@@ -176,35 +181,30 @@ namespace GResearch.Armada.Client
          */
         private async Task<string> ReadLineAsyncWithCancellation(StreamReader reader, CancellationToken ct)
         {
-            var taskCancellation = CancellationTokenSource.CreateLinkedTokenSource(ct);
-            var taskCancellationToken = taskCancellation.Token;
-
-            var task = Task.Run<string>(async() =>
+            using(var taskCancellation = CancellationTokenSource.CreateLinkedTokenSource(ct))
             {
-                if (!reader.EndOfStream)
+                var taskCancellationToken = taskCancellation.Token;
+
+                var task = Task.Run<string>(async() =>
                 {
-                    return await reader.ReadLineAsync();
-                }
+                    if (!reader.EndOfStream)
+                    {
+                        return await reader.ReadLineAsync();
+                    }
 
-                return NoLine;
-            }, ct);
-            var cancellation = Task.Run(async () =>
-            {
-                while (!taskCancellationToken.IsCancellationRequested)
+                    return NoLine;
+                }, ct);
+                var cancellation = Task.Run(async () =>
                 {
-                    await Task.Delay(TimeSpan.FromSeconds(1), taskCancellationToken);
-                }
-            }, taskCancellationToken);
+                    while (!taskCancellationToken.IsCancellationRequested)
+                    {
+                        await Task.Delay(TimeSpan.FromSeconds(1), taskCancellationToken);
+                    }
+                }, taskCancellationToken);
 
-
-            await Task.WhenAny(task, cancellation);
-
-            if (!taskCancellationToken.IsCancellationRequested)
-            {
-                taskCancellation.Cancel();
+                await Task.WhenAny(task, cancellation);
+                return task.IsCompleted ? task.Result : NoLine;
             }
-
-            return task.IsCompleted ? task.Result : NoLine;
         }
 
         private (string, StreamResponse<ApiEventStreamMessage>) ProcessEventLine(string fromMessageId, string line)

--- a/client/DotNet/Armada.Client/Client.cs
+++ b/client/DotNet/Armada.Client/Client.cs
@@ -201,13 +201,15 @@ namespace GResearch.Armada.Client
                     }
                 }, taskCancellationToken);
                 await Task.WhenAny(task, cancellation);
+                
+                var result = task.IsCompleted ? task.Result : NoLine;
 
                 if (!taskCancellationToken.IsCancellationRequested)
                 {
                     taskCancellation.Cancel();
                 }
 
-                return task.IsCompleted ? task.Result : NoLine;
+                return result;
             }
         }
 


### PR DESCRIPTION
Watch in the dotnet client can get into a situation where it is watching a stream that is closed
 - In the case of network failures

As it has no concept of keepalive, it waits forever as this connection is actually "dead" in there is nothing on the other end that may send data

Now the client will timeout if no activity happens for 10 minutes and reestablish the connection
 - In the default case a JobUtilisationEvent will come more often than this and keep the connection alive
 - In the case the connection gets into a broken state, it isn't terrible to retry every 10 minutes
 - Worst case, we end up "polling" every 10 minutes when watching an empty stream

This should make the client more resilient to network failures

Additionally now cancellation works as expected for Watch, rather than hanging

We should move the dotnet client to GRPC now that it has better GRPC support. As it has native keepalive + streaming