### PR TITLE
Fix bugs discovered in testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .idea
 .kube
 .test
+.build
 NuGet.Config
 armadactl.yaml
 loadtest.yaml

--- a/build/armada-load-tester/Dockerfile
+++ b/build/armada-load-tester/Dockerfile
@@ -4,7 +4,7 @@ RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 
 USER armada
 
-COPY ./bin/linux/armada-load-tester /app/
+COPY ./armada-load-tester /app/
 
 WORKDIR /app
 

--- a/build/armada/Dockerfile
+++ b/build/armada/Dockerfile
@@ -4,9 +4,9 @@ RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 
 USER armada
 
-COPY ./bin/linux/server /app/
+COPY ./server /app/
 
-COPY /config/armada/ /app/config/armada
+COPY ./config/ /app/config/armada
 
 WORKDIR /app
 

--- a/build/armadactl/Dockerfile
+++ b/build/armadactl/Dockerfile
@@ -4,7 +4,7 @@ RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 
 USER armada
 
-COPY ./bin/linux/armadactl /app/
+COPY ./armadactl /app/
 
 WORKDIR /app
 

--- a/build/binoculars/Dockerfile
+++ b/build/binoculars/Dockerfile
@@ -4,8 +4,9 @@ RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 
 USER armada
 
-COPY ./bin/linux/binoculars /app/
-COPY /config/binoculars/ /app/config/binoculars
+COPY ./binoculars /app/
+
+COPY /config/ /app/config/binoculars
 
 WORKDIR /app
 

--- a/build/executor/Dockerfile
+++ b/build/executor/Dockerfile
@@ -4,9 +4,9 @@ RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 
 USER armada
 
-COPY ./bin/linux/executor /app/
+COPY ./executor /app/
 
-COPY /config/executor/ /app/config/executor
+COPY /config/ /app/config/executor
 
 WORKDIR /app
 

--- a/build/fakeexecutor/Dockerfile
+++ b/build/fakeexecutor/Dockerfile
@@ -4,9 +4,9 @@ RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 
 USER armada
 
-COPY ./bin/linux/fakeexecutor /app/
+COPY ./fakeexecutor /app/
 
-COPY /config/executor/ /app/config/executor
+COPY /config/ /app/config/executor
 
 WORKDIR /app
 

--- a/build/lookoutingester/Dockerfile
+++ b/build/lookoutingester/Dockerfile
@@ -4,9 +4,9 @@ RUN addgroup -S -g 2000 armada && adduser -S -u 1000 armada -G armada
 
 USER armada
 
-COPY ./bin/linux/lookoutingester /app/
+COPY ./lookoutingester /app/
 
-COPY ./config/lookoutingester/ /app/config/lookoutingester
+COPY ./config/ /app/config/lookoutingester
 
 WORKDIR /app
 

--- a/cmd/eventsprinter/cmd/root.go
+++ b/cmd/eventsprinter/cmd/root.go
@@ -35,7 +35,7 @@ func RootCmd() *cobra.Command {
 	cmd.PersistentFlags().String("url", "pulsar://localhost:6650", "URL to connect to Pulsar on.")
 	cmd.PersistentFlags().Bool("verbose", false, "Print full event sequences.")
 	cmd.PersistentFlags().String("subscription", "eventsprinter", "Subscription to connect to Pulsar on.")
-	cmd.PersistentFlags().String("topic", "jobset-events", "Pulsar topic to subscribe to.")
+	cmd.PersistentFlags().String("topic", "persistent://armada/armada/jobset-events", "Pulsar topic to subscribe to.")
 
 	return cmd
 }

--- a/cmd/eventsprinter/logic/logic.go
+++ b/cmd/eventsprinter/logic/logic.go
@@ -224,11 +224,5 @@ func withSetup(url, topic, subscription string, action func(ctx context.Context,
 	}
 	defer consumer.Close()
 
-	// Skip any messages already published to Pulsar.
-	err = consumer.SeekByTime(time.Now())
-	if err != nil {
-		return err
-	}
-
 	return action(context.Background(), producer, consumer)
 }

--- a/e2e/pulsar_test/pulsar_test.go
+++ b/e2e/pulsar_test/pulsar_test.go
@@ -845,9 +845,11 @@ func isSequencef(t *testing.T, expected *armadaevents.EventSequence, actual *arm
 	ok = ok && assert.Equal(t, expected.JobSetName, actual.JobSetName)
 	ok = ok && assert.Equal(t, expected.UserId, actual.UserId)
 	ok = ok && assert.Equal(t, len(expected.Events), len(actual.Events))
-	for i, expectedEvent := range expected.Events {
-		actualEvent := actual.Events[i]
-		ok = ok && isEventf(t, expectedEvent, actualEvent, "%d-th event differed: %s", i, actualEvent)
+	if len(expected.Events) == len(actual.Events) {
+		for i, expectedEvent := range expected.Events {
+			actualEvent := actual.Events[i]
+			ok = ok && isEventf(t, expectedEvent, actualEvent, "%d-th event differed: %s", i, actualEvent)
+		}
 	}
 	return ok
 }

--- a/e2e/setup/pulsar/armada-config.yaml
+++ b/e2e/setup/pulsar/armada-config.yaml
@@ -7,6 +7,8 @@ pulsar:
   hostnameSuffix: "svc"
   certNameSuffix: "ingress-tls-certificate"
   dedupTable: pulsar_submit_dedup
+  eventsPrinter: true
+  eventsPrinterSubscription: "EventsPrinter"
 postgres:
   maxOpenConns: 100
   maxIdleConns: 25

--- a/e2e/setup/pulsar/armada-config.yaml
+++ b/e2e/setup/pulsar/armada-config.yaml
@@ -1,7 +1,7 @@
 pulsar:
   enabled: true
   URL: "pulsar://pulsar:6650"
-  jobsetEventsTopic: "jobset-events"
+  jobsetEventsTopic: "persistent://armada/armada/jobset-events"
   redisFromPulsarSubscription: "RedisFromPulsar"
   pulsarFromPulsarSubscription: "PulsarFromPulsar"
   hostnameSuffix: "svc"

--- a/internal/armada/configuration/types.go
+++ b/internal/armada/configuration/types.go
@@ -70,6 +70,9 @@ type PulsarConfig struct {
 	Annotations    map[string]string
 	// Settings for deduplication, which relies on a postgres server.
 	DedupTable string
+	// Log all pulsar events
+	EventsPrinterSubscription string
+	EventsPrinter             bool
 }
 
 type SchedulingConfig struct {

--- a/internal/armada/server.go
+++ b/internal/armada/server.go
@@ -161,6 +161,7 @@ func Serve(config *configuration.ArmadaConfig, healthChecks *health.MultiChecker
 
 	// If Pulsar is enabled, use the Pulsar submit endpoints.
 	if config.Pulsar.Enabled {
+		serverId := uuid.New()
 
 		// API endpoints that generate Pulsar messages.
 		log.Info("Pulsar config provided; using Pulsar submit endpoints.")
@@ -177,7 +178,7 @@ func Serve(config *configuration.ArmadaConfig, healthChecks *health.MultiChecker
 			panic(err)
 		}
 		producer, err := pulsarClient.CreateProducer(pulsar.ProducerOptions{
-			Name:             fmt.Sprintf("armada-server-%s", uuid.New()),
+			Name:             fmt.Sprintf("armada-server-%s", serverId),
 			CompressionType:  compressionType,
 			CompressionLevel: compressionLevel,
 			Topic:            config.Pulsar.JobsetEventsTopic,
@@ -252,7 +253,10 @@ func Serve(config *configuration.ArmadaConfig, healthChecks *health.MultiChecker
 
 		// Create a new producer for this service.
 		producer, err = pulsarClient.CreateProducer(pulsar.ProducerOptions{
-			Topic: config.Pulsar.JobsetEventsTopic,
+			Name:             fmt.Sprintf("armada-pulsar-to-pulsar-%s", serverId),
+			CompressionType:  compressionType,
+			CompressionLevel: compressionLevel,
+			Topic:            config.Pulsar.JobsetEventsTopic,
 		})
 		if err != nil {
 			panic(err)

--- a/internal/armada/server.go
+++ b/internal/armada/server.go
@@ -274,9 +274,6 @@ func Serve(config *configuration.ArmadaConfig, healthChecks *health.MultiChecker
 				panic(err)
 			}
 
-			// We're only interested in new events.
-			consumer.SeekByTime(time.Now())
-
 			eventsPrinter := server.EventsPrinter{
 				Consumer: consumer,
 			}

--- a/internal/armada/server.go
+++ b/internal/armada/server.go
@@ -266,16 +266,10 @@ func Serve(config *configuration.ArmadaConfig, healthChecks *health.MultiChecker
 
 		// Service that reads from Pulsar and logs events.
 		if config.Pulsar.EventsPrinter {
-			consumer, err = pulsarClient.Subscribe(pulsar.ConsumerOptions{
+			eventsPrinter := server.EventsPrinter{
+				Client:           pulsarClient,
 				Topic:            config.Pulsar.JobsetEventsTopic,
 				SubscriptionName: config.Pulsar.EventsPrinterSubscription,
-			})
-			if err != nil {
-				panic(err)
-			}
-
-			eventsPrinter := server.EventsPrinter{
-				Consumer: consumer,
 			}
 			go eventsPrinter.Run(context.Background())
 		}

--- a/internal/armada/server.go
+++ b/internal/armada/server.go
@@ -265,22 +265,23 @@ func Serve(config *configuration.ArmadaConfig, healthChecks *health.MultiChecker
 		go pulsarFromPulsar.Run(context.Background())
 
 		// Service that reads from Pulsar and logs events.
-		consumer, err = pulsarClient.Subscribe(pulsar.ConsumerOptions{
-			Topic:            config.Pulsar.JobsetEventsTopic,
-			SubscriptionName: config.Pulsar.EventsPrinterSubscription,
-		})
-		if err != nil {
-			panic(err)
+		if config.Pulsar.EventsPrinter {
+			consumer, err = pulsarClient.Subscribe(pulsar.ConsumerOptions{
+				Topic:            config.Pulsar.JobsetEventsTopic,
+				SubscriptionName: config.Pulsar.EventsPrinterSubscription,
+			})
+			if err != nil {
+				panic(err)
+			}
+
+			// We're only interested in new events.
+			consumer.SeekByTime(time.Now())
+
+			eventsPrinter := server.EventsPrinter{
+				Consumer: consumer,
+			}
+			go eventsPrinter.Run(context.Background())
 		}
-
-		// We're only interested in new events.
-		consumer.SeekByTime(time.Now())
-
-		eventsPrinter := server.EventsPrinter{
-			Consumer: consumer,
-		}
-		go eventsPrinter.Run(context.Background())
-
 	} else {
 		log.Info("No Pulsar config provided; submitting directly to Redis and Nats.")
 	}

--- a/internal/armada/server/eventsprinter.go
+++ b/internal/armada/server/eventsprinter.go
@@ -73,7 +73,7 @@ func (srv *EventsPrinter) Run(ctx context.Context) {
 			ctxWithTimeout, _ := context.WithTimeout(ctx, 10*time.Second)
 			msg, err := consumer.Receive(ctxWithTimeout)
 			if errors.Is(err, context.DeadlineExceeded) { //expected
-				log.Info("no new messages from Pulsar (or another instance holds the subscription")
+				log.Info("no new messages from Pulsar (or another instance holds the subscription)")
 				break
 			} else if err != nil {
 				logging.WithStacktrace(log, err).Warnf("receiving from Pulsar failed")

--- a/internal/armada/server/eventsprinter.go
+++ b/internal/armada/server/eventsprinter.go
@@ -3,13 +3,13 @@ package server
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/apache/pulsar-client-go/pulsar"
 	"github.com/gogo/protobuf/proto"
 	"github.com/sirupsen/logrus"
 
+	"github.com/G-Research/armada/internal/common/eventutil"
 	"github.com/G-Research/armada/internal/common/logging"
 	"github.com/G-Research/armada/internal/common/requestid"
 	"github.com/G-Research/armada/internal/pulsarutils/pulsarrequestid"
@@ -92,16 +92,7 @@ func (srv *EventsPrinter) Run(ctx context.Context) {
 				requestid.MetadataKey: pulsarrequestid.FromMessageOrMissing(msg),
 			})
 
-			s := "Sequence: "
-			for _, event := range sequence.Events {
-				jobId, _ := armadaevents.JobIdFromEvent(event)
-				jobIdString, err := armadaevents.UlidStringFromProtoUuid(jobId)
-				if err != nil {
-					logging.WithStacktrace(log, err).Warnf("converting jobId to string failed")
-					jobIdString = ""
-				}
-				s += fmt.Sprintf("[%T (job %s)] ", event.Event, jobIdString)
-			}
+			s := "Sequence: " + eventutil.ShortSequenceString(sequence)
 
 			messageLogger.Info(s)
 		}

--- a/internal/armada/server/eventsprinter.go
+++ b/internal/armada/server/eventsprinter.go
@@ -73,7 +73,7 @@ func (srv *EventsPrinter) Run(ctx context.Context) {
 			ctxWithTimeout, _ := context.WithTimeout(ctx, 10*time.Second)
 			msg, err := consumer.Receive(ctxWithTimeout)
 			if errors.Is(err, context.DeadlineExceeded) { //expected
-				log.Info("no new messages from Pulsar")
+				log.Info("no new messages from Pulsar (or another instance holds the subscription")
 				break
 			} else if err != nil {
 				logging.WithStacktrace(log, err).Warnf("receiving from Pulsar failed")

--- a/internal/armada/server/eventsprinter.go
+++ b/internal/armada/server/eventsprinter.go
@@ -1,0 +1,109 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/apache/pulsar-client-go/pulsar"
+	"github.com/gogo/protobuf/proto"
+	"github.com/sirupsen/logrus"
+
+	"github.com/G-Research/armada/internal/common/logging"
+	"github.com/G-Research/armada/internal/common/requestid"
+	"github.com/G-Research/armada/internal/pulsarutils/pulsarrequestid"
+	"github.com/G-Research/armada/pkg/armadaevents"
+)
+
+// EventsPrinter is a service that prints all events passing through pulsar to a logger.
+// This service is only meant for use during development; it will be slow when the number of events is large.
+type EventsPrinter struct {
+	Consumer pulsar.Consumer
+	// Logger from which the loggers used by this service are derived
+	// (e.g., using srv.Logger.WithField), or nil, in which case the global logrus logger is used.
+	Logger *logrus.Entry
+}
+
+// Run the service that reads from Pulsar and updates Armada until the provided context is cancelled.
+func (srv *EventsPrinter) Run(ctx context.Context) {
+
+	// Get the configured logger, or the standard logger if none is provided.
+	var log *logrus.Entry
+	if srv.Logger != nil {
+		log = srv.Logger.WithField("service", "EventsPrinter")
+	} else {
+		log = logrus.StandardLogger().WithField("service", "EventsPrinter")
+	}
+	log.Info("service started")
+
+	// Recover from panics by restarting the service.
+	defer func() {
+		if err := recover(); err != nil {
+			log.WithField("error", err).Error("unexpected panic; restarting")
+			time.Sleep(time.Second)
+			go srv.Run(ctx)
+		} else {
+			// An expected shutdown.
+			log.Info("service stopped")
+		}
+	}()
+
+	// Run until ctx is cancelled.
+	for {
+
+		// Exit if the context has been cancelled. Otherwise, get a message from Pulsar.
+		select {
+		case <-ctx.Done():
+			return
+		default:
+
+			// Get a message from Pulsar, which consists of a sequence of events (i.e., state transitions).
+			ctxWithTimeout, _ := context.WithTimeout(ctx, 10*time.Second)
+			msg, err := srv.Consumer.Receive(ctxWithTimeout)
+			if errors.Is(err, context.DeadlineExceeded) { //expected
+				log.Info("no new messages from Pulsar")
+				break
+			} else if err != nil {
+				logging.WithStacktrace(log, err).Warnf("receiving from Pulsar failed")
+				break
+			}
+
+			srv.Consumer.Ack(msg)
+
+			// We're only interested in control messages.
+			if !armadaevents.IsControlMessage(msg) {
+				continue
+			}
+
+			sequence := &armadaevents.EventSequence{}
+			err = proto.Unmarshal(msg.Payload(), sequence)
+			if err != nil {
+				logging.WithStacktrace(log, err).Warnf("unmarshalling Pulsar message failed")
+				continue
+			}
+
+			messageLogger := log.WithFields(logrus.Fields{
+				"Queue":               sequence.Queue,
+				"JobSetName":          sequence.JobSetName,
+				"UserId":              sequence.UserId,
+				"Groups":              sequence.Groups,
+				"NumEvents":           len(sequence.Events),
+				requestid.MetadataKey: pulsarrequestid.FromMessageOrMissing(msg),
+			})
+
+			s := "Sequence: "
+			for _, event := range sequence.Events {
+				jobId, _ := armadaevents.JobIdFromEvent(event)
+				jobIdString, err := armadaevents.UlidStringFromProtoUuid(jobId)
+				if err != nil {
+					logging.WithStacktrace(log, err).Warnf("converting jobId to string failed")
+					jobIdString = ""
+				}
+				s += fmt.Sprintf("[%T (job %s)] ", event.Event, jobIdString)
+			}
+
+			messageLogger.Info(s)
+		}
+	}
+}

--- a/internal/armada/server/eventsprinter.go
+++ b/internal/armada/server/eventsprinter.go
@@ -90,6 +90,12 @@ func (srv *EventsPrinter) Run(ctx context.Context) {
 				"Groups":              sequence.Groups,
 				"NumEvents":           len(sequence.Events),
 				requestid.MetadataKey: pulsarrequestid.FromMessageOrMissing(msg),
+				"PublishTime":         msg.PublishTime(),
+				"EventTime":           msg.EventTime(),
+				"Topic":               msg.Topic(),
+				"Properties":          msg.Properties(),
+				"PulsarId":            msg.ID(),
+				"Key":                 msg.Key(),
 			})
 
 			s := "Sequence: " + eventutil.ShortSequenceString(sequence)

--- a/internal/armada/server/log_to_pulsar.go
+++ b/internal/armada/server/log_to_pulsar.go
@@ -128,7 +128,7 @@ func (srv *PulsarFromPulsar) Run(ctx context.Context) {
 
 			// Process the events in the sequence. For efficiency, we may process several events at a time.
 			messageLogger.WithField("numEvents", len(sequence.Events)).Info("processing sequence")
-			err = srv.ProcessSequence(ctx, sequence)
+			err = srv.ProcessSequence(ctxWithLogger, sequence)
 			if err != nil {
 				logging.WithStacktrace(messageLogger, err).Error("failed to process sequence")
 			} else {
@@ -165,6 +165,10 @@ func (srv *PulsarFromPulsar) ProcessSequence(ctx context.Context, sequence *arma
 	msg := &pulsar.ProducerMessage{
 		Payload: payload,
 		Key:     sequence.JobSetName,
+		Properties: map[string]string{
+			requestid.MetadataKey:                     requestId,
+			armadaevents.PULSAR_MESSAGE_TYPE_PROPERTY: armadaevents.PULSAR_CONTROL_MESSAGE,
+		},
 	}
 	pulsarrequestid.AddToMessage(msg, requestId)
 

--- a/internal/armada/server/log_to_pulsar.go
+++ b/internal/armada/server/log_to_pulsar.go
@@ -100,6 +100,12 @@ func (srv *PulsarFromPulsar) Run(ctx context.Context) {
 				time.Sleep(100 * time.Millisecond)
 				continue
 			}
+
+			// We're only interested in control messages.
+			if !armadaevents.IsControlMessage(msg) {
+				continue
+			}
+
 			lastMessageId = msg.ID()
 			lastPublishTime = msg.PublishTime()
 			numReceived++

--- a/internal/armada/server/submit_from_log.go
+++ b/internal/armada/server/submit_from_log.go
@@ -110,6 +110,12 @@ func (srv *SubmitFromLog) Run(ctx context.Context) {
 				time.Sleep(100 * time.Millisecond)
 				continue
 			}
+
+			// We're only interested in control messages.
+			if !armadaevents.IsControlMessage(msg) {
+				continue
+			}
+
 			lastMessageId = msg.ID()
 			lastPublishTime = msg.PublishTime()
 			numReceived++

--- a/internal/armada/server/submit_from_log.go
+++ b/internal/armada/server/submit_from_log.go
@@ -141,6 +141,7 @@ func (srv *SubmitFromLog) Run(ctx context.Context) {
 				continue
 			}
 
+			messageLogger.WithField("numEvents", len(sequence.Events)).Info("processing sequence")
 			ok = srv.ProcessSequence(ctxWithLogger, sequence)
 			if ok {
 				srv.Consumer.Ack(msg)

--- a/internal/armada/server/submit_to_log.go
+++ b/internal/armada/server/submit_to_log.go
@@ -762,9 +762,15 @@ func PulsarSequenceFromApiEvent(msg *api.EventMessage) (sequence *armadaevents.E
 			return nil, err
 		}
 
+		runId, err := armadaevents.ProtoUuidFromUuidString(m.UnableToSchedule.KubernetesId)
+		if err != nil {
+			return nil, err
+		}
+
 		sequence.Events = append(sequence.Events, &armadaevents.EventSequence_Event{
 			Event: &armadaevents.EventSequence_Event_JobRunErrors{
 				JobRunErrors: &armadaevents.JobRunErrors{
+					RunId: runId,
 					JobId: jobId,
 					Errors: []*armadaevents.Error{
 						{
@@ -941,9 +947,15 @@ func PulsarSequenceFromApiEvent(msg *api.EventMessage) (sequence *armadaevents.E
 			return nil, err
 		}
 
+		runId, err := armadaevents.ProtoUuidFromUuidString(m.Terminated.KubernetesId)
+		if err != nil {
+			return nil, err
+		}
+
 		sequence.Events = append(sequence.Events, &armadaevents.EventSequence_Event{
 			Event: &armadaevents.EventSequence_Event_JobRunErrors{
 				JobRunErrors: &armadaevents.JobRunErrors{
+					RunId: runId,
 					JobId: jobId,
 					Errors: []*armadaevents.Error{
 						{

--- a/internal/armada/server_test.go
+++ b/internal/armada/server_test.go
@@ -32,7 +32,9 @@ func TestSubmitJob_EmptyPodSpec(t *testing.T) {
 			Name:           "test",
 			PriorityFactor: 1,
 		})
-		assert.Empty(t, err)
+		if !assert.NoError(t, err) {
+			return
+		}
 
 		request := &api.JobSubmitRequest{
 			JobRequestItems: []*api.JobSubmitRequestItem{{}},
@@ -51,7 +53,9 @@ func TestSubmitJob(t *testing.T) {
 			Name:           "test",
 			PriorityFactor: 1,
 		})
-		assert.Empty(t, err)
+		if !assert.NoError(t, err) {
+			return
+		}
 
 		cpu, _ := resource.ParseQuantity("1")
 		memory, _ := resource.ParseQuantity("512Mi")
@@ -59,10 +63,16 @@ func TestSubmitJob(t *testing.T) {
 		jobId := SubmitJob(client, ctx, cpu, memory, t)
 
 		leasedResponse, err := leaseJobs(leaseClient, ctx, common.ComputeResources{"cpu": cpu, "memory": memory})
-		assert.Empty(t, err)
+		if !assert.NoError(t, err) {
+			return
+		}
 
-		assert.Equal(t, 1, len(leasedResponse.Job))
-		assert.Equal(t, jobId, leasedResponse.Job[0].Id)
+		if !assert.Equal(t, 1, len(leasedResponse.Job)) {
+			return
+		}
+		if !assert.Equal(t, jobId, leasedResponse.Job[0].Id) {
+			return
+		}
 	})
 }
 
@@ -158,7 +168,7 @@ func SubmitJob(client api.SubmitClient, ctx context.Context, cpu resource.Quanti
 		JobSetId: "set",
 	}
 	response, err := client.SubmitJobs(ctx, request)
-	assert.Empty(t, err)
+	assert.NoError(t, err)
 	return response.JobResponseItems[0].JobId
 }
 

--- a/internal/common/eventutil/eventutil.go
+++ b/internal/common/eventutil/eventutil.go
@@ -36,7 +36,7 @@ func UnmarshalEventSequence(ctx context.Context, payload []byte) (*armadaevents.
 		err = &armadaerrors.ErrInvalidArgument{
 			Name:    "JobSetName",
 			Value:   "",
-			Message: "JobSetName not provided",
+			Message: fmt.Sprintf("JobSetName not provided for sequence %s", ShortSequenceString(sequence)),
 		}
 		err = errors.WithStack(err)
 		return nil, err
@@ -46,7 +46,7 @@ func UnmarshalEventSequence(ctx context.Context, payload []byte) (*armadaevents.
 		err = &armadaerrors.ErrInvalidArgument{
 			Name:    "Queue",
 			Value:   "",
-			Message: "Queue name not provided",
+			Message: fmt.Sprintf("Queue name not provided for sequence %s", ShortSequenceString(sequence)),
 		}
 		err = errors.WithStack(err)
 		return nil, err
@@ -66,6 +66,21 @@ func UnmarshalEventSequence(ctx context.Context, payload []byte) (*armadaevents.
 		return nil, err
 	}
 	return sequence, nil
+}
+
+// ShortSequenceString returns a short string representation of an events sequence.
+// To be used for logging, for example.
+func ShortSequenceString(sequence *armadaevents.EventSequence) string {
+	s := ""
+	for _, event := range sequence.Events {
+		jobId, _ := armadaevents.JobIdFromEvent(event)
+		jobIdString, err := armadaevents.UlidStringFromProtoUuid(jobId)
+		if err != nil {
+			jobIdString = ""
+		}
+		s += fmt.Sprintf("[%T (job %s)] ", event.Event, jobIdString)
+	}
+	return s
 }
 
 // ApiJobsFromLogSubmitJobs converts a slice of log jobs to API jobs.

--- a/internal/common/eventutil/eventutil.go
+++ b/internal/common/eventutil/eventutil.go
@@ -314,11 +314,11 @@ func K8sServicesIngressesFromApiJob(job *api.Job, ingressConfig *configuration.I
 // LogSubmitPriorityFromApiPriority returns the uint32 representation of the priority included with a submitted job,
 // or an error if the conversion fails.
 func LogSubmitPriorityFromApiPriority(priority float64) (uint32, error) {
-	if priority < 1 {
+	if priority < 0 {
 		return 0, &armadaerrors.ErrInvalidArgument{
 			Name:    "priority",
 			Value:   priority,
-			Message: "priority must be larger than or equal to 1",
+			Message: "priority must be larger than or equal to 0",
 		}
 	}
 	if priority > math.MaxUint32 {

--- a/internal/lookoutingester/pulsario/pulsar.go
+++ b/internal/lookoutingester/pulsario/pulsar.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/G-Research/armada/internal/common/logging"
 	"github.com/G-Research/armada/internal/lookoutingester/model"
+	"github.com/G-Research/armada/pkg/armadaevents"
 )
 
 var log = logrus.NewEntry(logrus.StandardLogger())
@@ -76,6 +77,12 @@ func Receive(ctx context.Context, consumer pulsar.Consumer, consumerId int, buff
 					time.Sleep(backoffTime)
 					continue
 				}
+
+				// We're only interested in control messages.
+				if !armadaevents.IsControlMessage(msg) {
+					continue
+				}
+
 				numReceived++
 				lastPublishTime = msg.PublishTime()
 				lastMessageId = msg.ID()

--- a/makefile
+++ b/makefile
@@ -261,7 +261,7 @@ setup-cluster:
 	mkdir -p .kube
 	kind get kubeconfig --internal --name armada-test > .kube/config
 
-tests-e2e-setup:# setup-cluster
+tests-e2e-setup: setup-cluster
 	docker run --rm -v ${PWD}:/go/src/armada -w /go/src/armada -e KUBECONFIG=/go/src/armada/.kube/config --network kind bitnami/kubectl:1.23 apply -f ./e2e/setup/namespace-with-anonymous-user.yaml
 
 	# Armada dependencies.

--- a/makefile
+++ b/makefile
@@ -253,12 +253,18 @@ setup-cluster:
 	mkdir -p .kube
 	kind get kubeconfig --internal --name armada-test > .kube/config
 
-tests-e2e-setup: setup-cluster 
+tests-e2e-setup:# setup-cluster
 	docker run --rm -v ${PWD}:/go/src/armada -w /go/src/armada -e KUBECONFIG=/go/src/armada/.kube/config --network kind bitnami/kubectl:1.23 apply -f ./e2e/setup/namespace-with-anonymous-user.yaml
+
+	docker run -d --name pulsar -p 0.0.0.0:6650:6650 --network=kind apachepulsar/pulsar:2.9.1 bin/pulsar standalone
 	docker run -d --name nats --network=kind nats-streaming:0.24.5
 	docker run -d --name redis -p=6379:6379 --network=kind redis:6.2.6
-	docker run -d --name pulsar -p 0.0.0.0:6650:6650 --network=kind apachepulsar/pulsar:2.9.1 bin/pulsar standalone
 	docker run -d --name postgres --network=kind -p 5432:5432 -e POSTGRES_PASSWORD=psw postgres:14.2
+
+	sleep 10
+	docker exec -it pulsar bin/pulsar-admin tenants create armada
+	docker exec -it pulsar bin/pulsar-admin namespaces create armada/armada
+	docker exec -it pulsar bin/pulsar-admin topics create-partitioned-topic persistent://armada/armada/jobset-events -p 100	
 
 	sleep 30 # give dependencies time to start up
 	docker run -d --name server --network=kind -p=50051:50051 -p 8080:8080 -v ${PWD}/e2e:/e2e \

--- a/makefile
+++ b/makefile
@@ -256,15 +256,22 @@ setup-cluster:
 tests-e2e-setup:# setup-cluster
 	docker run --rm -v ${PWD}:/go/src/armada -w /go/src/armada -e KUBECONFIG=/go/src/armada/.kube/config --network kind bitnami/kubectl:1.23 apply -f ./e2e/setup/namespace-with-anonymous-user.yaml
 
+	# Armada dependencies.
 	docker run -d --name pulsar -p 0.0.0.0:6650:6650 --network=kind apachepulsar/pulsar:2.9.1 bin/pulsar standalone
 	docker run -d --name nats --network=kind nats-streaming:0.24.5
 	docker run -d --name redis -p=6379:6379 --network=kind redis:6.2.6
 	docker run -d --name postgres --network=kind -p 5432:5432 -e POSTGRES_PASSWORD=psw postgres:14.2
 
-	sleep 10
+	# Create the partitioned topic used by Armada.
+	sleep 10 # pulsar-admin errors if the Pulsar server hasn't started up yet.
 	docker exec -it pulsar bin/pulsar-admin tenants create armada
 	docker exec -it pulsar bin/pulsar-admin namespaces create armada/armada
-	docker exec -it pulsar bin/pulsar-admin topics create-partitioned-topic persistent://armada/armada/jobset-events -p 100	
+	docker exec -it pulsar bin/pulsar-admin topics create-partitioned-topic persistent://armada/armada/jobset-events -p 100
+
+	# Disable topic auto-creation to ensure an error is thrown on using the wrong topic
+	# (Pulsar automatically created the public tenant and default namespace).
+	docker exec -it pulsar bin/pulsar-admin namespaces set-auto-topic-creation public/default --disable
+	docker exec -it pulsar bin/pulsar-admin namespaces set-auto-topic-creation armada/armada --disable
 
 	sleep 30 # give dependencies time to start up
 	docker run -d --name server --network=kind -p=50051:50051 -p 8080:8080 -v ${PWD}/e2e:/e2e \

--- a/makefile
+++ b/makefile
@@ -135,29 +135,38 @@ build-lookout-ingester:
 build: build-server build-executor build-fakeexecutor build-armadactl build-load-tester build-binoculars build-lookout-ingester
 
 build-docker-server:
-	$(GO_CMD) $(gobuildlinux) -o ./bin/linux/server cmd/armada/main.go
-	docker build $(dockerFlags) -t armada -f ./build/armada/Dockerfile .
+	mkdir -p .build/server
+	$(GO_CMD) $(gobuildlinux) -o ./.build/server/server cmd/armada/main.go
+	cp -a ./config/armada ./.build/server/config
+	docker build $(dockerFlags) -t armada -f ./build/armada/Dockerfile ./.build/server/
 
 build-docker-executor:
-	$(GO_CMD) $(gobuildlinux) -o ./bin/linux/executor cmd/executor/main.go
-	docker build $(dockerFlags) -t armada-executor -f ./build/executor/Dockerfile .
+	mkdir -p .build/executor
+	$(GO_CMD) $(gobuildlinux) -o ./.build/executor/executor cmd/executor/main.go
+	cp -a ./config/executor ./.build/executor/config
+	docker build $(dockerFlags) -t armada-executor -f ./build/executor/Dockerfile ./.build/executor
 
 build-docker-armada-load-tester:
-	$(GO_CMD) $(gobuildlinux) -o ./bin/linux/armada-load-tester cmd/armada-load-tester/main.go
-	docker build $(dockerFlags) -t armada-load-tester -f ./build/armada-load-tester/Dockerfile .
+	mkdir -p .build/armada-load-tester
+	$(GO_CMD) $(gobuildlinux) -o ./.build/armada-load-tester/armada-load-tester cmd/armada-load-tester/main.go
+	docker build $(dockerFlags) -t armada-load-tester -f ./build/armada-load-tester/Dockerfile ./.build/armada-load-tester
 
 build-docker-armadactl:
-	$(GO_CMD) $(gobuildlinux) -o ./bin/linux/armadactl cmd/armadactl/main.go
-	docker build $(dockerFlags) -t armadactl -f ./build/armadactl/Dockerfile .
+	mkdir -p .build/armadactl
+	$(GO_CMD) $(gobuildlinux) -o ./.build/armadactl/armadactl cmd/armadactl/main.go
+	docker build $(dockerFlags) -t armadactl -f ./build/armadactl/Dockerfile ./.build/armadactl
 
 build-docker-fakeexecutor:
-	$(GO_CMD) $(gobuildlinux) -o ./bin/linux/fakeexecutor cmd/fakeexecutor/main.go
-	docker build $(dockerFlags) -t armada-fakeexecutor -f ./build/fakeexecutor/Dockerfile .
-
+	mkdir -p .build/fakeexecutor
+	$(GO_CMD) $(gobuildlinux) -o ./.build/fakeexecutor/fakeexecutor cmd/fakeexecutor/main.go
+	cp -a ./config/executor ./.build/fakeexecutor/config
+	docker build $(dockerFlags) -t armada-fakeexecutor -f ./build/fakeexecutor/Dockerfile ./.build/fakeexecutor
 
 build-docker-lookout-ingester:
-	$(GO_CMD) $(gobuildlinux) -o ./bin/linux/lookoutingester cmd/lookoutingester/main.go
-	docker build $(dockerFlags) -t armada-lookout-ingester -f ./build/lookoutingester/Dockerfile .
+	mkdir -p .build/lookoutingester
+	$(GO_CMD) $(gobuildlinux) -o ./.build/lookoutingester/lookoutingester cmd/lookoutingester/main.go
+	cp -a ./config/lookoutingester ./.build/lookoutingester/config
+	docker build $(dockerFlags) -t armada-lookout-ingester -f ./build/lookoutingester/Dockerfile ./.build/lookoutingester
 
 build-docker-lookout:
 	$(NODE_CMD) npm ci
@@ -170,8 +179,10 @@ build-docker-lookout:
 	docker build $(dockerFlags) -t armada-lookout -f ./build/lookout/Dockerfile .
 
 build-docker-binoculars:
-	$(GO_CMD) $(gobuildlinux) -o ./bin/linux/binoculars cmd/binoculars/main.go
-	docker build $(dockerFlags) -t armada-binoculars -f ./build/binoculars/Dockerfile .
+	mkdir -p .build/binoculars
+	$(GO_CMD) $(gobuildlinux) -o ./.build/binoculars/binoculars cmd/binoculars/main.go
+	cp -a ./config/binoculars ./.build/binoculars/config
+	docker build $(dockerFlags) -t armada-binoculars -f ./build/binoculars/Dockerfile ./.build/binoculars
 
 build-docker: build-docker-server build-docker-executor build-docker-armadactl build-docker-armada-load-tester build-docker-fakeexecutor build-docker-lookout build-docker-lookout-ingester build-docker-binoculars
 


### PR DESCRIPTION
- Test cancelling all jobs in a jobset
- Add EventsPrinter service, which logs all events on Pulsar
- Allow priority of 0 or higher, instead of 1 or higher
- Add missing jobRunId
- Enable partitioning for Pulsar topic used in tests
- Add more logging
- Disable topic auto-creation for e2e test topic
- Optimize Docker build
- Clean up Pulsar e2e tests