### PR TITLE
Set ingress host correctly

### DIFF
--- a/cmd/eventsprinter/cmd/root.go
+++ b/cmd/eventsprinter/cmd/root.go
@@ -35,7 +35,7 @@ func RootCmd() *cobra.Command {
 	cmd.PersistentFlags().String("url", "pulsar://localhost:6650", "URL to connect to Pulsar on.")
 	cmd.PersistentFlags().Bool("verbose", false, "Print full event sequences.")
 	cmd.PersistentFlags().String("subscription", "eventsprinter", "Subscription to connect to Pulsar on.")
-	cmd.PersistentFlags().String("topic", "persistent://armada/armada/jobset-events", "Pulsar topic to subscribe to.")
+	cmd.PersistentFlags().String("topic", "persistent://armada/armada/events", "Pulsar topic to subscribe to.")
 
 	return cmd
 }

--- a/config/lookoutingester/config.yaml
+++ b/config/lookoutingester/config.yaml
@@ -14,7 +14,7 @@ postgres:
 pulsar:
   enabled: true
   URL: "pulsar://localhost:6650"
-  jobsetEventsTopic: "jobset-events"
+  jobsetEventsTopic: "persistent://armada/armada/events"
 
 paralellism: 1
 subscriptionName: "lookout-ingester"

--- a/e2e/pulsar_test/pulsar_test.go
+++ b/e2e/pulsar_test/pulsar_test.go
@@ -33,7 +33,7 @@ import (
 
 // Pulsar configuration. Must be manually reconciled with changes to the test setup or Armada.
 const pulsarUrl = "pulsar://localhost:6650"
-const pulsarTopic = "persistent://armada/armada/jobset-events"
+const pulsarTopic = "persistent://armada/armada/events"
 const pulsarSubscription = "e2e-test"
 const armadaUrl = "localhost:50051"
 const armadaQueueName = "e2e-test-queue"

--- a/e2e/setup/pulsar/armada-config.yaml
+++ b/e2e/setup/pulsar/armada-config.yaml
@@ -1,7 +1,7 @@
 pulsar:
   enabled: true
   URL: "pulsar://pulsar:6650"
-  jobsetEventsTopic: "persistent://armada/armada/jobset-events"
+  jobsetEventsTopic: "persistent://armada/armada/events"
   redisFromPulsarSubscription: "RedisFromPulsar"
   pulsarFromPulsarSubscription: "PulsarFromPulsar"
   hostnameSuffix: "svc"

--- a/internal/armada/server.go
+++ b/internal/armada/server.go
@@ -28,7 +28,6 @@ import (
 	"github.com/G-Research/armada/internal/common/health"
 	"github.com/G-Research/armada/internal/common/task"
 	"github.com/G-Research/armada/internal/common/util"
-	executorconfig "github.com/G-Research/armada/internal/executor/configuration"
 	"github.com/G-Research/armada/internal/lookout/postgres"
 	"github.com/G-Research/armada/internal/pgkeyvalue"
 	"github.com/G-Research/armada/internal/pulsarutils"
@@ -193,11 +192,6 @@ func Serve(config *configuration.ArmadaConfig, healthChecks *health.MultiChecker
 			QueueRepository: queueRepository,
 			Permissions:     permissions,
 			SubmitServer:    submitServer,
-			IngressConfig: &executorconfig.IngressConfiguration{
-				HostnameSuffix: config.Pulsar.HostnameSuffix,
-				CertNameSuffix: config.Pulsar.CertNameSuffix,
-				Annotations:    config.Pulsar.Annotations,
-			},
 		}
 		submitServerToRegister = pulsarSubmitServer
 

--- a/internal/common/eventutil/eventutil.go
+++ b/internal/common/eventutil/eventutil.go
@@ -315,6 +315,10 @@ func K8sServicesIngressesFromApiJob(job *api.Job, ingressConfig *configuration.I
 		domain.AssociatedIngressesCount: fmt.Sprintf("%d", len(job.Ingress)),
 	})
 
+	// We use an empty ingress config here.
+	// The executor applies executor-specific information later.
+	ingressConfig = &configuration.IngressConfiguration{}
+
 	// Create k8s objects from the data embedded in the request.
 	// GenerateIngresses expects a job object and a pod because it looks into those for optimisations.
 	// For example, it deletes services/ingresses for which there are no corresponding ports exposed in the PodSpec.

--- a/internal/common/eventutil/eventutil.go
+++ b/internal/common/eventutil/eventutil.go
@@ -315,10 +315,6 @@ func K8sServicesIngressesFromApiJob(job *api.Job, ingressConfig *configuration.I
 		domain.AssociatedIngressesCount: fmt.Sprintf("%d", len(job.Ingress)),
 	})
 
-	// We use an empty ingress config here.
-	// The executor applies executor-specific information later.
-	ingressConfig = &configuration.IngressConfiguration{}
-
 	// Create k8s objects from the data embedded in the request.
 	// GenerateIngresses expects a job object and a pod because it looks into those for optimisations.
 	// For example, it deletes services/ingresses for which there are no corresponding ports exposed in the PodSpec.

--- a/makefile
+++ b/makefile
@@ -265,7 +265,7 @@ tests-e2e-setup: setup-cluster
 	docker run --rm -v ${PWD}:/go/src/armada -w /go/src/armada -e KUBECONFIG=/go/src/armada/.kube/config --network kind bitnami/kubectl:1.23 apply -f ./e2e/setup/namespace-with-anonymous-user.yaml
 
 	# Armada dependencies.
-	docker run -d --name pulsar -p 0.0.0.0:6650:6650 --network=kind apachepulsar/pulsar:2.9.1 bin/pulsar standalone
+	docker run -d --name pulsar -p 0.0.0.0:6650:6650 --network=kind apachepulsar/pulsar:2.9.2 bin/pulsar standalone
 	docker run -d --name nats --network=kind nats-streaming:0.24.5
 	docker run -d --name redis -p=6379:6379 --network=kind redis:6.2.6
 	docker run -d --name postgres --network=kind -p 5432:5432 -e POSTGRES_PASSWORD=psw postgres:14.2
@@ -274,7 +274,8 @@ tests-e2e-setup: setup-cluster
 	sleep 10 # pulsar-admin errors if the Pulsar server hasn't started up yet.
 	docker exec -it pulsar bin/pulsar-admin tenants create armada
 	docker exec -it pulsar bin/pulsar-admin namespaces create armada/armada
-	docker exec -it pulsar bin/pulsar-admin topics create-partitioned-topic persistent://armada/armada/jobset-events -p 100
+	docker exec -it pulsar bin/pulsar-admin topics delete-partitioned-topic persistent://armada/armada/events -f || true
+	docker exec -it pulsar bin/pulsar-admin topics create-partitioned-topic persistent://armada/armada/events -p 2
 
 	# Disable topic auto-creation to ensure an error is thrown on using the wrong topic
 	# (Pulsar automatically created the public tenant and default namespace).


### PR DESCRIPTION
Previously, the Pulsar submit API would set the hostname. This was a problem since each executor may require a different hostname suffix. With this PR, each executor is responsible for adding the suffix (and some other info).