### PR TITLE
Always ack messages, run services in errgroups

### DIFF
--- a/e2e/pulsar_test/pulsar_test.go
+++ b/e2e/pulsar_test/pulsar_test.go
@@ -635,7 +635,7 @@ func TestSubmitJobWithError(t *testing.T) {
 	err := withSetup(func(ctx context.Context, client api.SubmitClient, producer pulsar.Producer, consumer pulsar.Consumer) error {
 
 		// Submit a few jobs that fail after a few seconds
-		numJobs := 2
+		numJobs := 1
 		req := createJobSubmitRequestWithError(numJobs)
 		ctxWithTimeout, _ := context.WithTimeout(context.Background(), time.Second)
 		res, err := client.SubmitJobs(ctxWithTimeout, req)

--- a/go.mod
+++ b/go.mod
@@ -68,6 +68,7 @@ require (
 	github.com/yuin/gopher-lua v0.0.0-20190514113301-1cd887cd7036 // indirect
 	golang.org/x/net v0.0.0-20220121210141-e204ce36a2ba
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/tools v0.1.8
 	google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa
 	google.golang.org/grpc v1.43.0

--- a/go.sum
+++ b/go.sum
@@ -1277,6 +1277,7 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180821044426-4ea2f632f6e9/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/internal/armada/server.go
+++ b/internal/armada/server.go
@@ -3,7 +3,7 @@ package armada
 import (
 	"context"
 	"fmt"
-	"sync"
+	"net"
 	"time"
 
 	"github.com/apache/pulsar-client-go/pulsar"
@@ -12,7 +12,9 @@ import (
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/nats-io/jsm.go"
 	"github.com/nats-io/stan.go"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/G-Research/armada/internal/armada/cache"
 	"github.com/G-Research/armada/internal/armada/configuration"
@@ -34,17 +36,29 @@ import (
 	"github.com/G-Research/armada/pkg/api"
 )
 
-func Serve(config *configuration.ArmadaConfig, healthChecks *health.MultiChecker) (func(), *sync.WaitGroup) {
+func Serve(ctx context.Context, config *configuration.ArmadaConfig, healthChecks *health.MultiChecker) error {
 
-	// TODO Using an error group would be better.
-	// Since we want to shut down everything in a controlled manner in case of an irrecoverable error.
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
+	log.Info("Armada server starting")
+	defer log.Info("Armada server shutting down")
 
-	// TODO Return an error, don't panic.
+	// We call startupCompleteCheck.MarkComplete() when all services have been started.
+	startupCompleteCheck := health.NewStartupCompleteChecker()
+	healthChecks.Add(startupCompleteCheck)
+
+	// Run all services within an errgroup to propagate errors between services.
+	// Defer cancelling the parent context to ensure the errgroup is cancelled on return.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	g, ctx := errgroup.WithContext(ctx)
+
+	// List of services to run concurrently.
+	// Because we want to start services only once all input validation has been completed,
+	// we add all services to a slice and start them together at the end of this function.
+	var services []func() error
+
 	err := validateArmadaConfig(config)
 	if err != nil {
-		panic(fmt.Errorf("configuration validation error: %v", err))
+		return err
 	}
 
 	// We support multiple simultaneous authentication services (e.g., username/password  OpenId).
@@ -53,12 +67,36 @@ func Serve(config *configuration.ArmadaConfig, healthChecks *health.MultiChecker
 	authServices := auth.ConfigureAuth(config.Auth)
 	grpcServer := grpcCommon.CreateGrpcServer(authServices)
 
-	// Allows for registering functions to be run periodically in the background
-	taskManager := task.NewBackgroundTaskManager(metrics.MetricPrefix)
+	// Shut down grpcServer if the context is cancelled.
+	// Give the server 5 seconds to shut down gracefully.
+	services = append(services, func() error {
+		<-ctx.Done()
+		go func() {
+			time.Sleep(5 * time.Second)
+			grpcServer.Stop()
+		}()
+		grpcServer.GracefulStop()
+		return nil
+	})
 
-	// TODO Redis setup code. Move into a separate function.
+	// Allows for registering functions to be run periodically in the background.
+	taskManager := task.NewBackgroundTaskManager(metrics.MetricPrefix)
+	defer taskManager.StopAll(time.Second * 2)
+
+	// Setup Redis
 	db := createRedisClient(&config.Redis)
+	defer func() {
+		if err := db.Close(); err != nil {
+			log.WithError(err).Error("faled to close Redis client")
+		}
+	}()
+
 	eventsDb := createRedisClient(&config.EventsRedis)
+	defer func() {
+		if err := db.Close(); err != nil {
+			log.WithError(err).Error("faled to close events Redis client")
+		}
+	}()
 
 	jobRepository := repository.NewRedisJobRepository(db, config.DatabaseRetention)
 	usageRepository := repository.NewRedisUsageRepository(db)
@@ -76,38 +114,38 @@ func Serve(config *configuration.ArmadaConfig, healthChecks *health.MultiChecker
 
 	// TODO It looks like multiple backends can be provided.
 	// We should ensure that only 1 system is provided.
-	// TODO Return an error, don't panic.
 	if len(config.EventsNats.Servers) > 0 {
 		stanClient, err := eventstream.NewStanClientConnection(
 			config.EventsNats.ClusterID,
 			"armada-server-"+util.NewULID(),
 			config.EventsNats.Servers)
 		if err != nil {
-			panic(err)
+			return err
 		}
 
 		eventStream = eventstream.NewStanEventStream(
 			config.EventsNats.Subject,
 			stanClient,
 			stan.SetManualAckMode(),
-			stan.StartWithLastReceived())
-
+			stan.StartWithLastReceived(),
+		)
+		defer eventStream.Close() // Closes the stanClient
 		healthChecks.Add(stanClient)
 	} else if len(config.EventsJetstream.Servers) > 0 {
 		stream, err := eventstream.NewJetstreamEventStream(
 			&config.EventsJetstream,
 			jsm.SamplePercent(100),
-			jsm.StartWithLastReceived())
+			jsm.StartWithLastReceived(),
+		)
 		if err != nil {
-			panic(err)
+			return err
 		}
+		defer stream.Close()
 		eventStream = stream
 
 		healthChecks.Add(stream)
 	}
 
-	// TODO: move this to task manager
-	eventstreamTeardown := func() {}
 	var eventProcessor *processor.RedisEventProcessor
 	if eventStream != nil {
 		streamEventStore = processor.NewEventStore(eventStream)
@@ -121,9 +159,7 @@ func Serve(config *configuration.ArmadaConfig, healthChecks *health.MultiChecker
 		jobStatusProcessor := processor.NewEventJobStatusProcessor(config.Events.JobStatusQueue, jobRepository, eventStream, jobStatusBatcher)
 		jobStatusProcessor.Start()
 
-		// TODO Teardown functions should return an error that can be logged/whatever by the caller.
-		// Not use log internally.
-		eventstreamTeardown = func() {
+		defer func() {
 			err := eventRepoBatcher.Stop()
 			if err != nil {
 				log.Errorf("failed to flush event processor buffer for redis")
@@ -136,7 +172,7 @@ func Serve(config *configuration.ArmadaConfig, healthChecks *health.MultiChecker
 			if err != nil {
 				log.Errorf("failed to close event stream connection: %v", err)
 			}
-		}
+		}()
 	} else {
 		eventStore = redisEventRepository
 	}
@@ -162,8 +198,6 @@ func Serve(config *configuration.ArmadaConfig, healthChecks *health.MultiChecker
 
 	// If Pulsar is enabled, use the Pulsar submit endpoints.
 	// Store a list of all Pulsar components to use during cleanup later.
-	var pulsarComponents []interface{ Close() }
-	pulsarContext, pulsarCancel := context.WithCancel(context.Background())
 	if config.Pulsar.Enabled {
 		serverId := uuid.New()
 
@@ -171,17 +205,17 @@ func Serve(config *configuration.ArmadaConfig, healthChecks *health.MultiChecker
 		log.Info("Pulsar config provided; using Pulsar submit endpoints.")
 		pulsarClient, err := pulsarutils.NewPulsarClient(&config.Pulsar)
 		if err != nil {
-			panic(err)
+			return err
 		}
-		pulsarComponents = append(pulsarComponents, pulsarClient)
+		defer pulsarClient.Close()
 
 		compressionType, err := pulsarutils.ParsePulsarCompressionType(config.Pulsar.CompressionType)
 		if err != nil {
-			panic(err)
+			return err
 		}
 		compressionLevel, err := pulsarutils.ParsePulsarCompressionLevel(config.Pulsar.CompressionLevel)
 		if err != nil {
-			panic(err)
+			return err
 		}
 		producer, err := pulsarClient.CreateProducer(pulsar.ProducerOptions{
 			Name:             fmt.Sprintf("armada-server-%s", serverId),
@@ -190,9 +224,10 @@ func Serve(config *configuration.ArmadaConfig, healthChecks *health.MultiChecker
 			Topic:            config.Pulsar.JobsetEventsTopic,
 		})
 		if err != nil {
-			panic(err)
+			return errors.WithStack(err)
 		}
-		pulsarComponents = append(pulsarComponents, producer)
+		defer producer.Close()
+
 		pulsarSubmitServer := &server.PulsarSubmitServer{
 			Producer:        producer,
 			QueueRepository: queueRepository,
@@ -206,16 +241,20 @@ func Serve(config *configuration.ArmadaConfig, healthChecks *health.MultiChecker
 			log.Info("Pulsar submit API deduplication enabled")
 			db, err := postgres.OpenPgxPool(config.Postgres)
 			if err != nil {
-				panic(err)
+				return err
 			}
+			defer db.Close()
+
 			store, err := pgkeyvalue.New(db, 1000000, config.Pulsar.DedupTable)
 			if err != nil {
-				panic(err)
+				return err
 			}
 			pulsarSubmitServer.KVStore = store
 
 			// Automatically clean up keys after two weeks.
-			store.PeriodicCleanup(pulsarContext, time.Hour, 14*24*time.Hour)
+			services = append(services, func() error {
+				return store.PeriodicCleanup(ctx, time.Hour, 14*24*time.Hour)
+			})
 		} else {
 			log.Info("Pulsar submit API deduplication disabled")
 		}
@@ -233,15 +272,17 @@ func Serve(config *configuration.ArmadaConfig, healthChecks *health.MultiChecker
 			Type:             pulsar.KeyShared,
 		})
 		if err != nil {
-			panic(err)
+			return errors.WithStack(err)
 		}
-		pulsarComponents = append(pulsarComponents, consumer)
+		defer consumer.Close()
 
 		submitFromLog := server.SubmitFromLog{
 			Consumer:     consumer,
 			SubmitServer: submitServer,
 		}
-		go submitFromLog.Run(pulsarContext)
+		services = append(services, func() error {
+			return submitFromLog.Run(ctx)
+		})
 
 		// Service that reads from Pulsar and submits messages back into Pulsar.
 		// E.g., needed to automatically publish JobSucceeded after a JobRunSucceeded.
@@ -251,9 +292,9 @@ func Serve(config *configuration.ArmadaConfig, healthChecks *health.MultiChecker
 			Type:             pulsar.KeyShared,
 		})
 		if err != nil {
-			panic(err)
+			return errors.WithStack(err)
 		}
-		pulsarComponents = append(pulsarComponents, consumer)
+		defer consumer.Close()
 
 		// Create a new producer for this service.
 		producer, err = pulsarClient.CreateProducer(pulsar.ProducerOptions{
@@ -263,15 +304,17 @@ func Serve(config *configuration.ArmadaConfig, healthChecks *health.MultiChecker
 			Topic:            config.Pulsar.JobsetEventsTopic,
 		})
 		if err != nil {
-			panic(err)
+			return errors.WithStack(err)
 		}
-		pulsarComponents = append(pulsarComponents, producer)
+		defer producer.Close()
 
 		pulsarFromPulsar := server.PulsarFromPulsar{
 			Consumer: consumer,
 			Producer: producer,
 		}
-		go pulsarFromPulsar.Run(pulsarContext)
+		services = append(services, func() error {
+			return pulsarFromPulsar.Run(ctx)
+		})
 
 		// Service that reads from Pulsar and logs events.
 		if config.Pulsar.EventsPrinter {
@@ -280,7 +323,9 @@ func Serve(config *configuration.ArmadaConfig, healthChecks *health.MultiChecker
 				Topic:            config.Pulsar.JobsetEventsTopic,
 				SubscriptionName: config.Pulsar.EventsPrinterSubscription,
 			}
-			go eventsPrinter.Run(pulsarContext)
+			services = append(services, func() error {
+				return eventsPrinter.Run(ctx)
+			})
 		}
 	} else {
 		log.Info("No Pulsar config provided; submitting directly to Redis and Nats.")
@@ -302,23 +347,25 @@ func Serve(config *configuration.ArmadaConfig, healthChecks *health.MultiChecker
 
 	grpc_prometheus.Register(grpcServer)
 
-	// TODO grpcCommon.Listen is supposed to call wg.Done() internally.
-	// Except, that it calls log.Fatalf first, so wg.Done() is never called.
-	// There's no clean way for grpcCommon.Listen to return an error.
-	grpcCommon.Listen(config.GrpcPort, grpcServer, wg)
-
-	teardown := func() {
-		pulsarCancel()
-		// Reverse order to close the Pulsar client last
-		// (i.e., the same order as if we had used defer).
-		for i := len(pulsarComponents) - 1; i >= 0; i-- {
-			pulsarComponents[i].Close()
-		}
-		eventstreamTeardown()
-		taskManager.StopAll(time.Second * 2)
-		grpcServer.GracefulStop()
+	// Cancel the errgroup if grpcServer.Serve returns an error.
+	log.Infof("Armada gRPC server listening on %d", config.GrpcPort)
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", config.GrpcPort))
+	if err != nil {
+		return errors.WithStack(err)
 	}
-	return teardown, wg
+	services = append(services, func() error {
+		return grpcServer.Serve(lis)
+	})
+
+	// Start all services and wait for the context to be cancelled,
+	// which if the parent context is cancelled or if any of the services returns an error.
+	// We start all services at the end of the function to ensure all services are ready.
+	for _, service := range services {
+		g.Go(service)
+	}
+
+	startupCompleteCheck.MarkComplete()
+	return g.Wait()
 }
 
 func createRedisClient(config *redis.UniversalOptions) redis.UniversalClient {
@@ -328,7 +375,7 @@ func createRedisClient(config *redis.UniversalOptions) redis.UniversalClient {
 // TODO Is this all validation that needs to be done?
 func validateArmadaConfig(config *configuration.ArmadaConfig) error {
 	if config.CancelJobsBatchSize <= 0 {
-		return fmt.Errorf("cancel jobs batch should be greater than 0: is %d", config.CancelJobsBatchSize)
+		return errors.WithStack(fmt.Errorf("cancel jobs batch should be greater than 0: is %d", config.CancelJobsBatchSize))
 	}
 	return nil
 }

--- a/internal/armada/server/eventsprinter.go
+++ b/internal/armada/server/eventsprinter.go
@@ -80,19 +80,13 @@ func (srv *EventsPrinter) Run(ctx context.Context) error {
 				logging.WithStacktrace(log, err).Warnf("receiving from Pulsar failed")
 				break
 			}
-
 			consumer.Ack(msg)
-
-			// We're only interested in control messages.
-			if !armadaevents.IsControlMessage(msg) {
-				continue
-			}
 
 			sequence := &armadaevents.EventSequence{}
 			err = proto.Unmarshal(msg.Payload(), sequence)
 			if err != nil {
 				logging.WithStacktrace(log, err).Warnf("unmarshalling Pulsar message failed")
-				continue
+				break
 			}
 
 			messageLogger := log.WithFields(logrus.Fields{
@@ -111,7 +105,6 @@ func (srv *EventsPrinter) Run(ctx context.Context) error {
 			})
 
 			s := "Sequence: " + eventutil.ShortSequenceString(sequence)
-
 			messageLogger.Info(s)
 		}
 	}

--- a/internal/armada/server/eventsprinter.go
+++ b/internal/armada/server/eventsprinter.go
@@ -59,6 +59,7 @@ func (srv *EventsPrinter) Run(ctx context.Context) {
 	if err != nil {
 		panic(err)
 	}
+	defer consumer.Close()
 
 	// Run until ctx is cancelled.
 	for {

--- a/internal/armada/server/eventsprinter.go
+++ b/internal/armada/server/eventsprinter.go
@@ -28,7 +28,7 @@ type EventsPrinter struct {
 }
 
 // Run the service that reads from Pulsar and updates Armada until the provided context is cancelled.
-func (srv *EventsPrinter) Run(ctx context.Context) {
+func (srv *EventsPrinter) Run(ctx context.Context) error {
 
 	// Get the configured logger, or the standard logger if none is provided.
 	var log *logrus.Entry
@@ -67,7 +67,7 @@ func (srv *EventsPrinter) Run(ctx context.Context) {
 		// Exit if the context has been cancelled. Otherwise, get a message from Pulsar.
 		select {
 		case <-ctx.Done():
-			return
+			return nil
 		default:
 
 			// Get a message from Pulsar, which consists of a sequence of events (i.e., state transitions).

--- a/internal/armada/server/log_to_pulsar.go
+++ b/internal/armada/server/log_to_pulsar.go
@@ -101,11 +101,6 @@ func (srv *PulsarFromPulsar) Run(ctx context.Context) error {
 				continue
 			}
 
-			// We're only interested in control messages.
-			if !armadaevents.IsControlMessage(msg) {
-				continue
-			}
-
 			lastMessageId = msg.ID()
 			lastPublishTime = msg.PublishTime()
 			numReceived++

--- a/internal/armada/server/log_to_pulsar.go
+++ b/internal/armada/server/log_to_pulsar.go
@@ -28,7 +28,7 @@ type PulsarFromPulsar struct {
 }
 
 // Run the service that reads from Pulsar and updates Armada until the provided context is cancelled.
-func (srv *PulsarFromPulsar) Run(ctx context.Context) {
+func (srv *PulsarFromPulsar) Run(ctx context.Context) error {
 
 	// Get the configured logger, or the standard logger if none is provided.
 	var log *logrus.Entry
@@ -83,7 +83,7 @@ func (srv *PulsarFromPulsar) Run(ctx context.Context) {
 		// Exit if the context has been cancelled. Otherwise, get a message from Pulsar.
 		select {
 		case <-ctx.Done():
-			return
+			return nil
 		default:
 
 			// Get a message from Pulsar, which consists of a sequence of events (i.e., state transitions).

--- a/internal/armada/server/submit_from_log.go
+++ b/internal/armada/server/submit_from_log.go
@@ -142,10 +142,9 @@ func (srv *SubmitFromLog) Run(ctx context.Context) {
 			}
 
 			messageLogger.WithField("numEvents", len(sequence.Events)).Info("processing sequence")
-			ok = srv.ProcessSequence(ctxWithLogger, sequence)
-			if ok {
-				srv.Consumer.Ack(msg)
-			}
+			// TODO: Improve retry logic.
+			srv.ProcessSequence(ctxWithLogger, sequence)
+			srv.Consumer.Ack(msg)
 		}
 	}
 }

--- a/internal/armada/server/submit_from_log.go
+++ b/internal/armada/server/submit_from_log.go
@@ -108,7 +108,7 @@ func (srv *SubmitFromLog) Run(ctx context.Context) {
 			if err != nil {
 				logging.WithStacktrace(log, err).WithField("lastMessageId", lastMessageId).Warnf("Pulsar receive failed; backing off")
 				time.Sleep(100 * time.Millisecond)
-				continue
+				break
 			}
 
 			lastMessageId = msg.ID()

--- a/internal/armada/server/submit_from_log.go
+++ b/internal/armada/server/submit_from_log.go
@@ -131,6 +131,7 @@ func (srv *SubmitFromLog) Run(ctx context.Context) {
 			// Unmarshal and validate the message.
 			sequence, err := eventutil.UnmarshalEventSequence(ctxWithLogger, msg.Payload())
 			if err != nil {
+				srv.Consumer.Ack(msg)
 				logging.WithStacktrace(messageLogger, err).Warnf("processing message failed; ignoring")
 				numErrored++
 				break

--- a/internal/armada/server/submit_from_log.go
+++ b/internal/armada/server/submit_from_log.go
@@ -38,7 +38,7 @@ type SubmitFromLog struct {
 }
 
 // Run the service that reads from Pulsar and updates Armada until the provided context is cancelled.
-func (srv *SubmitFromLog) Run(ctx context.Context) {
+func (srv *SubmitFromLog) Run(ctx context.Context) error {
 
 	// Get the configured logger, or the standard logger if none is provided.
 	var log *logrus.Entry
@@ -93,7 +93,7 @@ func (srv *SubmitFromLog) Run(ctx context.Context) {
 		// Exit if the context has been cancelled. Otherwise, get a message from Pulsar.
 		select {
 		case <-ctx.Done():
-			return
+			return nil
 		default:
 
 			// Get a message from Pulsar, which consists of a sequence of events (i.e., state transitions).

--- a/internal/armada/server/submit_from_log.go
+++ b/internal/armada/server/submit_from_log.go
@@ -111,11 +111,6 @@ func (srv *SubmitFromLog) Run(ctx context.Context) {
 				continue
 			}
 
-			// We're only interested in control messages.
-			if !armadaevents.IsControlMessage(msg) {
-				continue
-			}
-
 			lastMessageId = msg.ID()
 			lastPublishTime = msg.PublishTime()
 			numReceived++

--- a/internal/armada/server/submit_from_log.go
+++ b/internal/armada/server/submit_from_log.go
@@ -133,7 +133,7 @@ func (srv *SubmitFromLog) Run(ctx context.Context) {
 			if err != nil {
 				logging.WithStacktrace(messageLogger, err).Warnf("processing message failed; ignoring")
 				numErrored++
-				continue
+				break
 			}
 
 			messageLogger.WithField("numEvents", len(sequence.Events)).Info("processing sequence")

--- a/internal/common/health/multi_checker.go
+++ b/internal/common/health/multi_checker.go
@@ -2,6 +2,7 @@ package health
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 )
@@ -24,6 +25,10 @@ func NewMultiChecker(checkers ...Checker) *MultiChecker {
 func (mc *MultiChecker) Check() error {
 	mc.mu.Lock()
 	defer mc.mu.Unlock()
+
+	if len(mc.checkers) == 0 {
+		return fmt.Errorf("no checkers registered")
+	}
 
 	errorStrings := []string{}
 	for _, checker := range mc.checkers {

--- a/internal/common/health/multi_checker.go
+++ b/internal/common/health/multi_checker.go
@@ -3,6 +3,7 @@ package health
 import (
 	"errors"
 	"strings"
+	"sync"
 )
 
 // MultiChecker combines multiple Checker instances.
@@ -10,6 +11,7 @@ import (
 // and returns a new error created by joining any errors returned from those calls,
 // or nil if no errors are found.
 type MultiChecker struct {
+	mu       sync.Mutex
 	checkers []Checker
 }
 
@@ -20,6 +22,9 @@ func NewMultiChecker(checkers ...Checker) *MultiChecker {
 }
 
 func (mc *MultiChecker) Check() error {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+
 	errorStrings := []string{}
 	for _, checker := range mc.checkers {
 		err := checker.Check()
@@ -36,5 +41,7 @@ func (mc *MultiChecker) Check() error {
 }
 
 func (mc *MultiChecker) Add(checker Checker) {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
 	mc.checkers = append(mc.checkers, checker)
 }

--- a/internal/common/health/multi_checker_test.go
+++ b/internal/common/health/multi_checker_test.go
@@ -7,10 +7,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMultiChecker_WhenNoChecksAdded_CheckPasses(t *testing.T) {
+func TestMultiChecker_WhenNoChecksAdded_CheckFails(t *testing.T) {
 	mc := NewMultiChecker()
 	err := mc.Check()
-	assert.Nil(t, err)
+	assert.Error(t, err)
 }
 
 func TestMultiChecker_TwoChecksPass_CheckPasses(t *testing.T) {

--- a/internal/pgkeyvalue/pgkeyvalue.go
+++ b/internal/pgkeyvalue/pgkeyvalue.go
@@ -28,6 +28,7 @@ type PGKeyValueStore struct {
 	db *pgxpool.Pool
 	// Name of the postgres table used for storage.
 	tableName string
+	Logger    *logrus.Logger
 }
 
 func New(db *pgxpool.Pool, cacheSize int, tableName string) (*PGKeyValueStore, error) {
@@ -176,7 +177,13 @@ func (c *PGKeyValueStore) Cleanup(ctx context.Context, lifespan time.Duration) e
 // PeriodicCleanup starts a goroutine that automatically runs the cleanup job
 // every interval until the provided context is cancelled.
 func (c *PGKeyValueStore) PeriodicCleanup(ctx context.Context, interval time.Duration, lifespan time.Duration) error {
-	log := logrus.StandardLogger().WithField("service", "PGKeyValueStoreCleanup")
+	var log *logrus.Entry
+	if c.Logger == nil {
+		log = logrus.StandardLogger().WithField("service", "PGKeyValueStoreCleanup")
+	} else {
+		log = c.Logger.WithField("service", "PGKeyValueStoreCleanup")
+	}
+
 	log.Info("service started")
 	ticker := time.NewTicker(interval)
 	for {

--- a/internal/pgkeyvalue/pgkeyvalue_test.go
+++ b/internal/pgkeyvalue/pgkeyvalue_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/G-Research/armada/internal/common/armadaerrors"
@@ -114,6 +115,9 @@ func TestCleanup(t *testing.T) {
 			t.FailNow()
 		}
 
+		// Set an empty logger to avoid annoying "cleanup succeeded" messages
+		store.Logger = &logrus.Logger{}
+
 		// Adding a key for the first time should insert into both the local cache and postgres,
 		// and return false (since the key didn't already exist).
 		expected := []byte{0, 1, 2}
@@ -164,7 +168,7 @@ func TestCleanup(t *testing.T) {
 		// Then try adding baz twice more to make sure it gets cleaned up both times.
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		store.PeriodicCleanup(ctx, time.Microsecond, time.Microsecond)
+		go store.PeriodicCleanup(ctx, time.Microsecond, time.Microsecond)
 
 		time.Sleep(100 * time.Millisecond)
 		store.cache.Purge()


### PR DESCRIPTION
This pr updates Pulsar subscribers to always ack messages.

It also updates the server to run concurrent services in errgroups.
This allows errors to be propagated between services so that all services can be shut down gracefully in case of an error.
Further, if any service fails, we can shut down the app so that it can be restarted by k8s.