### PR TITLE
Revert "Improve Watch in dotnet client to handle network failures better"

### DIFF
--- a/client/DotNet/Armada.Client.Test/Tests.cs
+++ b/client/DotNet/Armada.Client.Test/Tests.cs
@@ -103,7 +103,7 @@ namespace GResearch.Armada.Client.Test
                 {
                     new V1Container
                     {
-                        Name = "container1",
+                        Name = "Container1",
                         Image = "index.docker.io/library/ubuntu:latest",
                         Args = new[] {"sleep", "10s"},
                         SecurityContext = new V1SecurityContext {RunAsUser = 1000},


### PR DESCRIPTION
Reverts G-Research/armada#953

users are seeing the folowing after this commit:
```
System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (Unable to read data from the transport connection: A blocking operation was interrupted by a call to WSACancelBlockingCall..)
```