### PR TITLE
Report unschedulable reason to user

### DIFF
--- a/internal/armada/repository/errors.go
+++ b/internal/armada/repository/errors.go
@@ -1,0 +1,53 @@
+package repository
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ErrNotFound should be returned by all repository functions whenever one or more
+// resources can't be found.
+//
+// When constructing errors of this type, you need to prepend the resource type.
+// For example, if a queue with name "foo" can't be found, create the error with
+// &ErrNotFound{ResourceNames: []string{"queue \"foo\""}}
+// instead of &ErrNotFound{ResourceNames: []string{"\"foo\""}}.
+// Doing so makes it unambiguous to the user which resource is referred to.
+//
+// If several of the same resource are missing, add those as a single resource name, e.g.,
+// &ErrNotFound{ResourceNames: []string{"jobs [\"1\", \"2\", \"3\"] \"foo\""}}.
+//
+// This error produces error messages of the form
+// "could not find queue "foo"", or, if several resources are missing,
+// "could not find any of [queue "foo", job "1234"]".
+type ErrNotFound struct {
+	ResourceNames []string
+}
+
+func (err *ErrNotFound) Error() string {
+	if len(err.ResourceNames) == 0 {
+		return "could not find <UNKNOWN>"
+	} else if len(err.ResourceNames) == 1 {
+		return fmt.Sprintf("could not find %q", err.ResourceNames[0])
+	} else {
+		return fmt.Sprintf("could not find any of [%s]", strings.Join(err.ResourceNames, ", "))
+	}
+}
+
+// ErrNotFound should be returned by all repository functions whenever one or more
+// resources to be created already exists.
+//
+// This error works, and should be constructed, in the same was as ErrNotFound.
+type ErrAlreadyExists struct {
+	ResourceNames []string
+}
+
+func (err *ErrAlreadyExists) Error() string {
+	if len(err.ResourceNames) == 0 {
+		return "resource <UNKNOWN> already exists"
+	} else if len(err.ResourceNames) == 1 {
+		return fmt.Sprintf("%q already exists", err.ResourceNames[0])
+	} else {
+		return fmt.Sprintf("the following already exists [%s]", strings.Join(err.ResourceNames, ", "))
+	}
+}

--- a/internal/armada/scheduling/lease.go
+++ b/internal/armada/scheduling/lease.go
@@ -275,7 +275,8 @@ func (c *leaseContext) leaseJobs(queue *api.Queue, slice common.ComputeResources
 			remainder = slice.DeepCopy()
 			remainder.Sub(requirement)
 			if isLargeEnough(job, c.minimumJobSize) && remainder.IsValid() && candidatesLimit.IsWithinLimit(job) {
-				newlyConsumed, ok := matchAnyNodeTypeAllocation(job, c.nodeResources, consumedNodeResources)
+				// TODO: Log error.
+				newlyConsumed, ok, _ := matchAnyNodeTypeAllocation(job, c.nodeResources, consumedNodeResources)
 				if ok {
 					slice = remainder
 					candidates = append(candidates, job)

--- a/internal/armada/scheduling/node_matching.go
+++ b/internal/armada/scheduling/node_matching.go
@@ -1,6 +1,7 @@
 package scheduling
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 	"time"
@@ -9,7 +10,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/G-Research/armada/internal/common"
+	"github.com/G-Research/armada/internal/common/armadaerrors"
 	"github.com/G-Research/armada/pkg/api"
+	"github.com/pkg/errors"
 )
 
 func CreateClusterSchedulingInfoReport(leaseRequest *api.LeaseRequest, nodeAllocations []*nodeTypeAllocation) *api.ClusterSchedulingInfoReport {
@@ -30,26 +33,34 @@ func extractNodeTypes(allocations []*nodeTypeAllocation) []*api.NodeType {
 	return result
 }
 
-func MatchSchedulingRequirements(job *api.Job, schedulingInfo *api.ClusterSchedulingInfoReport) bool {
-	if !isLargeEnough(job, schedulingInfo.MinimumJobSize) {
-		return false
-	}
-	for _, podSpec := range job.GetAllPodSpecs() {
-		// TODO: make sure there are enough nodes available for all the job pods
-		if !matchAnyNodeType(podSpec, schedulingInfo.NodeTypes) {
-			return false
+// MatchSchedulingRequirementsOnAnyCluster returns true if the provided job can be scheduled.
+// If returning false, the reason for not being able to schedule the pod is indicated by the returned error,
+// which is of type *armadaerrors.ErrPodUnschedulable.
+func MatchSchedulingRequirementsOnAnyCluster(job *api.Job, allClusterSchedulingInfos map[string]*api.ClusterSchedulingInfoReport) (bool, error) {
+	var errs []error
+	for _, schedulingInfo := range allClusterSchedulingInfos {
+		if ok, err := MatchSchedulingRequirements(job, schedulingInfo); ok {
+			return true, nil
+		} else {
+			errs = append(errs, err)
 		}
 	}
-	return true
+	return false, armadaerrors.NewCombinedErrPodUnschedulable(errs...)
 }
 
-func MatchSchedulingRequirementsOnAnyCluster(job *api.Job, allClusterSchedulingInfos map[string]*api.ClusterSchedulingInfoReport) bool {
-	for _, schedulingInfo := range allClusterSchedulingInfos {
-		if MatchSchedulingRequirements(job, schedulingInfo) {
-			return true
+func MatchSchedulingRequirements(job *api.Job, schedulingInfo *api.ClusterSchedulingInfoReport) (bool, error) {
+	if !isLargeEnough(job, schedulingInfo.MinimumJobSize) {
+		err := &armadaerrors.ErrPodUnschedulable{}
+		err = err.Add(fmt.Sprintf("pod resource requests too low; the minimum allowed is %v", schedulingInfo.MinimumJobSize), len(schedulingInfo.NodeTypes))
+		return false, err
+	}
+	for i, podSpec := range job.GetAllPodSpecs() {
+		// TODO: make sure there are enough nodes available for all the job pods.
+		if ok, err := matchAnyNodeType(podSpec, schedulingInfo.NodeTypes); !ok {
+			return false, errors.WithMessagef(err, "%d-th job can't be scheduled", i)
 		}
 	}
-	return false
+	return true, nil
 }
 
 func isLargeEnough(job *api.Job, minimumJobSize common.ComputeResources) bool {
@@ -58,59 +69,69 @@ func isLargeEnough(job *api.Job, minimumJobSize common.ComputeResources) bool {
 	return resourceRequest.IsValid()
 }
 
-func matchAnyNodeType(podSpec *v1.PodSpec, nodeTypes []*api.NodeType) bool {
-
+// matchAnyNodeType returns true if the pod can be scheduled on at least one node type.
+// If not, an error is returned indicating why the pod can't be scheduled.
+// The error is of type *armadaerrors.ErrPodUnschedulable.
+func matchAnyNodeType(podSpec *v1.PodSpec, nodeTypes []*api.NodeType) (bool, error) {
+	var result *armadaerrors.ErrPodUnschedulable
 	podMatchingContext := NewPodMatchingContext(podSpec)
-
 	for _, nodeType := range nodeTypes {
 		nodeResources := common.ComputeResources(nodeType.AllocatableResources).AsFloat()
-
-		if podMatchingContext.Matches(nodeType, nodeResources) {
-			return true
+		if ok, err := podMatchingContext.Matches(nodeType, nodeResources); ok {
+			return true, nil
+		} else if err != nil {
+			result = result.Add(err.Error(), 1)
+		} else {
+			result = result.Add("unknown reason", 1)
 		}
 	}
-	return false
+	return false, result
 }
 
 func matchAnyNodeTypeAllocation(job *api.Job,
 	nodeAllocations []*nodeTypeAllocation,
-	alreadyConsumed nodeTypeUsedResources) (nodeTypeUsedResources, bool) {
+	alreadyConsumed nodeTypeUsedResources) (nodeTypeUsedResources, bool, error) {
 
 	newlyConsumed := nodeTypeUsedResources{}
 
 	for _, podSpec := range job.GetAllPodSpecs() {
 
-		nodeType, ok := matchAnyNodeTypePodAllocation(podSpec, nodeAllocations, alreadyConsumed, newlyConsumed)
+		nodeType, ok, err := matchAnyNodeTypePodAllocation(podSpec, nodeAllocations, alreadyConsumed, newlyConsumed)
 
 		if !ok {
-			return nodeTypeUsedResources{}, false
+			return nodeTypeUsedResources{}, false, err
 		}
 		resourceRequest := common.TotalPodResourceRequest(podSpec).AsFloat()
 		resourceRequest.Add(newlyConsumed[nodeType])
 		newlyConsumed[nodeType] = resourceRequest
 	}
-	return newlyConsumed, true
+	return newlyConsumed, true, nil
 }
 
 func matchAnyNodeTypePodAllocation(
 	podSpec *v1.PodSpec,
 	nodeAllocations []*nodeTypeAllocation,
 	alreadyConsumed nodeTypeUsedResources,
-	newlyConsumed nodeTypeUsedResources) (*nodeTypeAllocation, bool) {
+	newlyConsumed nodeTypeUsedResources) (*nodeTypeAllocation, bool, error) {
 
 	podMatchingContext := NewPodMatchingContext(podSpec)
 
+	var result *armadaerrors.ErrPodUnschedulable
 	for _, node := range nodeAllocations {
 		available := node.availableResources.DeepCopy()
 		available.Sub(alreadyConsumed[node])
 		available.Sub(newlyConsumed[node])
 		available.LimitWith(common.ComputeResources(node.nodeType.AllocatableResources).AsFloat())
 
-		if podMatchingContext.Matches(&node.nodeType, available) {
-			return node, true
+		if ok, err := podMatchingContext.Matches(&node.nodeType, available); ok {
+			return node, true, nil
+		} else if err != nil {
+			result = result.Add(err.Error(), 1)
+		} else {
+			result = result.Add("unknown reason", 1)
 		}
 	}
-	return nil, false
+	return nil, false, result
 }
 
 func AggregateNodeTypeAllocations(nodes []api.NodeInfo) []*nodeTypeAllocation {

--- a/internal/armada/scheduling/node_matching_test.go
+++ b/internal/armada/scheduling/node_matching_test.go
@@ -37,20 +37,6 @@ func Test_MatchSchedulingRequirements_labels(t *testing.T) {
 	}})
 	assert.True(t, ok)
 	assert.NoError(t, err)
-
-	// assert.False(t, MatchSchedulingRequirements(job, &api.ClusterSchedulingInfoReport{}))
-	// assert.False(t, MatchSchedulingRequirements(job, &api.ClusterSchedulingInfoReport{NodeTypes: []*api.NodeType{
-	// 	{Labels: map[string]string{"armada/region": "eu"}},
-	// 	{Labels: map[string]string{"armada/zone": "2"}},
-	// }}))
-	// assert.False(t, MatchSchedulingRequirements(job, &api.ClusterSchedulingInfoReport{NodeTypes: []*api.NodeType{
-	// 	{Labels: map[string]string{"armada/region": "eu", "armada/zone": "2"}},
-	// }}))
-
-	// assert.True(t, MatchSchedulingRequirements(job, &api.ClusterSchedulingInfoReport{NodeTypes: []*api.NodeType{
-	// 	{Labels: map[string]string{"x": "y"}},
-	// 	{Labels: map[string]string{"armada/region": "eu", "armada/zone": "1", "x": "y"}},
-	// }}))
 }
 
 func Test_MatchSchedulingRequirements_isAbleToFitOnAvailableNodes(t *testing.T) {
@@ -79,19 +65,6 @@ func Test_MatchSchedulingRequirements_isAbleToFitOnAvailableNodes(t *testing.T) 
 	})
 	assert.True(t, ok)
 	assert.NoError(t, err)
-
-	// assert.False(t, MatchSchedulingRequirements(job, &api.ClusterSchedulingInfoReport{}))
-
-	// assert.False(t, MatchSchedulingRequirements(job, &api.ClusterSchedulingInfoReport{
-	// 	NodeTypes: []*api.NodeType{{AllocatableResources: common.ComputeResources{"cpu": resource.MustParse("1"), "memory": resource.MustParse("1Gi")}}},
-	// }))
-
-	// assert.True(t, MatchSchedulingRequirements(job, &api.ClusterSchedulingInfoReport{
-	// 	NodeTypes: []*api.NodeType{
-	// 		{AllocatableResources: common.ComputeResources{"cpu": resource.MustParse("1"), "memory": resource.MustParse("1Gi")}},
-	// 		{AllocatableResources: common.ComputeResources{"cpu": resource.MustParse("3"), "memory": resource.MustParse("3Gi")}},
-	// 	},
-	// }))
 }
 
 func Test_AggregateNodeTypesAllocations(t *testing.T) {

--- a/internal/armada/scheduling/pod_matching_context_test.go
+++ b/internal/armada/scheduling/pod_matching_context_test.go
@@ -17,15 +17,26 @@ func Test_Matches_BasicPod_ReturnsTrue(t *testing.T) {
 
 	available := makeResourceList(1, 10).AsFloat()
 	nodeType := &api.NodeType{}
-	assert.True(t, ctx.Matches(nodeType, available))
+
+	ok, err := ctx.Matches(nodeType, available)
+	assert.True(t, ok)
+	assert.NoError(t, err)
 }
 
 func Test_fits(t *testing.T) {
 	available := makeResourceList(1, 10).AsFloat()
 
-	assert.False(t, fits(makeResourceList(2, 20).AsFloat(), available))
-	assert.False(t, fits(makeResourceList(2, 5).AsFloat(), available))
-	assert.True(t, fits(makeResourceList(1, 10).AsFloat(), available))
+	ok, err := fits(makeResourceList(2, 20).AsFloat(), available)
+	assert.False(t, ok)
+	assert.Error(t, err)
+
+	ok, err = fits(makeResourceList(2, 5).AsFloat(), available)
+	assert.False(t, ok)
+	assert.Error(t, err)
+
+	ok, err = fits(makeResourceList(1, 10).AsFloat(), available)
+	assert.True(t, ok)
+	assert.NoError(t, err)
 }
 
 func Test_matchNodeSelector(t *testing.T) {
@@ -33,21 +44,34 @@ func Test_matchNodeSelector(t *testing.T) {
 		"A": "test",
 		"B": "test",
 	}
-	assert.False(t, matchNodeSelector(&v1.PodSpec{NodeSelector: map[string]string{"C": "test"}}, labels))
-	assert.False(t, matchNodeSelector(&v1.PodSpec{NodeSelector: map[string]string{"B": "42"}}, labels))
-	assert.True(t, matchNodeSelector(&v1.PodSpec{NodeSelector: map[string]string{"A": "test"}}, labels))
-	assert.True(t, matchNodeSelector(&v1.PodSpec{NodeSelector: map[string]string{"A": "test", "B": "test"}}, labels))
+
+	ok, err := matchNodeSelector(&v1.PodSpec{NodeSelector: map[string]string{"C": "test"}}, labels)
+	assert.False(t, ok)
+	assert.Error(t, err)
+
+	ok, err = matchNodeSelector(&v1.PodSpec{NodeSelector: map[string]string{"B": "42"}}, labels)
+	assert.False(t, ok)
+	assert.Error(t, err)
+
+	ok, err = matchNodeSelector(&v1.PodSpec{NodeSelector: map[string]string{"A": "test"}}, labels)
+	assert.True(t, ok)
+	assert.NoError(t, err)
+
+	ok, err = matchNodeSelector(&v1.PodSpec{NodeSelector: map[string]string{"A": "test", "B": "test"}}, labels)
+	assert.True(t, ok)
+	assert.NoError(t, err)
 }
 
 func Test_tolerates_WhenTaintHasNoToleration_ReturnsFalse(t *testing.T) {
 	taints := makeTaints()
 	podSpec := &v1.PodSpec{}
-	assert.False(t, tolerates(podSpec, taints))
+	ok, err := tolerates(podSpec, taints)
+	assert.False(t, ok)
+	assert.Error(t, err)
 }
 
 func Test_tolerates_WhenTaintHasAnEqualsToleration_ReturnsTrue(t *testing.T) {
 	taints := makeTaints()
-
 	podSpec := &v1.PodSpec{
 		Tolerations: []v1.Toleration{
 			{
@@ -56,9 +80,12 @@ func Test_tolerates_WhenTaintHasAnEqualsToleration_ReturnsTrue(t *testing.T) {
 				Value:    "test",
 				Effect:   v1.TaintEffectNoSchedule,
 			},
-		}}
+		},
+	}
 
-	assert.True(t, tolerates(podSpec, taints))
+	ok, err := tolerates(podSpec, taints)
+	assert.True(t, ok)
+	assert.NoError(t, err)
 }
 
 func Test_tolerates_WhenTaintHasAnExistsToleration_ReturnsTrue(t *testing.T) {
@@ -74,12 +101,13 @@ func Test_tolerates_WhenTaintHasAnExistsToleration_ReturnsTrue(t *testing.T) {
 		},
 	}
 
-	assert.True(t, tolerates(podSpec, taints))
+	ok, err := tolerates(podSpec, taints)
+	assert.True(t, ok)
+	assert.NoError(t, err)
 }
 
 func Test_tolerates_WhenTaintHasAToleration_ButEffectDiffers_ReturnsFalse(t *testing.T) {
 	taints := makeTaints()
-
 	podSpec := &v1.PodSpec{
 		Tolerations: []v1.Toleration{
 			{
@@ -90,7 +118,9 @@ func Test_tolerates_WhenTaintHasAToleration_ButEffectDiffers_ReturnsFalse(t *tes
 		},
 	}
 
-	assert.False(t, tolerates(podSpec, taints))
+	ok, err := tolerates(podSpec, taints)
+	assert.False(t, ok)
+	assert.NoError(t, err)
 }
 
 func makeTaints() []v1.Taint {
@@ -114,9 +144,10 @@ func Test_matchAnyNodeTypePodAllocation_WhenFindsMatch_ReturnsMatch(t *testing.T
 	alreadyConsumed := nodeTypeUsedResources{nodeAllocations[0]: common.ComputeResourcesFloat{"cpu": 3, "memory": 1 * 1024 * 1024 * 1024}}
 	newlyConsumed := nodeTypeUsedResources{nodeAllocations[0]: common.ComputeResourcesFloat{"cpu": 3, "memory": 1 * 1024 * 1024 * 1024}}
 
-	resultNode, resultFlag := matchAnyNodeTypePodAllocation(podSpec, nodeAllocations, alreadyConsumed, newlyConsumed)
+	resultNode, resultFlag, err := matchAnyNodeTypePodAllocation(podSpec, nodeAllocations, alreadyConsumed, newlyConsumed)
 	assert.Equal(t, nodeAllocations[0], resultNode)
 	assert.True(t, resultFlag)
+	assert.NoError(t, err)
 }
 
 func Test_matchAnyNodeTypePodAllocation_WhenAllAvailableCpuConsumed_ReturnsFalse(t *testing.T) {
@@ -125,9 +156,10 @@ func Test_matchAnyNodeTypePodAllocation_WhenAllAvailableCpuConsumed_ReturnsFalse
 	alreadyConsumed := nodeTypeUsedResources{nodeAllocations[0]: common.ComputeResourcesFloat{"cpu": 4, "memory": 1 * 1024 * 1024 * 1024}}
 	newlyConsumed := nodeTypeUsedResources{nodeAllocations[0]: common.ComputeResourcesFloat{"cpu": 4, "memory": 1 * 1024 * 1024 * 1024}}
 
-	resultNode, resultFlag := matchAnyNodeTypePodAllocation(podSpec, nodeAllocations, alreadyConsumed, newlyConsumed)
+	resultNode, resultFlag, err := matchAnyNodeTypePodAllocation(podSpec, nodeAllocations, alreadyConsumed, newlyConsumed)
 	assert.Nil(t, resultNode)
 	assert.False(t, resultFlag)
+	assert.Error(t, err)
 }
 
 func Test_matchAnyNodeTypePodAllocation_WhenNodeSelectorMatchesNoNodes_ReturnsFalse(t *testing.T) {
@@ -136,9 +168,10 @@ func Test_matchAnyNodeTypePodAllocation_WhenNodeSelectorMatchesNoNodes_ReturnsFa
 	alreadyConsumed := nodeTypeUsedResources{nodeAllocations[0]: common.ComputeResourcesFloat{}}
 	newlyConsumed := nodeTypeUsedResources{nodeAllocations[0]: common.ComputeResourcesFloat{}}
 
-	resultNode, resultFlag := matchAnyNodeTypePodAllocation(podSpec, nodeAllocations, alreadyConsumed, newlyConsumed)
+	resultNode, resultFlag, err := matchAnyNodeTypePodAllocation(podSpec, nodeAllocations, alreadyConsumed, newlyConsumed)
 	assert.Nil(t, resultNode)
 	assert.False(t, resultFlag)
+	assert.Error(t, err)
 }
 func Test_matchAnyNodeTypePodAllocation_WhenNodeSelectorRulesOutFirstNode_ReturnsSecondNode(t *testing.T) {
 	podSpec := &v1.PodSpec{NodeSelector: map[string]string{"a": "b"}}
@@ -150,9 +183,10 @@ func Test_matchAnyNodeTypePodAllocation_WhenNodeSelectorRulesOutFirstNode_Return
 	alreadyConsumed := nodeTypeUsedResources{nodeAllocations[0]: common.ComputeResourcesFloat{}}
 	newlyConsumed := nodeTypeUsedResources{nodeAllocations[0]: common.ComputeResourcesFloat{}}
 
-	resultNode, resultFlag := matchAnyNodeTypePodAllocation(podSpec, nodeAllocations, alreadyConsumed, newlyConsumed)
+	resultNode, resultFlag, err := matchAnyNodeTypePodAllocation(podSpec, nodeAllocations, alreadyConsumed, newlyConsumed)
 	assert.Equal(t, nodeAllocations[1], resultNode)
 	assert.True(t, resultFlag)
+	assert.NoError(t, err)
 }
 
 func Test_matchAnyNodeTypePodAllocation_WhenTaintRulesOutAllNodes_ReturnsFalse(t *testing.T) {
@@ -164,9 +198,10 @@ func Test_matchAnyNodeTypePodAllocation_WhenTaintRulesOutAllNodes_ReturnsFalse(t
 	alreadyConsumed := nodeTypeUsedResources{nodeAllocations[0]: common.ComputeResourcesFloat{}}
 	newlyConsumed := nodeTypeUsedResources{nodeAllocations[0]: common.ComputeResourcesFloat{}}
 
-	resultNode, resultFlag := matchAnyNodeTypePodAllocation(podSpec, nodeAllocations, alreadyConsumed, newlyConsumed)
+	resultNode, resultFlag, err := matchAnyNodeTypePodAllocation(podSpec, nodeAllocations, alreadyConsumed, newlyConsumed)
 	assert.Nil(t, resultNode)
 	assert.False(t, resultFlag)
+	assert.Error(t, err)
 }
 func Test_matchAnyNodeTypePodAllocation_WhenTaintRulesOutFirstNode_ReturnsSecondNode(t *testing.T) {
 	podSpec := &v1.PodSpec{Tolerations: []v1.Toleration{{Key: "a", Value: "b", Effect: v1.TaintEffectNoSchedule}}}
@@ -178,16 +213,19 @@ func Test_matchAnyNodeTypePodAllocation_WhenTaintRulesOutFirstNode_ReturnsSecond
 	alreadyConsumed := nodeTypeUsedResources{nodeAllocations[0]: common.ComputeResourcesFloat{}}
 	newlyConsumed := nodeTypeUsedResources{nodeAllocations[0]: common.ComputeResourcesFloat{}}
 
-	resultNode, resultFlag := matchAnyNodeTypePodAllocation(podSpec, nodeAllocations, alreadyConsumed, newlyConsumed)
+	resultNode, resultFlag, err := matchAnyNodeTypePodAllocation(podSpec, nodeAllocations, alreadyConsumed, newlyConsumed)
 	assert.Equal(t, nodeAllocations[1], resultNode)
 	assert.True(t, resultFlag)
+	assert.NoError(t, err)
 }
 
 func Test_matchesRequiredNodeAffinity_WhenNoAffinitySet_ReturnsTrue(t *testing.T) {
 	podSpec := &v1.PodSpec{}
 	nodeType := &api.NodeType{}
 
-	assert.True(t, matchesRequiredNodeAffinity(makeRequiredNodeAffinitySelector(podSpec), nodeType))
+	ok, err := matchesRequiredNodeAffinity(makeRequiredNodeAffinitySelector(podSpec), nodeType)
+	assert.True(t, ok)
+	assert.NoError(t, err)
 }
 
 func Test_matchesRequiredNodeAffinity_WhenInAffinitySet_MatchesOnlyLabelledNode(t *testing.T) {
@@ -200,11 +238,25 @@ func Test_matchesRequiredNodeAffinity_WhenInAffinitySet_MatchesOnlyLabelledNode(
 	podSpec := podWithRequiredNodeAffinity(reqs)
 	sel := makeRequiredNodeAffinitySelector(podSpec)
 
-	assert.False(t, matchesRequiredNodeAffinity(sel, &api.NodeType{}))
-	assert.False(t, matchesRequiredNodeAffinity(sel, &api.NodeType{Labels: map[string]string{}}))
-	assert.False(t, matchesRequiredNodeAffinity(sel, &api.NodeType{Labels: map[string]string{"does_not_match": "does_not_match"}}))
-	assert.False(t, matchesRequiredNodeAffinity(sel, &api.NodeType{Labels: map[string]string{"a": "does_not_match"}}))
-	assert.True(t, matchesRequiredNodeAffinity(sel, &api.NodeType{Labels: map[string]string{"a": "b"}}))
+	ok, err := matchesRequiredNodeAffinity(sel, &api.NodeType{})
+	assert.False(t, ok)
+	assert.Error(t, err)
+
+	ok, err = matchesRequiredNodeAffinity(sel, &api.NodeType{Labels: map[string]string{}})
+	assert.False(t, ok)
+	assert.Error(t, err)
+
+	ok, err = matchesRequiredNodeAffinity(sel, &api.NodeType{Labels: map[string]string{"does_not_match": "does_not_match"}})
+	assert.False(t, ok)
+	assert.Error(t, err)
+
+	ok, err = matchesRequiredNodeAffinity(sel, &api.NodeType{Labels: map[string]string{"a": "does_not_match"}})
+	assert.False(t, ok)
+	assert.Error(t, err)
+
+	ok, err = matchesRequiredNodeAffinity(sel, &api.NodeType{Labels: map[string]string{"a": "b"}})
+	assert.True(t, ok)
+	assert.NoError(t, err)
 }
 
 func Test_matchesRequiredNodeAffinity_WhenNotInAffinitySet_MatchesAllExceptLabelledNode(t *testing.T) {
@@ -217,12 +269,29 @@ func Test_matchesRequiredNodeAffinity_WhenNotInAffinitySet_MatchesAllExceptLabel
 	podSpec := podWithRequiredNodeAffinity(reqs)
 	sel := makeRequiredNodeAffinitySelector(podSpec)
 
-	assert.True(t, matchesRequiredNodeAffinity(sel, &api.NodeType{}))
-	assert.True(t, matchesRequiredNodeAffinity(sel, &api.NodeType{Labels: map[string]string{}}))
-	assert.True(t, matchesRequiredNodeAffinity(sel, &api.NodeType{Labels: map[string]string{"does_not_match": "does_not_match"}}))
-	assert.True(t, matchesRequiredNodeAffinity(sel, &api.NodeType{Labels: map[string]string{"a": "does_not_match"}}))
-	assert.False(t, matchesRequiredNodeAffinity(sel, &api.NodeType{Labels: map[string]string{"a": "b"}}))
-	assert.False(t, matchesRequiredNodeAffinity(sel, &api.NodeType{Labels: map[string]string{"a": "b", "does_not_match": "does_not_match"}}))
+	ok, err := matchesRequiredNodeAffinity(sel, &api.NodeType{})
+	assert.True(t, ok)
+	assert.NoError(t, err)
+
+	ok, err = matchesRequiredNodeAffinity(sel, &api.NodeType{Labels: map[string]string{}})
+	assert.True(t, ok)
+	assert.NoError(t, err)
+
+	ok, err = matchesRequiredNodeAffinity(sel, &api.NodeType{Labels: map[string]string{"does_not_match": "does_not_match"}})
+	assert.True(t, ok)
+	assert.NoError(t, err)
+
+	ok, err = matchesRequiredNodeAffinity(sel, &api.NodeType{Labels: map[string]string{"a": "does_not_match"}})
+	assert.True(t, ok)
+	assert.NoError(t, err)
+
+	ok, err = matchesRequiredNodeAffinity(sel, &api.NodeType{Labels: map[string]string{"a": "b"}})
+	assert.False(t, ok)
+	assert.Error(t, err)
+
+	ok, err = matchesRequiredNodeAffinity(sel, &api.NodeType{Labels: map[string]string{"a": "b", "does_not_match": "does_not_match"}})
+	assert.False(t, ok)
+	assert.Error(t, err)
 }
 
 func makeResourceList(cores int64, gigabytesRam int64) common.ComputeResources {

--- a/internal/armada/server/job_validation.go
+++ b/internal/armada/server/job_validation.go
@@ -1,19 +1,20 @@
 package server
 
 import (
-	"fmt"
-
 	"github.com/G-Research/armada/internal/armada/scheduling"
 	"github.com/G-Research/armada/pkg/api"
+	"github.com/pkg/errors"
 )
 
-func validateJobsCanBeScheduled(jobs []*api.Job, allClusterSchedulingInfo map[string]*api.ClusterSchedulingInfoReport) error {
+// validateJobsCanBeScheduled returns a boolean indicating if all pods that make up the provided jobs
+// can be scheduled. If it returns false, it also returns an error with information about which job
+// can't be scheduled and why.
+func validateJobsCanBeScheduled(jobs []*api.Job, allClusterSchedulingInfo map[string]*api.ClusterSchedulingInfoReport) (bool, error) {
 	activeClusterSchedulingInfo := scheduling.FilterActiveClusterSchedulingInfoReports(allClusterSchedulingInfo)
 	for i, job := range jobs {
-		if !scheduling.MatchSchedulingRequirementsOnAnyCluster(job, activeClusterSchedulingInfo) {
-			return fmt.Errorf("[validateJobsCanBeScheduled] job %d out of %d with Id %s can't be scheduled on any cluster", i, len(jobs), job.Id)
+		if ok, err := scheduling.MatchSchedulingRequirementsOnAnyCluster(job, activeClusterSchedulingInfo); !ok {
+			return false, errors.WithMessagef(err, "%d-th job can't be scheduled", i)
 		}
 	}
-
-	return nil
+	return true, nil
 }

--- a/internal/armada/server/lease.go
+++ b/internal/armada/server/lease.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/gogo/protobuf/types"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -196,7 +197,10 @@ func (q *AggregatedQueueServer) addAvoidNodeAffinity(jobId string, labels *api.O
 		}
 
 		changed := addAvoidNodeAffinity(jobs[0], labels, func(jobsToValidate []*api.Job) error {
-			return validateJobsCanBeScheduled(jobsToValidate, allClusterSchedulingInfo)
+			if ok, err := validateJobsCanBeScheduled(jobsToValidate, allClusterSchedulingInfo); !ok {
+				return errors.WithMessage(err, "can't schedule at least 1 job")
+			}
+			return nil
 		})
 
 		if changed {

--- a/internal/armada/server/submit.go
+++ b/internal/armada/server/submit.go
@@ -287,9 +287,8 @@ func (server *SubmitServer) SubmitJobs(ctx context.Context, req *api.JobSubmitRe
 		return nil, status.Errorf(codes.InvalidArgument, "[SubmitJobs] error getting scheduling info: %s", err)
 	}
 
-	err = validateJobsCanBeScheduled(jobs, allClusterSchedulingInfo)
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "[SubmitJobs] error submitting jobs for user %s: %s", principal.GetName(), err)
+	if ok, err := validateJobsCanBeScheduled(jobs, allClusterSchedulingInfo); !ok {
+		return nil, errors.WithMessagef(err, "can't schedule job for user %s", principal.GetName())
 	}
 
 	// Create events marking the jobs as submitted

--- a/internal/common/logging/errors.go
+++ b/internal/common/logging/errors.go
@@ -1,0 +1,29 @@
+package logging
+
+// TopmostWithCause recursively calls cause on the given error until it finds an error that does
+// not implement the causer interface, and returns the error directly preceding that one.
+// Typically, that is the final or penultimate error in the chain.
+// This function is meant to be used together with pkg/errors wrapping.
+//
+// Logging the error returned by this one with the %+v verb provides a stack trace recorded at
+// the point the error was created.
+func TopmostWithCause(err error) error {
+	type causer interface {
+		Cause() error
+	}
+
+	rv := err
+	for rv != nil {
+		cause, ok := rv.(causer)
+		if !ok {
+			break
+		}
+		err = cause.Cause()
+		_, ok = err.(causer)
+		if !ok {
+			break
+		}
+		rv = err
+	}
+	return rv
+}


### PR DESCRIPTION
Currently, Armada rejects jobs that can never be scheduler. However, Armada does not include a reason in the error returned to the user. This PR updates the logic that checks if a job can be scheduled to return a detailed error message.