### PR TITLE
Add CI job for Go 1.18 running on Ubuntu 22.04 (jammy)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ commands:
           git push -q origin HEAD
 
 jobs:
-  checks_and_unit_tests:
+  checks_and_unit_tests-ubuntu2004-go116: &checksAndUnitTests
     machine:
       docker_layer_caching: true
       image: ubuntu-2004:202104-01
@@ -174,6 +174,13 @@ jobs:
 
       - store_test_results:
           path: test_reports/junit.xml
+
+  checks_and_unit_tests-ubuntu2204-go118:
+    <<: *checksAndUnitTests
+    machine:
+      docker_layer_caching: true
+      image: ubuntu-2204:current
+      resource_class: xlarge
 
   build_and_integration_tests:
     machine:
@@ -367,7 +374,8 @@ workflows:
   build_and_deploy:
     jobs:
       -  build_and_integration_tests
-      -  checks_and_unit_tests
+      -  checks_and_unit_tests-ubuntu2004-go116
+      -  checks_and_unit_tests-ubuntu2204-go118
       - release:
           filters:
             tags:


### PR DESCRIPTION
This allows us to test both Ubuntu LTS golang versions.