### PR TITLE
Better show errors when Pulsar Send fails

### DIFF
--- a/internal/armada/server/submit_to_log.go
+++ b/internal/armada/server/submit_to_log.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -23,7 +24,6 @@ import (
 	"github.com/G-Research/armada/internal/common/requestid"
 	"github.com/G-Research/armada/internal/executor/configuration"
 	"github.com/G-Research/armada/internal/pgkeyvalue"
-	"github.com/G-Research/armada/internal/pulsarutils/pulsarrequestid"
 	"github.com/G-Research/armada/pkg/api"
 	"github.com/G-Research/armada/pkg/armadaevents"
 	"github.com/G-Research/armada/pkg/client/queue"
@@ -222,11 +222,6 @@ func (srv *PulsarSubmitServer) SubmitJobs(ctx context.Context, req *api.JobSubmi
 		}
 	}
 
-	payload, err := proto.Marshal(sequence)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to marshal event sequence")
-	}
-
 	// Create events marking the jobs as submitted
 	err = reportSubmitted(srv.SubmitServer.eventStore, apiJobs)
 	if err != nil {
@@ -238,20 +233,11 @@ func (srv *PulsarSubmitServer) SubmitJobs(ctx context.Context, req *api.JobSubmi
 		return nil, status.Errorf(codes.Internal, "error reporting duplicates: %s", err)
 	}
 
-	// Incoming gRPC requests are annotated with a unique id.
-	// Pass this id through the log by adding it to the Pulsar message properties.
-	if len(sequence.Events) > 0 {
-		requestId := requestid.FromContextOrMissing(ctx)
-		msg := &pulsar.ProducerMessage{
-			Payload:    payload,
-			Properties: map[string]string{requestid.MetadataKey: requestId},
-			Key:        req.JobSetId,
-		}
-		pulsarrequestid.AddToMessage(msg, requestId)
-		_, err = srv.Producer.Send(ctx, msg)
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "failed to send message")
-		}
+	err = srv.publishToPulsar(ctx, []*armadaevents.EventSequence{sequence})
+
+	if err != nil {
+		log.Errorf("Error sending message to pulsar: %+v", err)
+		return nil, status.Error(codes.Internal, "Failed to send message")
 	}
 
 	return &api.JobSubmitResponse{JobResponseItems: responses}, nil
@@ -361,24 +347,11 @@ func (srv *PulsarSubmitServer) CancelJobs(ctx context.Context, req *api.JobCance
 		cancelledIds = []string{req.JobId} // indicates no error
 	}
 
-	payload, err := proto.Marshal(sequence)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to marshal event sequence")
-	}
+	err = srv.publishToPulsar(ctx, []*armadaevents.EventSequence{sequence})
 
-	// Incoming gRPC requests are annotated with a unique id.
-	// Pass this id through the log by adding it to the Pulsar message properties.
-	requestId, ok := requestid.FromContext(ctx)
-	if !ok {
-		requestId = "missing"
-	}
-	_, err = srv.Producer.Send(ctx, &pulsar.ProducerMessage{
-		Payload:    payload,
-		Properties: map[string]string{requestid.MetadataKey: requestId},
-		Key:        req.JobSetId,
-	})
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to send message")
+		log.Errorf("Error sending message to pulsar: %+v", err)
+		return nil, status.Error(codes.Internal, "Failed to send message")
 	}
 
 	return &api.CancellationResult{
@@ -457,24 +430,11 @@ func (srv *PulsarSubmitServer) ReprioritizeJobs(ctx context.Context, req *api.Jo
 		results[jobIdString] = "" // empty string indicates no error
 	}
 
-	payload, err := proto.Marshal(sequence)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to marshal event sequence")
-	}
+	err = srv.publishToPulsar(ctx, []*armadaevents.EventSequence{sequence})
 
-	// Incoming gRPC requests are annotated with a unique id.
-	// Pass this id through the log by adding it to the Pulsar message properties.
-	requestId, ok := requestid.FromContext(ctx)
-	if !ok {
-		requestId = "missing"
-	}
-	_, err = srv.Producer.Send(ctx, &pulsar.ProducerMessage{
-		Payload:    payload,
-		Properties: map[string]string{requestid.MetadataKey: requestId},
-		Key:        req.JobSetId,
-	})
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to send message")
+		log.Errorf("Error sending message to pulsar: %+v", err)
+		return nil, status.Error(codes.Internal, "Failed to send message")
 	}
 
 	return &api.JobReprioritizeResponse{
@@ -577,52 +537,7 @@ func (srv *PulsarSubmitServer) SubmitApiEvents(ctx context.Context, apiEvents []
 		return nil
 	}
 
-	// Incoming gRPC requests are annotated with a unique id.
-	// Pass this id through the log by adding it to the Pulsar message properties.
-	requestId := requestid.FromContextOrMissing(ctx)
-
-	// Send each sequence async. Collect any errors via ch.
-	ch := make(chan error, len(sequences))
-	defer close(ch)
-	for _, sequence := range sequences {
-		payload, err := proto.Marshal(sequence)
-		if err != nil {
-			return errors.WithStack(err)
-		}
-
-		srv.Producer.SendAsync(
-			ctx,
-			&pulsar.ProducerMessage{
-				Payload: payload,
-				Properties: map[string]string{
-					requestid.MetadataKey:                     requestId,
-					armadaevents.PULSAR_MESSAGE_TYPE_PROPERTY: armadaevents.PULSAR_CONTROL_MESSAGE,
-				},
-				Key: sequence.JobSetName,
-			},
-			// Callback on send.
-			func(_ pulsar.MessageID, _ *pulsar.ProducerMessage, err error) {
-				ch <- err
-			},
-		)
-		if err != nil {
-			err = errors.WithStack(err)
-			return err
-		}
-	}
-
-	// Flush queued messages and wait until persisted.
-	err = srv.Producer.Flush()
-	if err != nil {
-		return err
-	}
-
-	// Collect any errors experienced by the async send and return.
-	var result *multierror.Error
-	for range sequences {
-		result = multierror.Append(result, <-ch)
-	}
-	return result.ErrorOrNil()
+	return srv.publishToPulsar(ctx, sequences)
 }
 
 // SubmitApiEvent converts an api.EventMessage into Pulsar state transition messages and publishes those to Pulsar.
@@ -660,4 +575,54 @@ func (srv *PulsarSubmitServer) SubmitApiEvent(ctx context.Context, apiEvent *api
 	}
 
 	return nil
+}
+
+// PublishToPulsar sends pulsar messages async
+func (srv *PulsarSubmitServer) publishToPulsar(ctx context.Context, sequences []*armadaevents.EventSequence) error {
+
+	// Incoming gRPC requests are annotated with a unique id.
+	// Pass this id through the log by adding it to the Pulsar message properties.
+	requestId := requestid.FromContextOrMissing(ctx)
+
+	// Send each sequence async. Collect any errors via ch.
+	ch := make(chan error, len(sequences))
+	defer close(ch)
+	for _, sequence := range sequences {
+		payload, err := proto.Marshal(sequence)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		srv.Producer.SendAsync(
+			ctx,
+			&pulsar.ProducerMessage{
+				Payload: payload,
+				Properties: map[string]string{
+					requestid.MetadataKey:                     requestId,
+					armadaevents.PULSAR_MESSAGE_TYPE_PROPERTY: armadaevents.PULSAR_CONTROL_MESSAGE,
+				},
+				Key: sequence.JobSetName,
+			},
+			// Callback on send.
+			func(_ pulsar.MessageID, _ *pulsar.ProducerMessage, err error) {
+				ch <- err
+			},
+		)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+	}
+
+	// Flush queued messages and wait until persisted.
+	err := srv.Producer.Flush()
+	if err != nil {
+		return err
+	}
+
+	// Collect any errors experienced by the async send and return.
+	var result *multierror.Error
+	for range sequences {
+		result = multierror.Append(result, <-ch)
+	}
+	return result.ErrorOrNil()
 }

--- a/internal/armada/server/submit_to_log.go
+++ b/internal/armada/server/submit_to_log.go
@@ -236,7 +236,7 @@ func (srv *PulsarSubmitServer) SubmitJobs(ctx context.Context, req *api.JobSubmi
 	err = srv.publishToPulsar(ctx, []*armadaevents.EventSequence{sequence})
 
 	if err != nil {
-		log.Errorf("Error sending message to pulsar: %+v", err)
+		log.WithError(err).Error("failed send to Pulsar")
 		return nil, status.Error(codes.Internal, "Failed to send message")
 	}
 
@@ -350,7 +350,7 @@ func (srv *PulsarSubmitServer) CancelJobs(ctx context.Context, req *api.JobCance
 	err = srv.publishToPulsar(ctx, []*armadaevents.EventSequence{sequence})
 
 	if err != nil {
-		log.Errorf("Error sending message to pulsar: %+v", err)
+		log.WithError(err).Error("failed send to Pulsar")
 		return nil, status.Error(codes.Internal, "Failed to send message")
 	}
 
@@ -433,7 +433,7 @@ func (srv *PulsarSubmitServer) ReprioritizeJobs(ctx context.Context, req *api.Jo
 	err = srv.publishToPulsar(ctx, []*armadaevents.EventSequence{sequence})
 
 	if err != nil {
-		log.Errorf("Error sending message to pulsar: %+v", err)
+		log.WithError(err).Error("failed send to Pulsar")
 		return nil, status.Error(codes.Internal, "Failed to send message")
 	}
 


### PR DESCRIPTION
I've moved all the pulsar sending code in `submit_to_log` into a common function that does async sends.
I've also made sure we log out the full error (including stack) of the errors we get when sending from this function.
