### PR TITLE
Add retry to docker pull in release job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,23 +319,23 @@ jobs:
 
             echo ${DOCKERHUB_PASS} | docker login -u ${DOCKERHUB_USER} --password-stdin
 
-            docker pull gresearchdev/armada-server-dev:${TAG}
+            ./scripts/docker-pull-with-retry.sh gresearchdev/armada-server-dev:${TAG} 30
             docker tag gresearchdev/armada-server-dev:${TAG} gresearchdev/armada-server:${RELEASE_TAG}
             docker push gresearchdev/armada-server:${RELEASE_TAG}
 
-            docker pull gresearchdev/armada-executor-dev:${TAG}
+            ./scripts/docker-pull-with-retry.sh gresearchdev/armada-executor-dev:${TAG}
             docker tag gresearchdev/armada-executor-dev:${TAG} gresearchdev/armada-executor:${RELEASE_TAG}
             docker push gresearchdev/armada-executor:${RELEASE_TAG}
 
-            docker pull gresearchdev/armada-armadactl-dev:${TAG}
+            ./scripts/docker-pull-with-retry.sh gresearchdev/armada-armadactl-dev:${TAG}
             docker tag gresearchdev/armada-armadactl-dev:${TAG} gresearchdev/armada-armadactl:${RELEASE_TAG}
             docker push gresearchdev/armada-armadactl:${RELEASE_TAG}
 
-            docker pull gresearchdev/armada-lookout-dev:${TAG}
+            ./scripts/docker-pull-with-retry.sh gresearchdev/armada-lookout-dev:${TAG}
             docker tag gresearchdev/armada-lookout-dev:${TAG} gresearchdev/armada-lookout:${RELEASE_TAG}
             docker push gresearchdev/armada-lookout:${RELEASE_TAG}
 
-            docker pull gresearchdev/armada-binoculars-dev:${TAG}
+            ./scripts/docker-pull-with-retry.sh gresearchdev/armada-binoculars-dev:${TAG}
             docker tag gresearchdev/armada-binoculars-dev:${TAG} gresearchdev/armada-binoculars:${RELEASE_TAG}
             docker push gresearchdev/armada-binoculars:${RELEASE_TAG}
 

--- a/scripts/docker-pull-with-retry.sh
+++ b/scripts/docker-pull-with-retry.sh
@@ -1,0 +1,15 @@
+IMAGE=$1
+RETRY_COUNT=${2:-5}
+
+# Try to pull image, return success on pull succeed
+for ((i=1; i<=$RETRY_COUNT; i++))
+do
+  if docker pull $IMAGE ; then
+    exit 0
+  fi
+  echo Failed to pull $IMAGE - attempt $i
+  sleep 3
+done
+
+# Return failure if all pull attempts fail
+exit 1

--- a/scripts/docker-pull-with-retry.sh
+++ b/scripts/docker-pull-with-retry.sh
@@ -1,10 +1,10 @@
 IMAGE=$1
 RETRY_COUNT=${2:-5}
 
-# Try to pull image, return success on pull succeed
 for ((i=1; i<=$RETRY_COUNT; i++))
 do
   if docker pull $IMAGE ; then
+    # Return 0 on pull success
     exit 0
   fi
   echo Failed to pull $IMAGE - attempt $i

--- a/scripts/docker-pull-with-retry.sh
+++ b/scripts/docker-pull-with-retry.sh
@@ -8,7 +8,7 @@ do
     exit 0
   fi
   echo Failed to pull $IMAGE - attempt $i
-  sleep 3
+  sleep 60
 done
 
 # Return failure if all pull attempts fail


### PR DESCRIPTION
Sometimes a release is created before the master branch has been built and images pushed
 - This cause the release to fail

Adding some retrying so it'll attempt to wait for the image to be pushed from master

The aim being less reliance on master being built before a release being created and still resulting in a successful release images being created