### PR TITLE
fix hang on db migrations

### DIFF
--- a/internal/common/database/migrations.go
+++ b/internal/common/database/migrations.go
@@ -57,7 +57,7 @@ func readVersion(ctx context.Context, db pgxtype.Querier) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-
+	defer result.Close()
 	var version int
 	result.Next()
 	err = result.Scan(&version)


### PR DESCRIPTION
We weren't closing a resultset in our db migration code that could lead to a hang