### PR TITLE
Fix helm templating without pulsar

### DIFF
--- a/deployment/armada/values.yaml
+++ b/deployment/armada/values.yaml
@@ -29,4 +29,4 @@ serviceAccount: null
 applicationConfig:
   grpcPort: 50051
   httpPort: 8080
-  pulsar:
+  pulsar: {}


### PR DESCRIPTION
Currently if `helm template` is run for the armada-server chart, templating fails because the `pulsar` block isn't specified.