### PR TITLE
Improve utilisation data collection

### DIFF
--- a/internal/executor/context/cluster_context.go
+++ b/internal/executor/context/cluster_context.go
@@ -1,7 +1,7 @@
 package context
 
 import (
-	ctx "context"
+	"context"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -47,7 +47,7 @@ type ClusterContext interface {
 	GetActiveBatchPods() ([]*v1.Pod, error)
 	GetNodes() ([]*v1.Node, error)
 	GetNode(nodeName string) (*v1.Node, error)
-	GetNodeStatsSummary(*v1.Node) (*v1alpha1.Summary, error)
+	GetNodeStatsSummary(context.Context, *v1.Node) (*v1alpha1.Summary, error)
 	GetPodEvents(pod *v1.Pod) ([]*v1.Event, error)
 	GetServices(pod *v1.Pod) ([]*v1.Service, error)
 	GetIngresses(pod *v1.Pod) ([]*networking.Ingress, error)
@@ -209,7 +209,7 @@ func (c *KubernetesClusterContext) GetNode(nodeName string) (*v1.Node, error) {
 	return c.nodeInformer.Lister().Get(nodeName)
 }
 
-func (c *KubernetesClusterContext) GetNodeStatsSummary(node *v1.Node) (*v1alpha1.Summary, error) {
+func (c *KubernetesClusterContext) GetNodeStatsSummary(ctx context.Context, node *v1.Node) (*v1alpha1.Summary, error) {
 	request := c.kubernetesClient.
 		CoreV1().
 		RESTClient().
@@ -218,7 +218,7 @@ func (c *KubernetesClusterContext) GetNodeStatsSummary(node *v1.Node) (*v1alpha1
 		Name(node.Name).
 		SubResource("proxy", "stats", "summary")
 
-	res := request.Do(ctx.Background())
+	res := request.Do(ctx)
 	rawJson, err := res.Raw()
 
 	if err != nil {
@@ -251,7 +251,7 @@ func (c *KubernetesClusterContext) SubmitPod(pod *v1.Pod, owner string, ownerGro
 		return nil, err
 	}
 
-	returnedPod, err := ownerClient.CoreV1().Pods(pod.Namespace).Create(ctx.Background(), pod, metav1.CreateOptions{})
+	returnedPod, err := ownerClient.CoreV1().Pods(pod.Namespace).Create(context.Background(), pod, metav1.CreateOptions{})
 
 	if err != nil {
 		c.submittedPods.Delete(util.ExtractPodKey(pod))
@@ -260,11 +260,11 @@ func (c *KubernetesClusterContext) SubmitPod(pod *v1.Pod, owner string, ownerGro
 }
 
 func (c *KubernetesClusterContext) SubmitService(service *v1.Service) (*v1.Service, error) {
-	return c.kubernetesClient.CoreV1().Services(service.Namespace).Create(ctx.Background(), service, metav1.CreateOptions{})
+	return c.kubernetesClient.CoreV1().Services(service.Namespace).Create(context.Background(), service, metav1.CreateOptions{})
 }
 
 func (c *KubernetesClusterContext) SubmitIngress(ingress *networking.Ingress) (*networking.Ingress, error) {
-	return c.kubernetesClient.NetworkingV1().Ingresses(ingress.Namespace).Create(ctx.Background(), ingress, metav1.CreateOptions{})
+	return c.kubernetesClient.NetworkingV1().Ingresses(ingress.Namespace).Create(context.Background(), ingress, metav1.CreateOptions{})
 }
 
 func (c *KubernetesClusterContext) AddAnnotation(pod *v1.Pod, annotations map[string]string) error {
@@ -277,7 +277,7 @@ func (c *KubernetesClusterContext) AddAnnotation(pod *v1.Pod, annotations map[st
 	if err != nil {
 		return err
 	}
-	_, err = c.kubernetesClient.CoreV1().Pods(pod.Namespace).Patch(ctx.Background(), pod.Name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
+	_, err = c.kubernetesClient.CoreV1().Pods(pod.Namespace).Patch(context.Background(), pod.Name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
 		return err
 	}
@@ -293,12 +293,12 @@ func (c *KubernetesClusterContext) DeletePods(pods []*v1.Pod) {
 func (c *KubernetesClusterContext) deletePodEvents(pod *v1.Pod) error {
 	deleteOptions := createDeleteOptions()
 	listOptions := createPodEventsListOptions(pod)
-	return c.kubernetesClient.CoreV1().Events(pod.Namespace).DeleteCollection(ctx.Background(), deleteOptions, listOptions)
+	return c.kubernetesClient.CoreV1().Events(pod.Namespace).DeleteCollection(context.Background(), deleteOptions, listOptions)
 }
 
 func (c *KubernetesClusterContext) DeleteService(service *v1.Service) error {
 	deleteOptions := createDeleteOptions()
-	err := c.kubernetesClient.CoreV1().Services(service.Namespace).Delete(ctx.Background(), service.Name, deleteOptions)
+	err := c.kubernetesClient.CoreV1().Services(service.Namespace).Delete(context.Background(), service.Name, deleteOptions)
 	if err != nil && k8s_errors.IsNotFound(err) {
 		return nil
 	}
@@ -307,7 +307,7 @@ func (c *KubernetesClusterContext) DeleteService(service *v1.Service) error {
 
 func (c *KubernetesClusterContext) DeleteIngress(ingress *networking.Ingress) error {
 	deleteOptions := createDeleteOptions()
-	err := c.kubernetesClient.NetworkingV1().Ingresses(ingress.Namespace).Delete(ctx.Background(), ingress.Name, deleteOptions)
+	err := c.kubernetesClient.NetworkingV1().Ingresses(ingress.Namespace).Delete(context.Background(), ingress.Name, deleteOptions)
 	if err != nil && k8s_errors.IsNotFound(err) {
 		return nil
 	}
@@ -335,7 +335,7 @@ func (c *KubernetesClusterContext) ProcessPodsToDelete() {
 		}
 
 		if err == nil {
-			err = c.kubernetesClient.CoreV1().Pods(podToDelete.Namespace).Delete(ctx.Background(), podToDelete.Name, deleteOptions)
+			err = c.kubernetesClient.CoreV1().Pods(podToDelete.Namespace).Delete(context.Background(), podToDelete.Name, deleteOptions)
 			if err == nil {
 				deletePodEventsErr := c.deletePodEvents(podToDelete)
 				if deletePodEventsErr != nil {

--- a/internal/executor/util/node_util.go
+++ b/internal/executor/util/node_util.go
@@ -63,13 +63,22 @@ func MergeNodeList(list1 []*v1.Node, list2 []*v1.Node) []*v1.Node {
 }
 
 func FilterNodes(nodes []*v1.Node, filter func(node *v1.Node) bool) []*v1.Node {
-	processingNodes := make([]*v1.Node, 0, len(nodes))
+	filteredNodes := make([]*v1.Node, 0, len(nodes))
 
 	for _, node := range nodes {
 		if filter(node) {
-			processingNodes = append(processingNodes, node)
+			filteredNodes = append(filteredNodes, node)
 		}
 	}
 
-	return processingNodes
+	return filteredNodes
+}
+
+func IsReady(node *v1.Node) bool {
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == v1.NodeReady && condition.Status == v1.ConditionTrue {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/executor/util/node_util_test.go
+++ b/internal/executor/util/node_util_test.go
@@ -176,3 +176,39 @@ func TestRemoveNodesFromList_HandlesEmptyLists(t *testing.T) {
 	result = RemoveNodesFromList([]*v1.Node{node1}, []*v1.Node{})
 	assert.Equal(t, []*v1.Node{node1}, result)
 }
+
+func TestIsReady(t *testing.T) {
+	readyNode := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "ready"}, Status: v1.NodeStatus{
+		Conditions: []v1.NodeCondition{
+			{
+				Type:   v1.NodeReady,
+				Status: v1.ConditionTrue,
+			},
+		},
+	}}
+	assert.True(t, IsReady(readyNode))
+}
+
+func TestIsReady_NotReadyNodes(t *testing.T) {
+	notReadyNode := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "notReady"}, Status: v1.NodeStatus{
+		Conditions: []v1.NodeCondition{
+			{
+				Type:   v1.NodeReady,
+				Status: v1.ConditionFalse,
+			},
+		},
+	}}
+	unknownReadyStateNode := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "unknownReady"}, Status: v1.NodeStatus{
+		Conditions: []v1.NodeCondition{
+			{
+				Type:   v1.NodeReady,
+				Status: v1.ConditionFalse,
+			},
+		},
+	}}
+	missingReadyStateNode := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "missingReady"}}
+
+	assert.False(t, IsReady(notReadyNode))
+	assert.False(t, IsReady(unknownReadyStateNode))
+	assert.False(t, IsReady(missingReadyStateNode))
+}


### PR DESCRIPTION
When there are bad nodes, sometimes our utilisation gathering gets stuck
 - Now skip collection of metrics for NotReady nodes
 - Add a timeout of 15s so don't hang forever. Not all "bad" nodes are NotReady