### PR TITLE
Fix retry logic in armadactl tests

### DIFF
--- a/e2e/armadactl_test/armadactl_test.go
+++ b/e2e/armadactl_test/armadactl_test.go
@@ -266,19 +266,19 @@ jobs:
 		func() error {
 			err = app.Analyze(name, "set1")
 			if err != nil {
-				t.Fatalf("expected no error, but got %s", err)
+				return fmt.Errorf("expected no error, but got %s", err)
 			}
 
 			out = buf.String()
 			buf.Reset()
 
 			if strings.Contains(out, "Found no events associated") {
-				return fmt.Errorf("error calling analyze; got response %s", out)
+				return fmt.Errorf("no events found, got response %s", out)
 			}
 
 			for _, s := range []string{fmt.Sprintf("Querying queue %s for job set set1", name), "api.JobSubmittedEvent", "api.JobQueuedEvent"} {
 				if !strings.Contains(out, s) {
-					t.Fatalf("expected output to contain '%s', but got '%s'", s, out)
+					return fmt.Errorf("expected output to contain '%s', but got '%s'", s, out)
 				}
 			}
 


### PR DESCRIPTION
`retry.Do` only works if the callback returns an error. Calling `t.Fatalf` will result in the test failing on the first run, without retrying.

This ensures that any error seen in the analyze step will prompt a retry.