### PR TITLE
Correctly report jobs as done on failed submission

### DIFF
--- a/internal/executor/service/cluster_allocation.go
+++ b/internal/executor/service/cluster_allocation.go
@@ -101,7 +101,7 @@ func (allocationService *ClusterAllocationService) processFailedJobs(failedSubmi
 			err := allocationService.eventReporter.Report(failEvent)
 
 			if err == nil {
-				toBeReportedDone = append(toBeReportedDone, details.Job.JobSetId)
+				toBeReportedDone = append(toBeReportedDone, details.Job.Id)
 			}
 		}
 	}


### PR DESCRIPTION
Currently the id being used when reporting done is wrong, meaning these jobs get retried endlessly unintentionally
 - As the lease isn't returned, the lease expires and that doesn't seem to count as a retry, so it doesn't get capped at 5