### PR TITLE
Remove line that incorrectly updates deletionCache

### DIFF
--- a/internal/executor/context/cluster_context.go
+++ b/internal/executor/context/cluster_context.go
@@ -330,7 +330,6 @@ func (c *KubernetesClusterContext) ProcessPodsToDelete() {
 			err = annotationErr
 			if annotationErr == nil {
 				podToDelete = updatedPod
-				c.podsToDelete.Update(podId, podToDelete)
 			}
 		}
 


### PR DESCRIPTION
This line should have been updating the value in the deletionCache to the updated pod, but it wasn't

However the value it updated would always be overwritten later in the function, so I have simply removed  the incorrect line