### PR TITLE
Adding pod name

### DIFF
--- a/internal/lookout/ui/src/components/job-dialog/JobDetails.tsx
+++ b/internal/lookout/ui/src/components/job-dialog/JobDetails.tsx
@@ -6,7 +6,7 @@ import { ExpandMore } from "@material-ui/icons"
 import { Job } from "../../services/JobService"
 import DetailRow from "./DetailRow"
 import { PreviousRuns } from "./PreviousRuns"
-import { RunDetailsRows } from "./RunDetailsRows"
+import RunDetailsRows from "./RunDetailsRows"
 
 import "./Details.css"
 
@@ -60,7 +60,7 @@ export default function JobDetails(props: DetailsProps) {
             <DetailRow name="Priority" value={props.job.priority.toString()} />
             <DetailRow name="Submitted" value={props.job.submissionTime} />
             {props.job.cancelledTime && <DetailRow name="Cancelled" value={props.job.cancelledTime} />}
-            {lastRun && <RunDetailsRows run={lastRun} />}
+            {lastRun && <RunDetailsRows run={lastRun} jobId={props.job.jobId} />}
             {props.job.annotations &&
               Object.entries(props.job.annotations).map(([name, value]) => (
                 <DetailRow key={"annotation-" + name} detailRowKey={"annotation-" + name} name={name} value={value} />

--- a/internal/lookout/ui/src/components/job-dialog/PreviousRuns.tsx
+++ b/internal/lookout/ui/src/components/job-dialog/PreviousRuns.tsx
@@ -4,7 +4,7 @@ import { Collapse, List, ListItem, ListItemText, Paper, Table, TableBody, TableC
 import { ExpandLess, ExpandMore } from "@material-ui/icons"
 
 import { Run } from "../../services/JobService"
-import { RunDetailsRows } from "./RunDetailsRows"
+import RunDetailsRows from "./RunDetailsRows"
 
 import "./PreviousRuns.css"
 

--- a/internal/lookout/ui/src/components/job-dialog/RunDetailsRows.test.tsx
+++ b/internal/lookout/ui/src/components/job-dialog/RunDetailsRows.test.tsx
@@ -1,0 +1,43 @@
+import React from "react"
+
+import { TableContainer, Table, TableBody } from "@material-ui/core"
+import { render, screen } from "@testing-library/react"
+
+import { Run } from "../../services/JobService"
+import RunDetailsRows from "./RunDetailsRows"
+
+function SetUpReactTable(run: Run, jobId: string) {
+  return (
+    <TableContainer>
+      <Table className="details-table-container">
+        <TableBody>
+          <RunDetailsRows run={run} jobId={jobId} />
+        </TableBody>
+      </Table>
+    </TableContainer>
+  )
+}
+
+describe("RunDetailsRow", () => {
+  it("Defaults", () => {
+    const run = { succeeded: true, cluster: "test", podNumber: 0, k8sId: "test" }
+    render(SetUpReactTable(run, "jobId"))
+    expect(screen.getByText("armada-jobId-0")).toBeInTheDocument()
+  })
+  it("All Parameters", () => {
+    const run = {
+      node: "demo",
+      podCreationTime: "42",
+      podStartTime: "42",
+      finishTime: "42",
+      error: "NoErrorInTest",
+      succeeded: true,
+      cluster: "test",
+      podNumber: 0,
+      k8sId: "test",
+    }
+    render(SetUpReactTable(run, "jobId"))
+    expect(screen.getByText("armada-jobId-0")).toBeInTheDocument()
+    expect(screen.getByText("NoErrorInTest")).toBeInTheDocument()
+  })
+})

--- a/internal/lookout/ui/src/components/job-dialog/RunDetailsRows.tsx
+++ b/internal/lookout/ui/src/components/job-dialog/RunDetailsRows.tsx
@@ -7,13 +7,16 @@ import "./Details.css"
 
 interface RunDetailsRowsProps {
   run: Run
+  jobId?: string
 }
 
-export function RunDetailsRows(props: RunDetailsRowsProps) {
+export default function RunDetailsRows(props: RunDetailsRowsProps) {
+  const armadaPodName = props.jobId ? `armada-${props.jobId}-${props.run.podNumber.toString()}` : null
   return (
     <>
       <DetailRow name="Cluster" value={props.run.cluster} />
       <DetailRow name="Pod number" value={props.run.podNumber.toString()} />
+      {armadaPodName && <DetailRow name="Pod Name" value={armadaPodName} />}
       <DetailRow name="Kubernetes Id" value={props.run.k8sId} />
       {props.run.node && <DetailRow name="Cluster node" value={props.run.node} />}
       {props.run.podCreationTime && <DetailRow name="Scheduled on cluster" value={props.run.podCreationTime} />}


### PR DESCRIPTION
Fix https://github.com/G-Research/armada/issues/905

There was one thing that isn't clear.  If you are rendering PreviousRuns, I don't believe the Run interface has a jobId.  It wasn't clear to me if I can assume all Runs have the same id.  For now, I left the type as optional so not to break this functionality.  

I am unsure how to test this.  Any ideas?