### PR TITLE
Ensure all references to Armada are capitalized

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -40,7 +40,7 @@ There are additional API methods defined in proto specifications, which are used
 ## REST
 The REST API only exposes the public part of the gRPC API and it is implemented using grpc-gateway (https://github.com/grpc-ecosystem/grpc-gateway).
 
-Swagger json specification can be found [here](../pkg/api/api.swagger.json) and is also served by armada under `my.armada.deployment/api/swagger.json`
+Swagger json specification can be found [here](../pkg/api/api.swagger.json) and is also served by Armada under `my.armada.deployment/api/swagger.json`
 
 ## Authentication
 
@@ -49,7 +49,7 @@ Both gRPC and REST API support the same set of authentication methods. In the ca
 See helm chart [documentation](./helm/server.md#Authentication) for different server authentication schemes setup.
 
 ### No Auth
-For testing, armada can be configured to accept no authentication. All operations will use user `anonymous` in this case.
+For testing, Armada can be configured to accept no authentication. All operations will use user `anonymous` in this case.
 
 ### OpenId Authentication
 When server is configured with OpenID, it will accept authorization header or metadata in the form `Bearer {oauth_token}`.

--- a/docs/aws-ec2/README.md
+++ b/docs/aws-ec2/README.md
@@ -2,7 +2,7 @@
 
 ## Background
 
-For development, you might want to set up an Amazon EC2 instance as the resource requirements for Armada are substantial. A typical armada installation requires a system with at least 16GB of memory to perform well. Running Armada on a laptop made before ~2017 will typically eat battery life and result in a slower UI.
+For development, you might want to set up an Amazon EC2 instance as the resource requirements for Armada are substantial. A typical Armada installation requires a system with at least 16GB of memory to perform well. Running Armada on a laptop made before ~2017 will typically eat battery life and result in a slower UI.
 
 Note: As of June 2022, not all Armada dependencies reliably build on a Mac M1 using standard package management. So if you have an M1 Mac, working on EC2 or another external server is your best bet.
 

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -96,7 +96,7 @@ To run NATS Streaming for development you can use docker:
 docker run -d -p 4223:4223 -p 8223:8223 nats-streaming -p 4223 -m 8223
 ```
 
-For armada configuration check end to end test setup:
+For Armada configuration check end to end test setup:
 ```bash
 go run ./cmd/armada/main.go --config ./e2e/setup/insecure-armada-auth-config.yaml --config ./e2e/setup/nats/armada-config.yaml
 ```
@@ -183,7 +183,7 @@ make e2e-stop-cluster
 
 This project uses code generation.
 
-The armada api is defined using proto files which are used to generate Go source code (and the c# client) for our gRPC communication.
+The Armada api is defined using proto files which are used to generate Go source code (and the c# client) for our gRPC communication.
 
 To generate source code from proto files:
 


### PR DESCRIPTION
Found and fixed all instances of Armada being lowercased outside of
a command / code block and capitalized them.