### PR TITLE
Fix when GHAs run

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,4 +1,10 @@
-on: [push]
+on:
+  push:
+    branches-ignore:
+      - master
+  pull_request:
+    branches-ignore:
+      - gh-pages
 
 jobs:
   go-lint:

--- a/.github/workflows/not-python.yml
+++ b/.github/workflows/not-python.yml
@@ -11,8 +11,8 @@ on:
       - '.github/workflows/python.yml'
       - 'docs/python_armada_client.md'
   pull_request:
-    branches:
-      - master
+    branches-ignore:
+      - gh-pages
     paths-ignore:
       - 'client/python/**'
       - 'build/python-client/**'

--- a/.github/workflows/not-python.yml
+++ b/.github/workflows/not-python.yml
@@ -13,6 +13,12 @@ on:
   pull_request:
     branches:
       - master
+    paths-ignore:
+      - 'client/python/**'
+      - 'build/python-client/**'
+      - 'pkg/api/*.proto'
+      - '.github/workflows/python.yml'
+      - 'docs/python_armada_client.md'
 
 jobs:
   run-tox:

--- a/.github/workflows/not-python.yml
+++ b/.github/workflows/not-python.yml
@@ -2,12 +2,17 @@ name: Run Python Linting and Unit Tests
 
 on:
   push:
+    branches-ignore:
+      - master
     paths-ignore:
       - 'client/python/**'
       - 'build/python-client/**'
       - 'pkg/api/*.proto'
       - '.github/workflows/python.yml'
       - 'docs/python_armada_client.md'
+  pull_request:
+    branches:
+      - master
 
 jobs:
   run-tox:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,7 +3,7 @@ name: Deploy GH Pages
 on:
   push:
     branches: 
-      - master 
+      - master
     paths:
       - 'docs/*.md'
       - 'docs/quickstart'

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -11,8 +11,8 @@ on:
       - '.github/workflows/python.yml'
       - 'docs/python_armada_client.md'
   pull_request:
-    branches:
-      - master
+    branches-ignore:
+      - gh-pages
     paths:
       - 'client/python/**'
       - 'build/python-client/**'

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,6 +13,12 @@ on:
   pull_request:
     branches:
       - master
+    paths:
+      - 'client/python/**'
+      - 'build/python-client/**'
+      - 'pkg/api/*.proto'
+      - '.github/workflows/python.yml'
+      - 'docs/python_armada_client.md'
 
 jobs:
   run-tox:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -2,12 +2,17 @@ name: Run Python Linting and Unit Tests
 
 on:
   push:
+    branches-ignore:
+      - master
     paths:
       - 'client/python/**'
       - 'build/python-client/**'
       - 'pkg/api/*.proto'
       - '.github/workflows/python.yml'
       - 'docs/python_armada_client.md'
+  pull_request:
+    branches:
+      - master
 
 jobs:
   run-tox:

--- a/.github/workflows/ts.yml
+++ b/.github/workflows/ts.yml
@@ -1,9 +1,14 @@
 on:
   push:
+    branches-ignore:
+      - master
     paths:
       - 'internal/lookout/ui/**'
       - 'build/lookout/**'
       - '.github/workflows/ts.yml'
+  pull_request:
+    branches-ignore:
+      - gh-pages
 
 jobs:
   ts-lint:

--- a/.github/workflows/ts.yml
+++ b/.github/workflows/ts.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches-ignore:
       - gh-pages
+    paths:
+      - 'internal/lookout/ui/**'
+      - 'build/lookout/**'
+      - '.github/workflows/ts.yml'
 
 jobs:
   ts-lint:


### PR DESCRIPTION
Aiming to make it run on pushes of all branches (except master, which
do not need to run tests after merge -- this will change when releasing
is moved to GHA).

Should also fix issue where PRs from forks don't have the job runners
show up in the list at the bottom of the pull request.

Related: Issue #1037