### PR TITLE
Improve pulsar invocation and handling in docs/dev/setup.sh script

### DIFF
--- a/docs/dev/docker-compose.yaml
+++ b/docs/dev/docker-compose.yaml
@@ -28,8 +28,11 @@ services:
       - "4223:4223"
       - "8223:8223"
   pulsar:
-    image: apachepulsar/pulsar:2.9.2
+    image: apachepulsar/pulsar:2.10.0
+    profiles: ["linux"]
     container_name: pulsar
-    command: bin/pulsar standalone
+    volumes:
+      - ../../scripts/pulsar.sh:/pulsar.sh
+    entrypoint: sh -c "bin/pulsar standalone && . /pulsar.sh"
     ports: 
       - "6650:6650"

--- a/docs/dev/setup.sh
+++ b/docs/dev/setup.sh
@@ -7,11 +7,23 @@ if [ -z "$stream_backend" ] || (echo "stan jetstream" | grep -v -q "$stream_back
 fi
 echo "Using $stream_backend"
 
+COMPOSE_CMD='docker-compose'
+
+DCLIENT_VERSION=$(docker version -f '{{.Client.Version}}')
+if echo $DCLIENT_VERSION | grep -q '^2' ; then
+  COMPOSE_CMD='docker compose'
+fi
+
 kind create cluster --name demo-a --config ./docs/dev/kind.yaml
 
-docker-compose -f ./docs/dev/docker-compose.yaml up -d
+OSTYPE=$(uname -s)
+if [ $OSTYPE == "Linux" ]; then
+  $COMPOSE_CMD --profile linux -f ./docs/dev/docker-compose.yaml up -d
+else
+  $COMPOSE_CMD -f ./docs/dev/docker-compose.yaml up -d
+fi
+
 sleep 10s
-bash scripts/pulsar.sh
 
 go run ./cmd/lookout/main.go --migrateDatabase
 

--- a/docs/dev/setup.sh
+++ b/docs/dev/setup.sh
@@ -23,7 +23,7 @@ else
   $COMPOSE_CMD -f ./docs/dev/docker-compose.yaml up -d
 fi
 
-sleep 10s
+sleep 10
 
 go run ./cmd/lookout/main.go --migrateDatabase
 


### PR DESCRIPTION
This is just a few improvements to the `docs/dev/setup.sh` script, for local system setup of Armada, per discussion with @kannon92 . 

Use `docker compose` (not `docker-compose`; this is the Compose V2 new preferred invocation) if running Docker client V20 or higher. Use compose `--profile profileArray` option to run Pulsar container only if on Linux (to be removed when Pulsar is stable on Mac M1 systems). Run `pulsar-admin` setup commands script directly from docker-compose file, rather than afterwards in setup.sh script. Finally, remove the 's' (seconds) suffix on the sleep invocation. (This is not portable and does not work on macOS (it's a GNU addition).)
