### PR TITLE
Remove install and build from script.  It is not used

### DIFF
--- a/.github/workflows/not-python.yml
+++ b/.github/workflows/not-python.yml
@@ -10,6 +10,7 @@ on:
       - 'pkg/api/*.proto'
       - '.github/workflows/python.yml'
       - 'docs/python_armada_client.md'
+      - 'scripts/build-python-client.sh'
   pull_request:
     branches-ignore:
       - gh-pages
@@ -19,6 +20,7 @@ on:
       - 'pkg/api/*.proto'
       - '.github/workflows/python.yml'
       - 'docs/python_armada_client.md'
+      - 'scripts/build-python-client.sh'
 
 jobs:
   run-tox:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -10,6 +10,8 @@ on:
       - 'pkg/api/*.proto'
       - '.github/workflows/python.yml'
       - 'docs/python_armada_client.md'
+      - 'scripts/build-python-client.sh'
+
   pull_request:
     branches-ignore:
       - gh-pages
@@ -19,6 +21,7 @@ on:
       - 'pkg/api/*.proto'
       - '.github/workflows/python.yml'
       - 'docs/python_armada_client.md'
+      - 'scripts/build-python-client.sh'
 
 jobs:
   run-tox:

--- a/scripts/build-python-client.sh
+++ b/scripts/build-python-client.sh
@@ -32,7 +32,3 @@ sed -i 's/from google.api/from armada_client.google.api/g' client/python/armada_
 sed -i 's/from google.api/from armada_client.google.api/g' client/python/armada_client/google/api/*.py
 
 find client/python/armada_client/ -name '*.py' | xargs sed -i 's/from k8s.io/from armada_client.k8s.io/g'
-
-cd client/python/armada_client
-poetry install
-poetry build


### PR DESCRIPTION
Remove poetry install and build as we are doing this work in tox.  

This just makes our build take longer and we don't reference these build artifacts.  