### PR TITLE
Move around quickstart to fix 404s

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,7 +27,8 @@ jobs:
       - name: Copy site files
         run: |
           cp master/docs/*.md gh-pages/
-          cp -r master/docs/quickstart gh-pages/_pages
+          rm gh-pages/docs-readme.md
+          cp -r master/docs/quickstart gh-pages/
           cp master/CODE_OF_CONDUCT.md master/CONTRIBUTING.md gh-pages/_pages/
 
       - name: Commit GH Pages

--- a/docs/docs-readme.md
+++ b/docs/docs-readme.md
@@ -1,0 +1,27 @@
+# Docs Readme
+
+## Overview
+Docs added to this directory are automatically copied into armadaproject.io.
+
+For example, if you wanted to document bananas, and you added `bananas.md`,
+once committed to master that would be published at
+`https://armadaproject.io/bananas/`.
+
+## Complex pages with assets
+If you'd like to add a more complex page, such as one with images or other
+linked assets, you have to be very careful to ensure links will work both
+for people viewing in github and for those viewing via armadaproject.io.
+
+The easiest way to accomplish this is by using page bundles. See quickstart
+as as example: quickstart/index.md is the actual content, with links to
+various images using relative pathing; e.g. `./my-image.png`. This is 
+considered a page bundle by jekyll (github pages) and are rendered as a 
+single page at `quickstart/`.
+
+In order to get this page bundle pushed to gh-pages branch, you'll need
+to adjust the github workflow in `.github/workflows/pages.yml` to add your
+new page bundle as well.
+
+## Removing pages
+If you put a commit here to remove a page, you will need to also commit
+to the gh-pages branch to remove that page.

--- a/docs/quickstart/index.md
+++ b/docs/quickstart/index.md
@@ -117,7 +117,7 @@ curl -X POST -i http://admin:prom-operator@localhost:30001/api/dashboards/import
 
 Grafana:
 
-![Armada Grafana dashboard](./quickstart/grafana-screenshot.png "Armada Grafana dashboard")
+![Armada Grafana dashboard](./grafana-screenshot.png "Armada Grafana dashboard")
 
 Note that the jobs in this demo simply run the `sleep` command so do not consume many resources.
 
@@ -130,4 +130,4 @@ kubectl port-forward svc/armada-lookout 8080:8080
 ```
 Then access it by opening [http://localhost:8080](http://localhost:8080) in your browser.
 
-![Lookout UI](./quickstart/lookout.png "Lookout UI")
+![Lookout UI](./lookout.png "Lookout UI")


### PR DESCRIPTION
Right now, the links in quickstart.md are setup to work in github,
and are rendered broken in armadaproject.io.

This change, and it's accompanying change in gh-pages branch, corrects
this and adds documentation to guide people making this kind of change
in the future.

Issue: #889