### PR TITLE
Fix of profile linux bug

### DIFF
--- a/docs/dev/teardown.sh
+++ b/docs/dev/teardown.sh
@@ -4,4 +4,16 @@
 
 kind delete cluster --name demo-a
 
-docker-compose -f ./docs/dev/docker-compose.yaml down
+COMPOSE_CMD='docker-compose'
+
+DCLIENT_VERSION=$(docker version -f '{{.Client.Version}}')
+if echo $DCLIENT_VERSION | grep -q '^2' ; then
+  COMPOSE_CMD='docker compose'
+fi
+
+OSTYPE=$(uname -s)
+if [ $OSTYPE == "Linux" ]; then
+  $COMPOSE_CMD -f ./docs/dev/docker-compose.yaml --profile linux down
+else
+  $COMPOSE_CMD -f ./docs/dev/docker-compose.yaml down
+fi


### PR DESCRIPTION
If we enable the profile flag for docker-compose, we need it for teardown.  

If we don't have this change, we have to remove the pulsar container before you are able to teardown the compose.