### PR TITLE
Improve gh-pages marketing

### DIFF
--- a/_includes/home-sample.html
+++ b/_includes/home-sample.html
@@ -8,7 +8,7 @@
           <div class="col-lg-7 mobile" style="text-align: center;">
             <img class="ml-lg-5 mobile-armada" src="{{ '/assets/img/brand/armada-under-shadow.svg' | relative_url }}" />
           </div>
-          <p class="lead mt-0">Armada is an application to achieve high throughput of run-to-completion jobs on multiple Kubernetes clusters. <br /><br />It stores queues for users/projects with pod specifications and creates these pods once there is available resource in one of the connected Kubernetes clusters.</p>
+          <p class="lead mt-0">Armada is a multi-kubernetes-cluster batch job meta-scheduler.<br /><br />It helps organizations distribute millions of batch jobs per day across many nodes across many clusters.</p>
           <br>
           <p><a href="https://circleci.com/gh/G-Research/armada" rel="nofollow"><img src="https://camo.githubusercontent.com/e7f830f920356607471e7e797a849e67e7cf9c46/68747470733a2f2f636972636c6563692e636f6d2f67682f68656c6d2f68656c6d2e7376673f7374796c653d736869656c64" alt="CircleCI" data-canonical-src="https://circleci.com/gh/helm/helm.svg?style=shield" style="max-width:100%;"></a>
             <a href="https://goreportcard.com/report/github.com/G-Research/armada" rel="nofollow"><img src="https://camo.githubusercontent.com/f8375a7adc7b9391bd55796acd5b5557b7d87b74/68747470733a2f2f676f7265706f7274636172642e636f6d2f62616467652f6769746875622e636f6d2f472d52657365617263682f61726d616461" alt="Go Report Card" data-canonical-src="https://goreportcard.com/badge/github.com/G-Research/armada" style="max-width:100%;"></a></p>


### PR DESCRIPTION
@severinson I can't recall all of the changes we spoke about when we sat down and looked at the Armada website, but I do remember that I wanted to change the text of the subheading here.  

I know there's some controversy or sensitivity towards referring to Armada as a batch scheduler, but maybe we can call it a "meta scheduler" and it'll be clearer what it does without running afoul of those feelings?

If you have other suggestions that you can recall, I'll be happy to make more edits. I should have done this immediately when we spoke about it!