### PR TITLE
Do not rely on system-provided golang for python jobs

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -30,6 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: ./.github/workflows/go-setup
       - uses: actions/setup-python@v2
         with:
           python-version: '3.8.10'


### PR DESCRIPTION
This is a required step to ensure jobs will be able to pass in the
future against golang 1.18.

Issue #1142