### PR TITLE
Go setup is useless without matrix set

### DIFF
--- a/.github/workflows/airflow-operator.yml
+++ b/.github/workflows/airflow-operator.yml
@@ -40,8 +40,15 @@ on:
 jobs:
   run-tox:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # We technically support 1.16 and 1.18; but this just needs any
+        # go version new enough to generate python proto files; 1.18 is
+        # more future-proof, so use it.
+        go: [ '1.18' ]
     steps:
       - uses: actions/checkout@v2
+      - uses: ./.github/workflows/go-setup
       - uses: actions/setup-python@v2
         with:
           python-version: '3.8.10'

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -28,6 +28,12 @@ on:
 jobs:
   run-tox:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # We technically support 1.16 and 1.18; but this just needs any
+        # go version new enough to generate python proto files; 1.18 is
+        # more future-proof, so use it.
+        go: [ '1.18' ]
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/workflows/go-setup
@@ -48,6 +54,12 @@ jobs:
         working-directory: client/python
   python-integration-tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # We technically support 1.16 and 1.18; but this just needs any
+        # go version new enough to generate python proto files; 1.18 is
+        # more future-proof, so use it.
+        go: [ '1.18' ]
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/workflows/go-setup


### PR DESCRIPTION
Before this change, the go-setup include was a noop due to a missing
go version identifier and go-setup itself was missing from airflow-operator.yml.

These jobs only need go to generate the python files from the proto files. Any
version of go we support will work; so I use 1.18 to future proof it. No need to matrix
python tests on go versions :).

Issue #1142