### PR TITLE
Python client version bump: 0.2.0

### DIFF
--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "armada_client"
-version = "0.1.0-dev"
+version = "0.2.0"
 description = "Armada gRPC API python client"
 readme = "README.md"
 requires-python = ">=3.7,<3.9"


### PR DESCRIPTION
This is a prerequisite to pushing this version to pypi.

Issue #1072 