### PR TITLE
[DO NOT MERGE] Make Job Utilisation Events Opt-Out

### DIFF
--- a/internal/executor/domain/pod_metadata.go
+++ b/internal/executor/domain/pod_metadata.go
@@ -13,4 +13,5 @@ const (
 	IngressReported          = "ingress_reported"
 	MarkedForDeletion        = "deletion_requested"
 	JobDoneAnnotation        = "reported_done"
+	Utilisation              = "armada_utilisation_events"
 )

--- a/internal/executor/util/kubernetes_object.go
+++ b/internal/executor/util/kubernetes_object.go
@@ -171,8 +171,9 @@ func CreatePod(job *api.Job, defaults *configuration.PodDefaults, i int) *v1.Pod
 		domain.PodCount:  strconv.Itoa(len(allPodSpecs)),
 	})
 	annotation := util.MergeMaps(job.Annotations, map[string]string{
-		domain.JobSetId: job.JobSetId,
-		domain.Owner:    job.Owner,
+		domain.JobSetId:    job.JobSetId,
+		domain.Owner:       job.Owner,
+		domain.Utilisation: "true", //TODO: take this from job
 	})
 
 	setRestartPolicyNever(podSpec)

--- a/internal/executor/util/pod_util.go
+++ b/internal/executor/util/pod_util.go
@@ -66,6 +66,18 @@ func IsManagedPod(pod *v1.Pod) bool {
 	return ok
 }
 
+func IsUtilisationEnabledPod(pod *v1.Pod) bool {
+	enabledStr, ok := pod.Annotations[domain.Utilisation]
+	if ok {
+		enabled, _ := strconv.ParseBool(enabledStr)
+		return enabled
+	} else {
+		// previously all pods were utilisation enabled implicitly so to maintain compatibility we
+		// consider a missing annotation to be enabled
+		return true
+	}
+}
+
 func GetManagedPodSelector() labels.Selector {
 	return managedPodSelector.DeepCopySelector()
 }

--- a/internal/executor/utilisation/job_utilisation_reporter.go
+++ b/internal/executor/utilisation/job_utilisation_reporter.go
@@ -95,7 +95,7 @@ func (r *UtilisationEventReporter) ReportUtilisationEvents() {
 }
 
 func (r *UtilisationEventReporter) updatePod(pod *v1.Pod) {
-	if !util.IsManagedPod(pod) {
+	if !util.IsManagedPod(pod) || !util.IsUtilisationEnabledPod(pod) {
 		return
 	}
 


### PR DESCRIPTION
Job Utilisation Events are expensive to store.  This change adds an extra field to `api.Job` that users can specify to tell Armada that they do no need these events created.
