### PR TITLE
Do not pass extra ${USER} to id

### DIFF
--- a/makefile
+++ b/makefile
@@ -49,7 +49,7 @@ else
 endif
 
 ifeq ($(DOCKER_RUN_AS_USER),)
-	DOCKER_RUN_AS_USER = -u $(shell id -u ${USER}):$(shell id -g ${USER})
+	DOCKER_RUN_AS_USER = -u $(shell id -u):$(shell id -g)
 endif
 ifeq ($(platform),windows32)
 	DOCKER_RUN_AS_USER =


### PR DESCRIPTION
The id tool, without a user passed, will default to current user.
This is the behavior we want. In trying to pass the user, we
introduce quoting issues which cause failures on AD-style unix
usernames; e.g. DOMAIN\username.

Co-Authored-By: Kevin Hannon <kannon1992@gmail.com>
Closes: #1311 