### PR TITLE
Remove redundant proto file logic and speed up copying (#1319)

### DIFF
--- a/build/proto/Dockerfile
+++ b/build/proto/Dockerfile
@@ -51,35 +51,10 @@ RUN curl -sSL https://www.nuget.org/api/v2/package/Grpc.Tools/2.46.3 --output gr
     mv grpctools/tools/linux_x64/grpc_csharp_plugin /usr/local/bin/grpc_csharp_plugin && \
     chmod +x /usr/local/bin/grpc_csharp_plugin
 
-# Remove after I copy proto files
-ARG GOGO_PROTOBUF_VERSION
-RUN GO111MODULE=on go get github.com/gogo/protobuf/protoc-gen-gogofaster@v${GOGO_PROTOBUF_VERSION} && \
-    mkdir -p /proto/github.com/gogo/protobuf && \
-    cp -r /go/pkg/mod/github.com/gogo/protobuf@v${GOGO_PROTOBUF_VERSION}/* /proto/github.com/gogo/protobuf && \
-    mkdir -p /proto/google && \
-    cp -r /go/pkg/mod/github.com/gogo/protobuf@v${GOGO_PROTOBUF_VERSION}/protobuf/google/* /proto/google
-
-ARG GRPC_GATEWAY_VERSION
-RUN GO111MODULE=on go get \
-   github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway@v${GRPC_GATEWAY_VERSION} \
-    github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger@v${GRPC_GATEWAY_VERSION} && \
-    mkdir -p /proto/google && \
-    cp -r /go/pkg/mod/github.com/grpc-ecosystem/grpc-gateway@v${GRPC_GATEWAY_VERSION}/third_party/googleapis/google/* /proto/google
-
-# Remove after you can inject proto files
-ARG K8S_VERSION
-RUN go mod download k8s.io/api@v${K8S_VERSION} && \
-    go mod download k8s.io/apimachinery@v${K8S_VERSION} && \
-    mkdir -p /proto/k8s.io/api && \
-    mkdir -p /proto/k8s.io/apimachinery && \
-    cp -r $(go env GOPATH)/pkg/mod/k8s.io/api@v${K8S_VERSION}/* /proto/k8s.io/api && \
-    cp -r $(go env GOPATH)/pkg/mod/k8s.io/apimachinery@v${K8S_VERSION}/* /proto/k8s.io/apimachinery
-
 ARG GOLANG_VERSION
 FROM --platform=linux/amd64 golang:${GOLANG_VERSION}-buster
 COPY --from=builder /usr/local/bin /usr/local/bin
 COPY --from=builder /go/bin /usr/local/bin
-COPY --from=builder /proto /proto
 
 RUN curl -OL https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb
 RUN dpkg -i packages-microsoft-prod.deb

--- a/build/proto/Dockerfile
+++ b/build/proto/Dockerfile
@@ -51,6 +51,14 @@ RUN curl -sSL https://www.nuget.org/api/v2/package/Grpc.Tools/2.46.3 --output gr
     mv grpctools/tools/linux_x64/grpc_csharp_plugin /usr/local/bin/grpc_csharp_plugin && \
     chmod +x /usr/local/bin/grpc_csharp_plugin
 
+ARG GOGO_PROTOBUF_VERSION
+RUN GO111MODULE=on go get github.com/gogo/protobuf/protoc-gen-gogofaster@v${GOGO_PROTOBUF_VERSION}
+
+ARG GRPC_GATEWAY_VERSION
+RUN GO111MODULE=on go get \
+   github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway@v${GRPC_GATEWAY_VERSION} \
+    github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger@v${GRPC_GATEWAY_VERSION}
+
 ARG GOLANG_VERSION
 FROM --platform=linux/amd64 golang:${GOLANG_VERSION}-buster
 COPY --from=builder /usr/local/bin /usr/local/bin

--- a/build/proto/Dockerfile.arm64
+++ b/build/proto/Dockerfile.arm64
@@ -60,6 +60,14 @@ RUN curl -sSL https://www.nuget.org/api/v2/package/Grpc.Tools/2.46.3 --output gr
     mv grpctools/tools/linux_arm64/grpc_csharp_plugin /usr/local/bin/grpc_csharp_plugin && \
     chmod +x /usr/local/bin/grpc_csharp_plugin
 
+ARG GOGO_PROTOBUF_VERSION
+RUN GO111MODULE=on go get github.com/gogo/protobuf/protoc-gen-gogofaster@v${GOGO_PROTOBUF_VERSION}
+
+ARG GRPC_GATEWAY_VERSION
+RUN GO111MODULE=on go get \
+   github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway@v${GRPC_GATEWAY_VERSION} \
+    github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger@v${GRPC_GATEWAY_VERSION}
+
 ARG GOLANG_VERSION
 FROM --platform=linux/arm64 golang:${GOLANG_VERSION}-buster
 COPY --from=builder /usr/local/bin /usr/local/bin

--- a/build/proto/Dockerfile.arm64
+++ b/build/proto/Dockerfile.arm64
@@ -60,35 +60,11 @@ RUN curl -sSL https://www.nuget.org/api/v2/package/Grpc.Tools/2.46.3 --output gr
     mv grpctools/tools/linux_arm64/grpc_csharp_plugin /usr/local/bin/grpc_csharp_plugin && \
     chmod +x /usr/local/bin/grpc_csharp_plugin
 
-# Remove after I copy proto files
-ARG GOGO_PROTOBUF_VERSION
-RUN GO111MODULE=on go get github.com/gogo/protobuf/protoc-gen-gogofaster@v${GOGO_PROTOBUF_VERSION} && \
-    mkdir -p /proto/github.com/gogo/protobuf && \
-    cp -r /go/pkg/mod/github.com/gogo/protobuf@v${GOGO_PROTOBUF_VERSION}/* /proto/github.com/gogo/protobuf && \
-    mkdir -p /proto/google && \
-    cp -r /go/pkg/mod/github.com/gogo/protobuf@v${GOGO_PROTOBUF_VERSION}/protobuf/google/* /proto/google
-
-ARG GRPC_GATEWAY_VERSION
-RUN GO111MODULE=on go get \
-   github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway@v${GRPC_GATEWAY_VERSION} \
-    github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger@v${GRPC_GATEWAY_VERSION} && \
-    mkdir -p /proto/google && \
-    cp -r /go/pkg/mod/github.com/grpc-ecosystem/grpc-gateway@v${GRPC_GATEWAY_VERSION}/third_party/googleapis/google/* /proto/google
-
-# Remove after you can inject proto files
-ARG K8S_VERSION
-RUN go mod download k8s.io/api@v${K8S_VERSION} && \
-    go mod download k8s.io/apimachinery@v${K8S_VERSION} && \
-    mkdir -p /proto/k8s.io/api && \
-    mkdir -p /proto/k8s.io/apimachinery && \
-    cp -r $(go env GOPATH)/pkg/mod/k8s.io/api@v${K8S_VERSION}/* /proto/k8s.io/api && \
-    cp -r $(go env GOPATH)/pkg/mod/k8s.io/apimachinery@v${K8S_VERSION}/* /proto/k8s.io/apimachinery
-
 ARG GOLANG_VERSION
 FROM --platform=linux/arm64 golang:${GOLANG_VERSION}-buster
 COPY --from=builder /usr/local/bin /usr/local/bin
 COPY --from=builder /go/bin /usr/local/bin
-COPY --from=builder /proto /proto
+
 RUN apt-get update -y
 # dotnet requires the ICU libraries
 RUN apt-get install -y libicu-dev 

--- a/makefile
+++ b/makefile
@@ -446,7 +446,6 @@ setup-proto: download
 	# first delete files in this directory - by default it has write perms disabled.
 	if [ -d proto/google/protobuf/compiler ]; then  chmod 0755 proto/google/protobuf/compiler ; fi
 	rm -rf proto
-	mkdir -p proto
 	mkdir -p proto/google/api
 	mkdir -p proto/google/protobuf
 	mkdir -p proto/k8s.io/apimachinery/pkg/api/resource
@@ -460,21 +459,20 @@ setup-proto: download
 	mkdir -p proto/github.com/gogo/protobuf/gogoproto/
 
 # Copy third party annotations from grpc-ecosystem
-
-	$(GO_CMD) cp /go/pkg/mod/github.com/grpc-ecosystem/grpc-gateway$(GRPC_GATEWAY_VERSION)/third_party/googleapis/google/api/annotations.proto proto/google/api
-	$(GO_CMD) cp /go/pkg/mod/github.com/grpc-ecosystem/grpc-gateway$(GRPC_GATEWAY_VERSION)/third_party/googleapis/google/api/http.proto proto/google/api
-	$(GO_CMD) cp -r /go/pkg/mod/github.com/gogo/protobuf$(GOGO_PROTOBUF_VERSION)/protobuf/google/protobuf proto/google
-	$(GO_CMD) cp /go/pkg/mod/github.com/gogo/protobuf$(GOGO_PROTOBUF_VERSION)/gogoproto/gogo.proto proto/github.com/gogo/protobuf/gogoproto/
-
-#K8S MACHINERY API COPY
-	$(GO_CMD) cp /go/pkg/mod/k8s.io/apimachinery$(K8_APIM_VERSION)/pkg/api/resource/generated.proto proto/k8s.io/apimachinery/pkg/api/resource/
-	$(GO_CMD) cp /go/pkg/mod/k8s.io/apimachinery$(K8_APIM_VERSION)/pkg/apis/meta/v1/generated.proto proto/k8s.io/apimachinery/pkg/apis/meta/v1
-	$(GO_CMD) cp /go/pkg/mod/k8s.io/apimachinery$(K8_APIM_VERSION)/pkg/runtime/generated.proto proto/k8s.io/apimachinery/pkg/runtime
-	$(GO_CMD) cp /go/pkg/mod/k8s.io/apimachinery$(K8_APIM_VERSION)/pkg/runtime/schema/generated.proto proto/k8s.io/apimachinery/pkg/runtime/schema/
-	$(GO_CMD) cp /go/pkg/mod/k8s.io/apimachinery$(K8_APIM_VERSION)/pkg/util/intstr/generated.proto proto/k8s.io/apimachinery/pkg/util/intstr/
-#K8S API COPY
-	$(GO_CMD) cp /go/pkg/mod/k8s.io/api$(K8_API_VERSION)/networking/v1/generated.proto proto/k8s.io/api/networking/v1
-	$(GO_CMD) cp /go/pkg/mod/k8s.io/api$(K8_API_VERSION)/core/v1/generated.proto proto/k8s.io/api/core/v1
+	$(GO_CMD) bash -c " \
+	 cp /go/pkg/mod/github.com/grpc-ecosystem/grpc-gateway$(GRPC_GATEWAY_VERSION)/third_party/googleapis/google/api/annotations.proto proto/google/api ; \
+	 cp /go/pkg/mod/github.com/grpc-ecosystem/grpc-gateway$(GRPC_GATEWAY_VERSION)/third_party/googleapis/google/api/http.proto proto/google/api ; \
+	 cp -r /go/pkg/mod/github.com/gogo/protobuf$(GOGO_PROTOBUF_VERSION)/protobuf/google/protobuf proto/google ; \
+	 cp /go/pkg/mod/github.com/gogo/protobuf$(GOGO_PROTOBUF_VERSION)/gogoproto/gogo.proto proto/github.com/gogo/protobuf/gogoproto/ ; \
+	 \
+	 cp /go/pkg/mod/k8s.io/apimachinery$(K8_APIM_VERSION)/pkg/api/resource/generated.proto proto/k8s.io/apimachinery/pkg/api/resource/ ; \
+	 cp /go/pkg/mod/k8s.io/apimachinery$(K8_APIM_VERSION)/pkg/apis/meta/v1/generated.proto proto/k8s.io/apimachinery/pkg/apis/meta/v1 ; \
+	 cp /go/pkg/mod/k8s.io/apimachinery$(K8_APIM_VERSION)/pkg/runtime/generated.proto proto/k8s.io/apimachinery/pkg/runtime ; \
+	 cp /go/pkg/mod/k8s.io/apimachinery$(K8_APIM_VERSION)/pkg/runtime/schema/generated.proto proto/k8s.io/apimachinery/pkg/runtime/schema/ ; \
+	 cp /go/pkg/mod/k8s.io/apimachinery$(K8_APIM_VERSION)/pkg/util/intstr/generated.proto proto/k8s.io/apimachinery/pkg/util/intstr/ ; \
+	 \
+	 cp /go/pkg/mod/k8s.io/api$(K8_API_VERSION)/networking/v1/generated.proto proto/k8s.io/api/networking/v1 ; \
+	 cp /go/pkg/mod/k8s.io/api$(K8_API_VERSION)/core/v1/generated.proto proto/k8s.io/api/core/v1 "
 
 	chmod -R ug+w proto
 


### PR DESCRIPTION
Remove the redundant proto file copying that I added in the recent dotnet-grpc changes; speed up proto file copying operations in the makefile by running them all in just one container instance, rather than in many sequential ones.

With these changes, running `make dotnet-grpc` goes from taking ~39 secs to ~12 secs on my Macbook Pro; on my AMD 12-core 32GB Linux desktop system, it goes from ~11.5 secs to ~6.8 secs. The generated artifacts are the same.

closes 1319