### PR TITLE
Publish .net grpc client to nuget

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -411,7 +411,7 @@ jobs:
           name: Publish Nuget
           command: |
             RELEASE_TAG=${CIRCLE_TAG#"v"}
-            make publish-nuget
+            make push-nuget
 
       - store_artifacts:
           path: bin/client/DotNet

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -408,7 +408,7 @@ jobs:
             make download # no-op if we restored from cache            
 
       - run:
-          name: Publish Nuget
+          name: Push dotnet clients to nuget
           command: |
             RELEASE_TAG=${CIRCLE_TAG#"v"}
             make push-nuget

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -383,20 +383,35 @@ jobs:
       - update-charts
 
   release-dotnet-client:
-    docker:
-      - image: mcr.microsoft.com/dotnet/core/sdk:3.0.101-alpine3.10
-    working_directory: /go/src/github.com/G-Research/armada
+    machine:
+      docker_layer_caching: true
+      image: ubuntu-2204:current
+      resource_class: xlarge
+    environment:
+      GO111MODULE: "on"
+      GOPATH: "/home/circleci/go"
+      GOCACHE: "/home/circleci/go/cache"
+    working_directory: ~/go/src/github.com/G-Research/armada
     steps:
       - checkout
-      
+
+      - restore_cache: # restore dependencies
+          keys:
+            - go-mod-v3-{{ checksum "go.sum" }}
+
       - run:
-          name: Release dotnet client
+          name: Download dependencies
+          command: |
+            curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+            chmod +x kubectl
+            sudo mv kubectl /usr/local/bin/
+            make download # no-op if we restored from cache            
+
+      - run:
+          name: Publish Nuget
           command: |
             RELEASE_TAG=${CIRCLE_TAG#"v"}
-            dotnet pack client/DotNet/Armada.Client/Armada.Client.csproj -c Release -p:PackageVersion=${RELEASE_TAG} -o ./bin/client/DotNet
-            dotnet nuget push ./bin/client/DotNet/G-Research.Armada.Client.${RELEASE_TAG}.nupkg -k ${NUGET_API_KEY} -s https://api.nuget.org/v3/index.json
-            dotnet pack client/DotNet/ArmadaProject.Io.Client/ArmadaProject.Io.Client.csproj -c Release -p:PackageVersion=${RELEASE_TAG} -o ./bin/client/DotNet
-            dotnet nuget push ./bin/client/DotNet/ArmadaProject.Io.Client.${RELEASE_TAG}.nupkg -k ${NUGET_API_KEY} -s https://api.nuget.org/v3/index.json
+            make publish-nuget
 
       - store_artifacts:
           path: bin/client/DotNet

--- a/makefile
+++ b/makefile
@@ -103,6 +103,11 @@ ifndef RELEASE_VERSION
 override RELEASE_VERSION = UNKNOWN_VERSION
 endif
 
+# The NUGET_API_KEY environment variable is set by circleci (to insert into dotnet nuget push commands)
+ifndef NUGET_API_KEY
+override NUGET_API_KEY = UNKNOWN_NUGET_API_KEY
+endif
+
 # use bash for running:
 export SHELL:=/bin/bash
 export SHELLOPTS:=$(if $(SHELLOPTS),$(SHELLOPTS):)pipefail:errexit

--- a/makefile
+++ b/makefile
@@ -522,6 +522,13 @@ dotnet: dotnet-setup setup-proto
 	$(DOTNET_CMD) dotnet build ./client/DotNet/Armada.Client /t:NSwag
 	$(DOTNET_CMD) dotnet build ./client/DotNet/ArmadaProject.Io.Client
 
+# publish dotnet clients to nuget. Requires RELEASE_TAG and NUGET_API_KEY env vars to be set
+publish-nuget: dotnet-setup setup-proto
+	$(DOTNET_CMD) dotnet pack client/DotNet/Armada.Client/Armada.Client.csproj -c Release -p:PackageVersion=${RELEASE_TAG} -o ./bin/client/DotNet
+	$(DOTNET_CMD) dotnet nuget push ./bin/client/DotNet/G-Research.Armada.Client.${RELEASE_TAG}.nupkg -k ${NUGET_API_KEY} -s https://api.nuget.org/v3/index.json
+	$(DOTNET_CMD) dotnet pack client/DotNet/ArmadaProject.Io.Client/ArmadaProject.Io.Client.csproj -c Release -p:PackageVersion=${RELEASE_TAG} -o ./bin/client/DotNet
+	$(DOTNET_CMD) dotnet nuget push ./bin/client/DotNet/ArmadaProject.Io.Client.${RELEASE_TAG}.nupkg -k ${NUGET_API_KEY} -s https://api.nuget.org/v3/index.json
+
 # Download all dependencies and install tools listed in internal/tools/tools.go
 download:
 	$(GO_TEST_CMD) go mod download

--- a/makefile
+++ b/makefile
@@ -522,8 +522,8 @@ dotnet: dotnet-setup setup-proto
 	$(DOTNET_CMD) dotnet build ./client/DotNet/Armada.Client /t:NSwag
 	$(DOTNET_CMD) dotnet build ./client/DotNet/ArmadaProject.Io.Client
 
-# publish dotnet clients to nuget. Requires RELEASE_TAG and NUGET_API_KEY env vars to be set
-publish-nuget: dotnet-setup setup-proto
+# Pack and push dotnet clients to nuget. Requires RELEASE_TAG and NUGET_API_KEY env vars to be set
+push-nuget: dotnet-setup setup-proto
 	$(DOTNET_CMD) dotnet pack client/DotNet/Armada.Client/Armada.Client.csproj -c Release -p:PackageVersion=${RELEASE_TAG} -o ./bin/client/DotNet
 	$(DOTNET_CMD) dotnet nuget push ./bin/client/DotNet/G-Research.Armada.Client.${RELEASE_TAG}.nupkg -k ${NUGET_API_KEY} -s https://api.nuget.org/v3/index.json
 	$(DOTNET_CMD) dotnet pack client/DotNet/ArmadaProject.Io.Client/ArmadaProject.Io.Client.csproj -c Release -p:PackageVersion=${RELEASE_TAG} -o ./bin/client/DotNet


### PR DESCRIPTION
Changes to the dotnet client nuget release steps in circleci now that generating the dependent proto files is a requirement.