### PR TITLE
Ensure `make airflow-operator` is called for release

### DIFF
--- a/.github/workflows/airflow-operator-release-to-pypi.yml
+++ b/.github/workflows/airflow-operator-release-to-pypi.yml
@@ -12,6 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/workflows/go-setup
+      - run: make airflow-operator
       - uses: ./.github/workflows/python-tests
         with:
           python-version: '3.8.10'


### PR DESCRIPTION
This is needed for airflow operator releases.