### PR TITLE
Fix .net client nuget release pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -410,8 +410,7 @@ jobs:
       - run:
           name: Push dotnet clients to nuget
           command: |
-            RELEASE_TAG=${CIRCLE_TAG#"v"}
-            make push-nuget
+            RELEASE_TAG=${CIRCLE_TAG#"v"} make push-nuget
 
       - store_artifacts:
           path: bin/client/DotNet

--- a/makefile
+++ b/makefile
@@ -109,6 +109,11 @@ ifndef RELEASE_VERSION
 override RELEASE_VERSION = UNKNOWN_VERSION
 endif
 
+# The RELEASE_TAG environment variable is set by circleci (to insert into go build and output filenames)
+ifndef RELEASE_TAG
+override RELEASE_TAG = UNKNOWN_TAG
+endif
+
 # The NUGET_API_KEY environment variable is set by circleci (to insert into dotnet nuget push commands)
 ifndef NUGET_API_KEY
 override NUGET_API_KEY = UNKNOWN_NUGET_API_KEY


### PR DESCRIPTION
- set env variable (not bash variable) with `make push-nuget` command.
- set `RELEASE_TAG` to `UNKNOWN_TAG` when not set in makefile