### PR TITLE
Fix ubuntu version in circleCI machine provisioning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ jobs:
   build_and_integration_tests:
     machine:
       docker_layer_caching: true
-      image: ubuntu-2204:202207-01
+      image: ubuntu-2204:2022.07.1
       resource_class: xlarge
     environment:
       GO111MODULE: "on"
@@ -211,7 +211,7 @@ jobs:
   release-armadactl:
     machine:
       docker_layer_caching: true
-      image: ubuntu-2204:202207-01
+      image: ubuntu-2204:2022.07.1
       resource_class: xlarge
     environment:
       GO111MODULE: "on"
@@ -252,7 +252,7 @@ jobs:
   release-docker-images:
     machine:
       docker_layer_caching: true
-      image: ubuntu-2204:202207-01
+      image: ubuntu-2204:2022.07.1
       resource_class: medium
     environment:
       GO111MODULE: "on"
@@ -296,7 +296,7 @@ jobs:
   release-charts:
     machine:
       docker_layer_caching: true
-      image: ubuntu-2204:202207-01
+      image: ubuntu-2204:2022.07.1
       resource_class: medium
     environment:
       GO111MODULE: "on"
@@ -315,7 +315,7 @@ jobs:
   release-dotnet-client:
     machine:
       docker_layer_caching: true
-      image: ubuntu-2204:202207-01
+      image: ubuntu-2204:2022.07.1
       resource_class: xlarge
     environment:
       GO111MODULE: "on"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ jobs:
   build_and_integration_tests:
     machine:
       docker_layer_caching: true
-      image: ubuntu-2204:2022.07.01
+      image: ubuntu-2204:202207-01
       resource_class: xlarge
     environment:
       GO111MODULE: "on"
@@ -211,7 +211,7 @@ jobs:
   release-armadactl:
     machine:
       docker_layer_caching: true
-      image: ubuntu-2204:2022.07.01
+      image: ubuntu-2204:202207-01
       resource_class: xlarge
     environment:
       GO111MODULE: "on"
@@ -252,7 +252,7 @@ jobs:
   release-docker-images:
     machine:
       docker_layer_caching: true
-      image: ubuntu-2204:2022.07.01
+      image: ubuntu-2204:202207-01
       resource_class: medium
     environment:
       GO111MODULE: "on"
@@ -296,7 +296,7 @@ jobs:
   release-charts:
     machine:
       docker_layer_caching: true
-      image: ubuntu-2204:2022.07.01
+      image: ubuntu-2204:202207-01
       resource_class: medium
     environment:
       GO111MODULE: "on"
@@ -315,7 +315,7 @@ jobs:
   release-dotnet-client:
     machine:
       docker_layer_caching: true
-      image: ubuntu-2204:2022.07.01
+      image: ubuntu-2204:202207-01
       resource_class: xlarge
     environment:
       GO111MODULE: "on"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ jobs:
   build_and_integration_tests:
     machine:
       docker_layer_caching: true
-      image: ubuntu-2204:current
+      image: ubuntu-2204:2022.07.01
       resource_class: xlarge
     environment:
       GO111MODULE: "on"
@@ -211,7 +211,7 @@ jobs:
   release-armadactl:
     machine:
       docker_layer_caching: true
-      image: ubuntu-2004:202104-01
+      image: ubuntu-2204:2022.07.01
       resource_class: xlarge
     environment:
       GO111MODULE: "on"
@@ -252,7 +252,7 @@ jobs:
   release-docker-images:
     machine:
       docker_layer_caching: true
-      image: ubuntu-2004:202104-01
+      image: ubuntu-2204:2022.07.01
       resource_class: medium
     environment:
       GO111MODULE: "on"
@@ -296,7 +296,7 @@ jobs:
   release-charts:
     machine:
       docker_layer_caching: true
-      image: ubuntu-2004:202104-01
+      image: ubuntu-2204:2022.07.01
       resource_class: medium
     environment:
       GO111MODULE: "on"
@@ -315,7 +315,7 @@ jobs:
   release-dotnet-client:
     machine:
       docker_layer_caching: true
-      image: ubuntu-2204:current
+      image: ubuntu-2204:2022.07.01
       resource_class: xlarge
     environment:
       GO111MODULE: "on"


### PR DESCRIPTION
This PR updates all circleCI VMs to be Ubuntu 22.04 release machines at the current latest to ensure go compilation uses go 1.18 at all stages (to fix the armadactl release pipeline).

It also changes the couple of machines that were running on `2204:current` to be version pinned on tag `2022.07.1` to ensure stability and control as circleCI updates their machines.