### PR TITLE
Create dir that SQLite uses, if missing (#1388)

### DIFF
--- a/internal/jobservice/application.go
+++ b/internal/jobservice/application.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"fmt"
 	"net"
+	"os"
+	"path/filepath"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -38,6 +40,14 @@ func (a *App) StartUp(ctx context.Context, config *configuration.JobServiceConfi
 
 	subscribedJobSets := make(map[string]*repository.SubscribeTable)
 	jobStatusMap := repository.NewJobSetSubscriptions(subscribedJobSets)
+
+	dbDir := filepath.Dir(config.DatabasePath)
+	if _, err := os.Stat(dbDir); os.IsNotExist(err) {
+		err = os.Mkdir(dbDir, 0755)
+		if err != nil {
+			log.Fatalf("Error: could not make directory at %s for Sqlite DB: %v", dbDir, err)
+		}
+	}
 
 	db, err := sql.Open("sqlite", config.DatabasePath)
 	if err != nil {

--- a/internal/jobservice/application.go
+++ b/internal/jobservice/application.go
@@ -32,7 +32,6 @@ func New() *App {
 }
 
 func (a *App) StartUp(ctx context.Context, config *configuration.JobServiceConfiguration) error {
-
 	// Setup an errgroup that cancels on any job failing or there being no active jobs.
 	g, _ := errgroup.WithContext(ctx)
 
@@ -43,7 +42,7 @@ func (a *App) StartUp(ctx context.Context, config *configuration.JobServiceConfi
 
 	dbDir := filepath.Dir(config.DatabasePath)
 	if _, err := os.Stat(dbDir); os.IsNotExist(err) {
-		err = os.Mkdir(dbDir, 0755)
+		err = os.Mkdir(dbDir, 0o755)
 		if err != nil {
 			log.Fatalf("Error: could not make directory at %s for Sqlite DB: %v", dbDir, err)
 		}


### PR DESCRIPTION
If the directory for the SQLite database that JobService uses (as specified for the key `databasePath` in `config/jobservice/config.yaml`) does not already exist, create it. Without this, JobService panics and exits with a misleading message from SQLite stating "out of memory".  If the `mkdir` fails, render an error stating as such, and exit.