### PR TITLE
Lookout Pruner To Delete Jobs With Null Submitted Time

### DIFF
--- a/internal/lookout/repository/job_pruner.go
+++ b/internal/lookout/repository/job_pruner.go
@@ -28,7 +28,7 @@ func DeleteOldJobs(db *sql.DB, batchSizeLimit int, cutoff time.Time) error {
 	// This would be much better done as a proper statement with parameters, but postgres doesn't support
 	// parameters if there are multiple statements.
 	queryText := fmt.Sprintf(`
-				CREATE TEMP TABLE rows_to_delete AS (SELECT job_id FROM job WHERE submitted < '%v');
+				CREATE TEMP TABLE rows_to_delete AS (SELECT job_id FROM job WHERE submitted < '%v' OR submitted IS NULL);
 				CREATE TEMP TABLE batch (job_id varchar(32));
 				
 				DO

--- a/internal/lookout/repository/job_pruner_test.go
+++ b/internal/lookout/repository/job_pruner_test.go
@@ -25,7 +25,7 @@ func Test_HappyPath(t *testing.T) {
 		})
 	})
 
-	t.Run("delete nothing", func(t *testing.T) {
+	t.Run("delete nothing but null", func(t *testing.T) {
 		withPopulatedDatabase(t, func(db *sql.DB) {
 			err := DeleteOldJobs(db, 10, startDate.AddDate(0, 0, -1))
 			assert.NoError(t, err)
@@ -110,6 +110,13 @@ func withPopulatedDatabase(t *testing.T, action func(db *sql.DB)) {
 				jobId, "foo", "bar")
 			assert.NoError(t, err4)
 		}
+
+		// Extra job will a null submitted time.  This should always be deleted
+		_, err := db.Exec(
+			"INSERT INTO job (job_id, queue, jobset, submitted) VALUES ($1, $2, $3, $4)",
+			"null-submitted", queue, "test-jobset", nil)
+		assert.NoError(t, err)
+
 		action(db)
 		return nil
 	})


### PR DESCRIPTION
Historically we have managed to acquire jobs in the lookout database with a null submitted time.  These jobs are never cleaned up by the Lookout DB Pruner because the pruner only deletes jobs older than 6 weeks, but with a null submitted time the age of the job cannot be determined.

This change modifies the pruner to also delete any job with a null submitted time.  This should be safe as going forward, Armada should not generate such events.