### PR TITLE
Use Correct Redis DB For New Event API

### DIFF
--- a/internal/armada/server.go
+++ b/internal/armada/server.go
@@ -93,10 +93,10 @@ func Serve(ctx context.Context, config *configuration.ArmadaConfig, healthChecks
 		}
 	}()
 
-	eventDb := createRedisClient(&config.EventsRedis)
+	eventDb := createRedisClient(&config.EventsApiRedis)
 	defer func() {
 		if err := legacyEventDb.Close(); err != nil {
-			log.WithError(err).Error("failed to close events Redis client")
+			log.WithError(err).Error("failed to close events api Redis client")
 		}
 	}()
 


### PR DESCRIPTION
Use the Correct Redis Settings for the new Event Api (previously we were using the same redis settings as for the old event api)