### PR TITLE
Fill in created time for events if not present

### DIFF
--- a/internal/eventingester/convert/conversions.go
+++ b/internal/eventingester/convert/conversions.go
@@ -55,6 +55,16 @@ func (rc *MessageRowConverter) ConvertBatch(ctx context.Context, batch []*pulsar
 			log.WithError(err).Warnf("Could not unmarshal proto for msg %s", pulsarMsg.ID())
 			continue
 		}
+
+		// Fill in time if it is not set
+		// TODO - once created is set everywhere we can remove this
+		for _, event := range es.Events {
+			if event.GetCreated() == nil {
+				publishTime := pulsarMsg.PublishTime()
+				event.Created = &publishTime
+			}
+		}
+
 		sequences = append(sequences, es)
 	}
 	sequences = eventutil.CompactEventSequences(sequences)

--- a/internal/eventingester/convert/conversions_test.go
+++ b/internal/eventingester/convert/conversions_test.go
@@ -72,9 +72,8 @@ func TestSingle(t *testing.T) {
 }
 
 func TestSingleWithMissingCreated(t *testing.T) {
-
 	// Succeeded
-	var suceededMissingCreated = &armadaevents.EventSequence_Event{
+	suceededMissingCreated := &armadaevents.EventSequence_Event{
 		// No created time
 		Event: &armadaevents.EventSequence_Event_JobRunSucceeded{
 			JobRunSucceeded: &armadaevents.JobRunSucceeded{

--- a/internal/eventingester/convert/conversions_test.go
+++ b/internal/eventingester/convert/conversions_test.go
@@ -71,6 +71,34 @@ func TestSingle(t *testing.T) {
 	assert.Equal(t, expectedSequence.Events, es.Events)
 }
 
+func TestSingleWithMissingCreated(t *testing.T) {
+
+	// Succeeded
+	var suceededMissingCreated = &armadaevents.EventSequence_Event{
+		// No created time
+		Event: &armadaevents.EventSequence_Event_JobRunSucceeded{
+			JobRunSucceeded: &armadaevents.JobRunSucceeded{
+				RunId: runIdProto,
+				JobId: jobIdProto,
+			},
+		},
+	}
+
+	msg := NewMsg(baseTime, suceededMissingCreated)
+	compressor, err := compress.NewZlibCompressor(0)
+	assert.NoError(t, err)
+	converter := MessageRowConverter{Compressor: compressor, MaxMessageBatchSize: 1024}
+	batchUpdate := converter.ConvertBatch(context.Background(), []*pulsarutils.ConsumerMessage{msg})
+	expectedSequence := armadaevents.EventSequence{
+		Events: []*armadaevents.EventSequence_Event{jobRunSucceeded},
+	}
+	assert.Equal(t, []*pulsarutils.ConsumerMessageId{{msg.Message.ID(), 0, msg.ConsumerId}}, batchUpdate.MessageIds)
+	event := batchUpdate.Events[0]
+	es, err := extractEventSeq(event.Event)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedSequence.Events, es.Events)
+}
+
 func TestMultiple(t *testing.T) {
 	msg := NewMsg(baseTime, cancelled, jobRunSucceeded)
 	compressor, err := compress.NewZlibCompressor(0)


### PR DESCRIPTION
Created time is not always populated on events.  Default to the Pulsar message time if this is not present.