### PR TITLE
[Event API] handle succeeded events

### DIFF
--- a/internal/armada/repository/apimessages/conversions_test.go
+++ b/internal/armada/repository/apimessages/conversions_test.go
@@ -563,6 +563,34 @@ func TestConvertJobError(t *testing.T) {
 	assert.Equal(t, expected, apiEvents)
 }
 
+func TestConvertJobSucceeded(t *testing.T) {
+	succeeded := &armadaevents.EventSequence_Event{
+		Created: &baseTime,
+		Event: &armadaevents.EventSequence_Event_JobSucceeded{
+			JobSucceeded: &armadaevents.JobSucceeded{
+				JobId: jobIdProto,
+			},
+		},
+	}
+
+	expected := []*api.EventMessage{
+		{
+			Events: &api.EventMessage_Succeeded{
+				Succeeded: &api.JobSucceededEvent{
+					JobId:    jobIdString,
+					JobSetId: jobSetName,
+					Queue:    queue,
+					Created:  baseTime,
+				},
+			},
+		},
+	}
+
+	apiEvents, err := FromEventSequence(toEventSeq(succeeded))
+	assert.NoError(t, err)
+	assert.Equal(t, expected, apiEvents)
+}
+
 func TestConvertJobRunning(t *testing.T) {
 	running := &armadaevents.EventSequence_Event{
 		Created: &baseTime,


### PR DESCRIPTION
The event api wasn't converting job succeeded events (doh!)- this fixes that.

Note that that current pulsar event messages don't contain `kubernetesId`, `PodNumber` etc.  We may well need to follow up with a (much larger) pr to have these populated else the api will be a breaking change.