### PR TITLE
remove config parsing from armdactl

### DIFF
--- a/cmd/jobservice/cmd/root.go
+++ b/cmd/jobservice/cmd/root.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/G-Research/armada/internal/common"
 	"github.com/G-Research/armada/internal/jobservice"
-	"github.com/G-Research/armada/pkg/client"
 )
 
 // RootCmd is the root Cobra command that gets called from the main func.
@@ -15,7 +14,6 @@ func RootCmd() *cobra.Command {
 		Use:   "jobservice",
 		Short: "jobservice is used for polling functionality",
 	}
-	client.AddArmadaApiConnectionCommandlineArgs(cmd)
 	common.ConfigureLogging()
 	common.BindCommandlineArguments()
 

--- a/cmd/jobservice/cmd/run.go
+++ b/cmd/jobservice/cmd/run.go
@@ -16,7 +16,6 @@ import (
 	"github.com/G-Research/armada/internal/common"
 	"github.com/G-Research/armada/internal/jobservice"
 	"github.com/G-Research/armada/internal/jobservice/configuration"
-	"github.com/G-Research/armada/pkg/client"
 )
 
 func runCmd(app *jobservice.App) *cobra.Command {
@@ -41,7 +40,6 @@ func runCmdE(app *jobservice.App) func(cmd *cobra.Command, args []string) error 
 		}
 		configArray := strings.Split(configValue, " ")
 		common.LoadConfig(&config, "./config/jobservice", configArray)
-		config.ApiConnection = *client.ExtractCommandlineArmadaApiConnectionDetails()
 
 		err := app.StartUp(ctx, &config)
 		if err != nil {


### PR DESCRIPTION
Let's just parse the config from jobservice.

Closes #1470 