### PR TITLE
[EventIngester] Don't store the groups on the eventSequence

### DIFF
--- a/internal/eventingester/convert/conversions.go
+++ b/internal/eventingester/convert/conversions.go
@@ -65,6 +65,9 @@ func (rc *MessageRowConverter) ConvertBatch(ctx context.Context, batch []*pulsar
 			}
 		}
 
+		// cut out groups:
+		es.Groups = nil
+
 		sequences = append(sequences, es)
 	}
 	sequences = eventutil.CompactEventSequences(sequences)


### PR DESCRIPTION
Don't store all the groups in the (new) events database as we now pass around all the groups and this can be very large.