### PR TITLE
Fix Incorrect Container Name in Event Ingester

### DIFF
--- a/deployment/event-ingester/templates/deployment.yaml
+++ b/deployment/event-ingester/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         runAsUser: 1000
         runAsGroup: 2000
       containers:
-        - name: lookout-ingester
+        - name: event-ingester
           imagePullPolicy: IfNotPresent
           image: {{ .Values.image.repository }}:{{ required "A value is required for .Values.image.tag" .Values.image.tag }}
           args:


### PR DESCRIPTION
Copy & Paste error meant that it was called "lookout-ingester" rather than "event-ingester"