### PR TITLE
Fail job submission to pod immediately if namespace doesn't exist

### DIFF
--- a/config/executor/config.yaml
+++ b/config/executor/config.yaml
@@ -40,6 +40,7 @@ kubernetes:
   # Instantly fail jobs when the pod submission error matches the regexes below
   fatalPodSubmissionErrors:
     - "admission webhook"
+    - "namespaces \".*\" not found"
   pendingPodChecks:
     timeWithoutEventsOrStatus: 10m
     events:


### PR DESCRIPTION
Closes #1441 