### PR TITLE
Give Executor Patch perms on Events

### DIFF
--- a/deployment/executor/templates/clusterrole.yaml
+++ b/deployment/executor/templates/clusterrole.yaml
@@ -28,6 +28,7 @@ rules:
   - watch
   - delete
   - deletecollection
+  - patch
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
We need this because the executor now adds annotations to events to facilitate preemption.