### PR TITLE
WIP: Upload docker images from artifacts

### DIFF
--- a/.github/workflows/upload-docker-images.yml
+++ b/.github/workflows/upload-docker-images.yml
@@ -1,0 +1,56 @@
+name: Release Armada
+
+on:
+  workflow_call: {}
+
+jobs:
+  upload-docker-images:
+    runs-on: ubuntu-22.04
+    environment: armada-dockerhub
+    steps:
+      # trigger docker image upload workflow; downloading tarballs from artifacts and uploading them to docker
+      - name: Assemble container tag
+        id: container_tag
+        uses: pr-mpt/actions-commit-hash@v1
+        with:
+          commit: "${{ github.sha }}"
+          prefix: "${{ github.ref_name }}"
+      - name: Download saved docker-images artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: docker-images
+          path: docker-images.zip
+      - name: Unzip docker-images artifacts
+        run: |
+          unzip docker-images.zip
+          tar xf docker-images.tar.gz
+          rm docker-images.tar.gz
+      - name: Upload images to docker
+        env:
+            DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+            DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        run: |
+          # Note(JayF): All the offical docker actions for uploading these
+          # containers also assume you need to rebuild them. That makes them
+          # ill-suited for our workflow.
+          TAG=$(echo -n "${{ steps.container_tag.outputs.long }}" | sed 's|/|-|g')
+          
+          echo ${DOCKERHUB_PASS} | docker login -u ${DOCKERHUB_USER} --password-stdin
+
+          IMAGES_TO_UPLOAD=(
+            "armada-server"
+            "armada-executor"
+            "armada-armadactl"
+            "armada-testsuite"
+            "armada-lookout"
+            "armada-lookout-ingester"
+            "armada-event-ingester"
+            "armada-binoculars"
+            "armada-jobservice"
+          )
+          for image in "${IMAGES_TO_UPLOAD[@]}"; do
+              remote="gresearchdev/${image}-dev:${TAG}"
+              docker load -i $image.tar.gz
+              docker tag $image $remote 
+              docker push $remote
+          done

--- a/.github/workflows/upload-docker-images.yml
+++ b/.github/workflows/upload-docker-images.yml
@@ -8,13 +8,6 @@ jobs:
     runs-on: ubuntu-22.04
     environment: armada-dockerhub
     steps:
-      # trigger docker image upload workflow; downloading tarballs from artifacts and uploading them to docker
-      - name: Assemble container tag
-        id: container_tag
-        uses: pr-mpt/actions-commit-hash@v1
-        with:
-          commit: "${{ github.sha }}"
-          prefix: "${{ github.ref_name }}"
       - name: Download saved docker-images artifact
         uses: actions/download-artifact@v2
         with:
@@ -33,7 +26,13 @@ jobs:
           # Note(JayF): All the offical docker actions for uploading these
           # containers also assume you need to rebuild them. That makes them
           # ill-suited for our workflow.
-          TAG=$(echo -n "${{ steps.container_tag.outputs.long }}" | sed 's|/|-|g')
+          TAG_SUFFIX=$(${{ github.sha }} | sed 's|/|-|g')
+          
+          if ${{github.ref_name}} == "master"; then
+            TAG=$TAG_SUFFIX
+          else
+            TAG="${{github.ref_name}}-$TAG_SUFFIX"
+          fi
           
           echo ${DOCKERHUB_PASS} | docker login -u ${DOCKERHUB_USER} --password-stdin
 

--- a/.github/workflows/upload-docker-images.yml
+++ b/.github/workflows/upload-docker-images.yml
@@ -27,8 +27,8 @@ jobs:
           rm docker-images.tar.gz
       - name: Upload images to docker
         env:
-            DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-            DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+            DOCKERHUB_PASS: ${{ secrets.DOCKERHUB_PASS }}
+            DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
         run: |
           # Note(JayF): All the offical docker actions for uploading these
           # containers also assume you need to rebuild them. That makes them


### PR DESCRIPTION
This should work, needs testing.

Final flow will be as follows:
- go-integration-tests builds and saves docker images to an artifact (#1473)
- go-integration-tests uses workflow_call to call upload-docker-images@master (change TODO, will be written once this and 1473 merge)
- upload-docker-images downloads those artifacts, and pushes them to docker
  - This is a separate workflow, so secrets can be isolated to an environment (`armada-dockerhub`), and then we can configure that environment to only work when called on a protected branch.
- (on release), armada-release re-tags these docker images (along with doing other work) and pushes them to dockerhub (#1552) 