### PR TITLE
Fix TestIsNetworkErrorNats test failure

### DIFF
--- a/internal/common/armadaerrors/errors_test.go
+++ b/internal/common/armadaerrors/errors_test.go
@@ -182,7 +182,7 @@ func TestIsNetworkErrorPulsar(t *testing.T) {
 }
 
 func TestIsNetworkErrorNats(t *testing.T) {
-	_, err := nats.Connect("nats://localhost:4222")
+	_, err := nats.Connect("nats://localhost:43432")
 
 	assert.True(t, IsNetworkError(errors.Wrap(err, "foo")))
 	assert.True(t, IsNetworkError(fmt.Errorf("%w", err)))


### PR DESCRIPTION
By changing to a random high port, but longer term we should:
1. Figure out why this suddenly started failing.
2. Fix unit tests so they don't depend on external system state.