### PR TITLE
Py gen test fix

### DIFF
--- a/client/python/armada_client/gen/event_typings.py
+++ b/client/python/armada_client/gen/event_typings.py
@@ -10,12 +10,16 @@ def get_event_states():
 
 
 def get_all_job_event_classes():
+    job_events = []
+
     for possible_event in event_pb2.__dict__:
         try:
             if "job_id" in getattr(event_pb2, possible_event).DESCRIPTOR.fields_by_name:
-                yield possible_event
+                job_events.append(possible_event)
         except AttributeError:
             continue
+
+    return job_events
 
 
 def get_job_states():

--- a/client/python/armada_client/gen/event_typings.py
+++ b/client/python/armada_client/gen/event_typings.py
@@ -10,7 +10,12 @@ def get_event_states():
 
 
 def get_all_job_event_classes():
-    return [x for x in event_pb2.__dict__ if hasattr(getattr(event_pb2, x), "job_id")]
+    for possible_event in event_pb2.__dict__:
+        try:
+            if "job_id" in getattr(event_pb2, possible_event).DESCRIPTOR.fields_by_name:
+                yield possible_event
+        except AttributeError:
+            continue
 
 
 def get_job_states():
@@ -66,7 +71,7 @@ def main():
     states = get_event_states()
     print("Done creating EventStates")
 
-    classes = get_all_job_event_classes()
+    classes = list(get_all_job_event_classes())
     print("Done creating JobEvent classes")
 
     jobstates = get_job_states()

--- a/client/python/armada_client/gen/event_typings.py
+++ b/client/python/armada_client/gen/event_typings.py
@@ -75,7 +75,7 @@ def main():
     states = get_event_states()
     print("Done creating EventStates")
 
-    classes = list(get_all_job_event_classes())
+    classes = get_all_job_event_classes()
     print("Done creating JobEvent classes")
 
     jobstates = get_job_states()

--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.2.1"
 description = "Armada gRPC API python client"
 readme = "README.md"
 requires-python = ">=3.7,<3.9"
-dependencies = ["grpcio~=1.46.3", "grpcio-tools~=1.46.3", "mypy-protobuf>=3.2.0"]
+dependencies = ["grpcio~=1.49", "grpcio-tools~=1.49", "mypy-protobuf>=3.2.0"]
 license = { text = "Apache Software License" }
 authors = [{ name = "G-Research Open Source Software", email = "armada@armadaproject.io" }]
 

--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.2.1"
 description = "Armada gRPC API python client"
 readme = "README.md"
 requires-python = ">=3.7,<3.9"
-dependencies = ["grpcio>=1.49", "grpcio-tools>=1.49", "mypy-protobuf>=3.2.0"]
+dependencies = ["grpcio>=1.46.3", "grpcio-tools>=1.46.3", "mypy-protobuf>=3.2.0"]
 license = { text = "Apache Software License" }
 authors = [{ name = "G-Research Open Source Software", email = "armada@armadaproject.io" }]
 

--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.2.1"
 description = "Armada gRPC API python client"
 readme = "README.md"
 requires-python = ">=3.7,<3.9"
-dependencies = ["grpcio~=1.49", "grpcio-tools~=1.49", "mypy-protobuf>=3.2.0"]
+dependencies = ["grpcio>=1.49", "grpcio-tools>=1.49", "mypy-protobuf>=3.2.0"]
 license = { text = "Apache Software License" }
 authors = [{ name = "G-Research Open Source Software", email = "armada@armadaproject.io" }]
 

--- a/third_party/airflow/pyproject.toml
+++ b/third_party/airflow/pyproject.toml
@@ -10,8 +10,8 @@ requires-python = ">=3.7,<3.9"
 dependencies = [
 	"armada-client",
 	"apache-airflow>=2.3.1",
-	"grpcio~=1.46.3",
-	"grpcio-tools~=1.46.3",
+	"grpcio>=1.46.3",
+	"grpcio-tools>=1.46.3",
 	"types-protobuf>=3.19.22"
 ]
 authors = [{name = "Armada-GROSS", email = "armada@armadaproject.io"}]


### PR DESCRIPTION
Closes #1560 

Basically, since grpc version 1.48, there has been a major change in how the stub files are generated, relying more heavily on the `DESCRIPTOR` tag for all the serialized infomation.

We now use this variable for all our generation, hopefully avoiding this issue going forward.