### PR TITLE
Improve sqlite handling in Jobservice

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -202,9 +202,9 @@ Additionally, the `moq` tool has been used to generate test mocks in `internal/j
 ```
 go install github.com/matryer/moq@latest
 cd internal/jobservice/events (or wherever)
+rm ./*_moq.go
 go generate
 ```
-
 
 ### Usage metrics
 

--- a/internal/jobservice/application.go
+++ b/internal/jobservice/application.go
@@ -58,9 +58,9 @@ func (a *App) StartUp(ctx context.Context, config *configuration.JobServiceConfi
 	}
 	defer db.Close()
 	sqlJobRepo := repository.NewSQLJobService(jobStatusMap, config, db)
+	sqlJobRepo.Setup()
 	jobService := server.NewJobService(config, sqlJobRepo)
 	js.RegisterJobServiceServer(grpcServer, jobService)
-	sqlJobRepo.CreateTable()
 
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", config.GrpcPort))
 	if err != nil {

--- a/internal/jobservice/eventstojobs/eventstojobs.go
+++ b/internal/jobservice/eventstojobs/eventstojobs.go
@@ -105,7 +105,12 @@ func (eventToJobService *EventsToJobService) streamCommon(ctx context.Context, t
 				jobStatus := EventsToJobResponse(*msg.Message)
 				if jobStatus != nil {
 					jobStatus := repository.NewJobStatus(eventToJobService.queue, eventToJobService.jobSetId, currentJobId, *jobStatus)
-					eventToJobService.jobServiceRepository.UpdateJobServiceDb(jobStatus)
+					err := eventToJobService.jobServiceRepository.UpdateJobServiceDb(jobStatus)
+					if err != nil {
+						log.WithError(err).Error("could not update job status, retrying")
+						time.Sleep(5 * time.Second)
+						continue
+					}
 				}
 				// advance the message id for next loop
 				fromMessageId = msg.GetId()

--- a/internal/jobservice/repository/sql_job_service.go
+++ b/internal/jobservice/repository/sql_job_service.go
@@ -151,7 +151,7 @@ func (s *SQLJobService) UpdateJobServiceDb(jobTable *JobStatus) error {
 
 	stmt, err := s.db.Prepare("INSERT OR REPLACE INTO jobservice VALUES (?, ?, ?, ?, ?, ?)")
 	if err != nil {
-		panic(err)
+		return err
 	}
 	defer stmt.Close()
 	jobState := jobTable.jobResponse.State.String()

--- a/internal/jobservice/repository/sql_job_service.go
+++ b/internal/jobservice/repository/sql_job_service.go
@@ -18,7 +18,7 @@ import (
 type JobTableUpdater interface {
 	SubscribeJobSet(string, string)
 	IsJobSetSubscribed(string, string) bool
-	UpdateJobServiceDb(*JobStatus)
+	UpdateJobServiceDb(*JobStatus) error
 }
 
 // Internal structure for storing in memory JobTables and Subscription JobSets
@@ -143,7 +143,7 @@ func jobStateStrToJSRState(jobState string) (js.JobServiceResponse_State, error)
 }
 
 // Update database with JobTable.
-func (s *SQLJobService) UpdateJobServiceDb(jobTable *JobStatus) {
+func (s *SQLJobService) UpdateJobServiceDb(jobTable *JobStatus) error {
 	// SQLite only allows one write at a time. Therefore we must serialize
 	// writes in order to avoid SQL_BUSY errors.
 	s.writeLock.Lock()
@@ -158,10 +158,7 @@ func (s *SQLJobService) UpdateJobServiceDb(jobTable *JobStatus) {
 
 	_, errExec := stmt.Exec(jobTable.queue, jobTable.jobSetId, jobTable.jobId, jobState, jobTable.jobResponse.Error, jobTable.timeStamp)
 
-	// TODO: Make more robust
-	if errExec != nil {
-		panic(errExec)
-	}
+	return errExec
 }
 
 // Simple Health Check to Verify if SqlLite is working.

--- a/internal/jobservice/repository/sql_job_service_moq.go
+++ b/internal/jobservice/repository/sql_job_service_moq.go
@@ -23,7 +23,7 @@ var _ JobTableUpdater = &JobTableUpdaterMock{}
 // 			SubscribeJobSetFunc: func(s1 string, s2 string)  {
 // 				panic("mock out the SubscribeJobSet method")
 // 			},
-// 			UpdateJobServiceDbFunc: func(jobTable *JobTable)  {
+// 			UpdateJobServiceDbFunc: func(jobStatus *JobStatus) error {
 // 				panic("mock out the UpdateJobServiceDb method")
 // 			},
 // 		}
@@ -40,7 +40,7 @@ type JobTableUpdaterMock struct {
 	SubscribeJobSetFunc func(s1 string, s2 string)
 
 	// UpdateJobServiceDbFunc mocks the UpdateJobServiceDb method.
-	UpdateJobServiceDbFunc func(jobTable *JobStatus)
+	UpdateJobServiceDbFunc func(jobStatus *JobStatus) error
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -60,8 +60,8 @@ type JobTableUpdaterMock struct {
 		}
 		// UpdateJobServiceDb holds details about calls to the UpdateJobServiceDb method.
 		UpdateJobServiceDb []struct {
-			// JobTable is the jobTable argument value.
-			JobTable *JobStatus
+			// JobStatus is the jobStatus argument value.
+			JobStatus *JobStatus
 		}
 	}
 	lockIsJobSetSubscribed sync.RWMutex
@@ -140,29 +140,29 @@ func (mock *JobTableUpdaterMock) SubscribeJobSetCalls() []struct {
 }
 
 // UpdateJobServiceDb calls UpdateJobServiceDbFunc.
-func (mock *JobTableUpdaterMock) UpdateJobServiceDb(jobTable *JobStatus) {
+func (mock *JobTableUpdaterMock) UpdateJobServiceDb(jobStatus *JobStatus) error {
 	if mock.UpdateJobServiceDbFunc == nil {
 		panic("JobTableUpdaterMock.UpdateJobServiceDbFunc: method is nil but JobTableUpdater.UpdateJobServiceDb was just called")
 	}
 	callInfo := struct {
-		JobTable *JobStatus
+		JobStatus *JobStatus
 	}{
-		JobTable: jobTable,
+		JobStatus: jobStatus,
 	}
 	mock.lockUpdateJobServiceDb.Lock()
 	mock.calls.UpdateJobServiceDb = append(mock.calls.UpdateJobServiceDb, callInfo)
 	mock.lockUpdateJobServiceDb.Unlock()
-	mock.UpdateJobServiceDbFunc(jobTable)
+	return mock.UpdateJobServiceDbFunc(jobStatus)
 }
 
 // UpdateJobServiceDbCalls gets all the calls that were made to UpdateJobServiceDb.
 // Check the length with:
 //     len(mockedJobTableUpdater.UpdateJobServiceDbCalls())
 func (mock *JobTableUpdaterMock) UpdateJobServiceDbCalls() []struct {
-	JobTable *JobStatus
+	JobStatus *JobStatus
 } {
 	var calls []struct {
-		JobTable *JobStatus
+		JobStatus *JobStatus
 	}
 	mock.lockUpdateJobServiceDb.RLock()
 	calls = mock.calls.UpdateJobServiceDb

--- a/internal/jobservice/repository/sql_job_service_test.go
+++ b/internal/jobservice/repository/sql_job_service_test.go
@@ -301,8 +301,6 @@ func TestHealthCheck(t *testing.T) {
 // This test will fail if sqlite writes are not serialised somehow due to
 // SQLITE_BUSY errors.
 func TestConcurrentJobStatusUpdating(t *testing.T) {
-	t.Skip("Test is flaky, need to more robustly handle SQL_BUSY errors occurring in UpdateJobServiceDb")
-
 	WithSqlServiceRepo(func(r *SQLJobService) {
 		responseRunning := &jobservice.JobServiceResponse{State: jobservice.JobServiceResponse_RUNNING}
 

--- a/internal/jobservice/repository/sql_job_service_test.go
+++ b/internal/jobservice/repository/sql_job_service_test.go
@@ -17,7 +17,8 @@ func TestConstructInMemoryDoesNotExist(t *testing.T) {
 	WithSqlServiceRepo(func(r *SQLJobService) {
 		responseExpected := &jobservice.JobServiceResponse{State: jobservice.JobServiceResponse_JOB_ID_NOT_FOUND}
 		jobStatus := NewJobStatus("test", "job-set-1", "job-id", *responseExpected)
-		r.UpdateJobServiceDb(jobStatus)
+		err := r.UpdateJobServiceDb(jobStatus)
+		assert.Nil(t, err)
 
 		resp, err := r.GetJobStatus("job-set-1")
 		assert.Nil(t, err)
@@ -30,7 +31,8 @@ func TestConstructInMemoryServiceFailed(t *testing.T) {
 		responseExpected := &jobservice.JobServiceResponse{State: jobservice.JobServiceResponse_FAILED, Error: "TestFail"}
 		jobStatus := NewJobStatus("test", "job-set-1", "job-id", *responseExpected)
 
-		r.UpdateJobServiceDb(jobStatus)
+		err := r.UpdateJobServiceDb(jobStatus)
+		assert.Nil(t, err)
 
 		resp, err := r.GetJobStatus("job-id")
 		assert.Nil(t, err)
@@ -106,9 +108,10 @@ func TestDeleteJobsInJobSet(t *testing.T) {
 
 		jobStatus1 := NewJobStatus("test", "job-set-1", "job-id", *responseExpected1)
 
-		r.UpdateJobServiceDb(jobStatus1)
-		jobResponse1, _ := r.GetJobStatus("job-id")
+		err := r.UpdateJobServiceDb(jobStatus1)
+		assert.Nil(t, err)
 
+		jobResponse1, _ := r.GetJobStatus("job-id")
 		assert.Equal(t, jobResponse1, responseExpected1)
 
 		r.SubscribeJobSet("test", "job-set-1")
@@ -131,7 +134,9 @@ func TestCheckToUnSubscribe(t *testing.T) {
 
 		jobStatus1 := NewJobStatus("test", "job-set-1", "job-id", *responseExpected1)
 
-		r.UpdateJobServiceDb(jobStatus1)
+		err := r.UpdateJobServiceDb(jobStatus1)
+		assert.Nil(t, err)
+
 		r.SubscribeJobSet("test", "job-set-1")
 		assert.True(t, r.IsJobSetSubscribed("test", "job-set-1"))
 		assert.False(t, r.CheckToUnSubscribe("test", "job-set-1", 100000))
@@ -147,8 +152,11 @@ func TestCheckToUnSubscribeWithoutSubscribing(t *testing.T) {
 		jobStatus1 := NewJobStatus("test", "job-set-1", "job-id", *responseExpected1)
 		jobStatus2 := NewJobStatus("test", "job-set-2", "job-id-3", *responseExpected2)
 
-		r.UpdateJobServiceDb(jobStatus1)
-		r.UpdateJobServiceDb(jobStatus2)
+		err := r.UpdateJobServiceDb(jobStatus1)
+		assert.Nil(t, err)
+		err = r.UpdateJobServiceDb(jobStatus2)
+		assert.Nil(t, err)
+
 		assert.False(t, r.IsJobSetSubscribed("test", "job-set-1"))
 		assert.False(t, r.CheckToUnSubscribe("test", "job-set-1", 100000))
 	})
@@ -190,13 +198,20 @@ func TestGetJobStatusAllStates(t *testing.T) {
 		jobStatus6 := NewJobStatus("test", "job-set-1", "job-id-6", *responseCancelled)
 		jobStatus7 := NewJobStatus("test", "job-set-1", "job-id-7", *responseDoesNotExist)
 
-		r.UpdateJobServiceDb(jobStatus1)
-		r.UpdateJobServiceDb(jobStatus2)
-		r.UpdateJobServiceDb(jobStatus3)
-		r.UpdateJobServiceDb(jobStatus4)
-		r.UpdateJobServiceDb(jobStatus5)
-		r.UpdateJobServiceDb(jobStatus6)
-		r.UpdateJobServiceDb(jobStatus7)
+		err := r.UpdateJobServiceDb(jobStatus1)
+		assert.Nil(t, err)
+		err = r.UpdateJobServiceDb(jobStatus2)
+		assert.Nil(t, err)
+		err = r.UpdateJobServiceDb(jobStatus3)
+		assert.Nil(t, err)
+		err = r.UpdateJobServiceDb(jobStatus4)
+		assert.Nil(t, err)
+		err = r.UpdateJobServiceDb(jobStatus5)
+		assert.Nil(t, err)
+		err = r.UpdateJobServiceDb(jobStatus6)
+		assert.Nil(t, err)
+		err = r.UpdateJobServiceDb(jobStatus7)
+		assert.Nil(t, err)
 
 		actualFailed, errFailed := r.GetJobStatus("job-id")
 		actualSuccess, errSuccess := r.GetJobStatus("job-id-2")
@@ -229,7 +244,8 @@ func TestDeleteJobsBeforePersistingRaceError(t *testing.T) {
 		noExist := &jobservice.JobServiceResponse{State: jobservice.JobServiceResponse_JOB_ID_NOT_FOUND}
 
 		jobStatus1 := NewJobStatus("test-race", "job-set-race", "job-race", *responseSuccess)
-		r.UpdateJobServiceDb(jobStatus1)
+		err := r.UpdateJobServiceDb(jobStatus1)
+		assert.Nil(t, err)
 		r.SubscribeJobSet("test-race", "job-set-race")
 		r.CleanupJobSetAndJobs("test-race", "job-set-race")
 		actualSuccess, actualError := r.GetJobStatus("job-race")
@@ -246,7 +262,8 @@ func TestGetJobStatusAfterPersisting(t *testing.T) {
 		responseSuccess := &jobservice.JobServiceResponse{State: jobservice.JobServiceResponse_SUCCEEDED}
 
 		jobStatus1 := NewJobStatus("test", "job-set-1", "job-id", *responseSuccess)
-		r.UpdateJobServiceDb(jobStatus1)
+		err := r.UpdateJobServiceDb(jobStatus1)
+		assert.Nil(t, err)
 		actual, actualErr := r.GetJobStatus("job-id")
 		assert.Nil(t, actualErr)
 		assert.Equal(t, actual, responseSuccess)
@@ -259,12 +276,14 @@ func TestDuplicateIdDatabaseInsert(t *testing.T) {
 		responseSuccess := &jobservice.JobServiceResponse{State: jobservice.JobServiceResponse_SUCCEEDED}
 
 		jobStatus1 := NewJobStatus("test", "job-set-1", "job-id", *responseRunning)
-		r.UpdateJobServiceDb(jobStatus1)
+		err := r.UpdateJobServiceDb(jobStatus1)
+		assert.Nil(t, err)
 		actualSql, actualErr := r.GetJobStatus("job-id")
 		assert.Equal(t, actualSql, responseRunning)
 		assert.Nil(t, actualErr)
 		jobStatus2 := NewJobStatus("test", "job-set-1", "job-id", *responseSuccess)
-		r.UpdateJobServiceDb(jobStatus2)
+		err = r.UpdateJobServiceDb(jobStatus2)
+		assert.Nil(t, err)
 		actualSuccessSql, actualSuccessErr := r.GetJobStatus("job-id")
 		assert.Equal(t, actualSuccessSql, responseSuccess)
 		assert.Nil(t, actualSuccessErr)
@@ -302,7 +321,8 @@ func TestConcurrentJobStatusUpdating(t *testing.T) {
 				jobStatus := NewJobStatus("test", "job-set-1", jobId, *responseRunning)
 
 				startWg.Wait()
-				r.UpdateJobServiceDb(jobStatus)
+				err := r.UpdateJobServiceDb(jobStatus)
+				assert.Nil(t, err)
 				actualSql, actualErr := r.GetJobStatus(jobId)
 				assert.Equal(t, actualSql, responseRunning)
 				assert.Nil(t, actualErr)

--- a/internal/jobservice/repository/sql_job_service_test.go
+++ b/internal/jobservice/repository/sql_job_service_test.go
@@ -323,7 +323,7 @@ func WithSqlServiceRepo(action func(r *SQLJobService)) {
 		panic(err)
 	}
 	repo := NewSQLJobService(jobStatusMap, config, db)
-	repo.CreateTable()
+	repo.Setup()
 	action(repo)
 	db.Close()
 	os.Remove("test.db")


### PR DESCRIPTION
Does a few specific things:

- Enables [WAL](https://www.sqlite.org/wal.html) journaling for SQLite DB used by jobservice.
- Expands locking to encompass entire `SQLJobService.UpdateJobServiceDb` method.
- Returns an error from `SQLJobService.UpdateJobServiceDb` instead of `panic`ing on `stmt.Exec` error. Callers of `UpdateJobServiceDb` can handle the error (or not) as they see fit.

The move to WAL virtually eliminates the incidence of `SQLITE_BUSY` errors when used in conjunction with using a `sync.Mutex` around operations that would write to the DB. Additional load testing seems to indicate we're more likely to run into semaphore acquisition panics under extreme load under this regime. 

Closes #1563 