### PR TITLE
Improve logging around auth attempts for grpc calls

### DIFF
--- a/internal/common/auth/authorization/anonymous.go
+++ b/internal/common/auth/authorization/anonymous.go
@@ -4,6 +4,10 @@ import "context"
 
 type AnonymousAuthService struct{}
 
+func (authService *AnonymousAuthService) Name() string {
+	return "Anonymous"
+}
+
 func (AnonymousAuthService) Authenticate(ctx context.Context) (Principal, error) {
 	return anonymousPrincipal, nil
 }

--- a/internal/common/auth/authorization/basic.go
+++ b/internal/common/auth/authorization/basic.go
@@ -18,6 +18,10 @@ func NewBasicAuthService(users map[string]configuration.UserInfo) *BasicAuthServ
 	return &BasicAuthService{users: users}
 }
 
+func (authService *BasicAuthService) Name() string {
+	return "Basic"
+}
+
 func (authService *BasicAuthService) Authenticate(ctx context.Context) (Principal, error) {
 	basicAuth, err := grpc_auth.AuthFromMD(ctx, "basic")
 	if err == nil {

--- a/internal/common/auth/authorization/basic.go
+++ b/internal/common/auth/authorization/basic.go
@@ -32,7 +32,7 @@ func (authService *BasicAuthService) Authenticate(ctx context.Context) (Principa
 		pair := strings.SplitN(string(payload), ":", 2)
 		return authService.loginUser(pair[0], pair[1])
 	}
-	return nil, missingCredentials
+	return nil, missingCredentialsErr
 }
 
 func (authService *BasicAuthService) loginUser(username string, password string) (Principal, error) {
@@ -40,5 +40,5 @@ func (authService *BasicAuthService) loginUser(username string, password string)
 	if ok && userInfo.Password == password {
 		return NewStaticPrincipal(username, userInfo.Groups), nil
 	}
-	return nil, invalidCredentials
+	return nil, invalidCredentialsErr
 }

--- a/internal/common/auth/authorization/basic_test.go
+++ b/internal/common/auth/authorization/basic_test.go
@@ -26,10 +26,10 @@ func TestBasicAuthService(t *testing.T) {
 		metadata.NewIncomingContext(context.Background(), basicPassword("root", "test")))
 
 	assert.NotNil(t, e)
-	assert.NotEqual(t, e, missingCredentials)
+	assert.NotEqual(t, e, missingCredentialsErr)
 
 	_, e = service.Authenticate(context.Background())
-	assert.Equal(t, e, missingCredentials)
+	assert.Equal(t, e, missingCredentialsErr)
 }
 
 func basicPassword(user, password string) map[string][]string {

--- a/internal/common/auth/authorization/common.go
+++ b/internal/common/auth/authorization/common.go
@@ -108,6 +108,7 @@ func WithPrincipal(ctx context.Context, principal Principal) context.Context {
 // The gRPC server may be started with multiple AuthService to give several options for authentication.
 type AuthService interface {
 	Authenticate(ctx context.Context) (Principal, error)
+	Name() string
 }
 
 // CreateMiddlewareAuthFunction returns an authentication function that combines the given

--- a/internal/common/auth/authorization/common_test.go
+++ b/internal/common/auth/authorization/common_test.go
@@ -10,9 +10,9 @@ import (
 
 func TestCreateMiddlewareAuthFunction(t *testing.T) {
 	principal := NewStaticPrincipal("test", []string{"group"})
-	failingService := &fakeAuthService{nil, errors.New("failed")}
-	serviceWithoutCredentials := &fakeAuthService{nil, missingCredentials}
-	successfulService := &fakeAuthService{principal, nil}
+	failingService := &fakeAuthService{nil, errors.New("failed"), "alwaysFailService"}
+	serviceWithoutCredentials := &fakeAuthService{nil, missingCredentialsErr, "missingCredsService"}
+	successfulService := &fakeAuthService{principal, nil, "successService"}
 
 	_, e := CreateMiddlewareAuthFunction([]AuthService{failingService, successfulService})(context.Background())
 	assert.NotNil(t, e, "failed auth should result in error")
@@ -26,13 +26,60 @@ func TestCreateMiddlewareAuthFunction(t *testing.T) {
 	assert.NotNil(t, e, "no credentials should result in error")
 }
 
+func TestCreateMiddlewareAuthFunctionContinuesEvenWithInvalidCreds(t *testing.T) {
+	principal := NewStaticPrincipal("test", []string{"group"})
+	invalidCredsService := &fakeAuthService{
+		principal: principal,
+		err:       invalidCredentialsErr,
+		name:      "invalidCredsService",
+	}
+	secondInvalidCredsService := &fakeAuthService{
+		principal: principal,
+		err:       invalidCredentialsErr,
+		name:      "secondInvalidCredsService",
+	}
+	missingCredsService := &fakeAuthService{
+		principal: principal,
+		err:       missingCredentialsErr,
+		name:      "missingCredsService",
+	}
+	successfulService := &fakeAuthService{
+		principal: principal,
+		err:       nil,
+		name:      "successService",
+	}
+
+	_, e := CreateMiddlewareAuthFunction(
+		[]AuthService{
+			invalidCredsService,
+			missingCredsService,
+			secondInvalidCredsService,
+		})(context.Background())
+	assert.NotNil(t, e, "failed auth should result in error")
+	assert.Contains(t, e.Error(), invalidCredsService.Name())
+	assert.Contains(t, e.Error(), missingCredsService.Name())
+	assert.Contains(t, e.Error(), secondInvalidCredsService.Name())
+
+	c, e := CreateMiddlewareAuthFunction(
+		[]AuthService{
+			invalidCredsService,
+			missingCredsService,
+			secondInvalidCredsService,
+			successfulService,
+		})(context.Background())
+	assert.Nil(t, e)
+	ctxPrincipal := GetPrincipal(c)
+	assert.Equal(t, principal, ctxPrincipal, "principal should be added to context")
+}
+
 type fakeAuthService struct {
 	principal Principal
 	err       error
+	name      string
 }
 
 func (f *fakeAuthService) Name() string {
-	return "Fake"
+	return f.name
 }
 
 func (f *fakeAuthService) Authenticate(ctx context.Context) (Principal, error) {

--- a/internal/common/auth/authorization/common_test.go
+++ b/internal/common/auth/authorization/common_test.go
@@ -31,6 +31,10 @@ type fakeAuthService struct {
 	err       error
 }
 
+func (f *fakeAuthService) Name() string {
+	return "Fake"
+}
+
 func (f *fakeAuthService) Authenticate(ctx context.Context) (Principal, error) {
 	return f.principal, f.err
 }

--- a/internal/common/auth/authorization/kerberos.go
+++ b/internal/common/auth/authorization/kerberos.go
@@ -64,6 +64,10 @@ func NewKerberosAuthService(config *configuration.KerberosAuthenticationConfig, 
 	}, nil
 }
 
+func (authService *KerberosAuthService) Name() string {
+	return "Kerberos"
+}
+
 func (authService *KerberosAuthService) Authenticate(ctx context.Context) (Principal, error) {
 	encodedToken, err := grpc_auth.AuthFromMD(ctx, spnego.HTTPHeaderAuthResponseValueKey)
 	if err != nil {

--- a/internal/common/auth/authorization/kerberos.go
+++ b/internal/common/auth/authorization/kerberos.go
@@ -73,7 +73,7 @@ func (authService *KerberosAuthService) Authenticate(ctx context.Context) (Princ
 	if err != nil {
 		// Add WWW-Authenticate header
 		_ = grpc.SetHeader(ctx, metadata.Pairs(spnego.HTTPHeaderAuthResponse, spnego.HTTPHeaderAuthResponseValueKey))
-		return nil, missingCredentials
+		return nil, missingCredentialsErr
 	}
 
 	tokenData, err := base64.StdEncoding.DecodeString(encodedToken)

--- a/internal/common/auth/authorization/kubernetes.go
+++ b/internal/common/auth/authorization/kubernetes.go
@@ -66,6 +66,10 @@ func NewKubernetesNativeAuthService(config configuration.KubernetesAuthConfig) K
 	}
 }
 
+func (authService *KubernetesNativeAuthService) Name() string {
+	return "KubernetesNative"
+}
+
 type CacheData struct {
 	Name  string `json:"name"`
 	Valid bool   `json:"valid"`
@@ -76,12 +80,12 @@ func (authService *KubernetesNativeAuthService) Authenticate(ctx context.Context
 	authHeader := strings.SplitN(metautils.ExtractIncoming(ctx).Get("authorization"), " ", 2)
 
 	if len(authHeader) < 2 || authHeader[0] != "KubernetesAuth" {
-		return nil, missingCredentials
+		return nil, missingCredentialsErr
 	}
 
 	token, ca, err := parseAuth(authHeader[1])
 	if err != nil {
-		return nil, missingCredentials
+		return nil, missingCredentialsErr
 	}
 
 	// Get token time

--- a/internal/common/auth/authorization/oidc.go
+++ b/internal/common/auth/authorization/oidc.go
@@ -38,6 +38,10 @@ func NewOpenIdAuthService(verifier *oidc.IDTokenVerifier, groupsClaim string) *O
 	return &OpenIdAuthService{verifier, groupsClaim}
 }
 
+func (authService *OpenIdAuthService) Name() string {
+	return "OIDC"
+}
+
 func (authService *OpenIdAuthService) Authenticate(ctx context.Context) (Principal, error) {
 	token, err := grpc_auth.AuthFromMD(ctx, "bearer")
 	if err != nil {

--- a/internal/common/auth/authorization/oidc.go
+++ b/internal/common/auth/authorization/oidc.go
@@ -45,7 +45,7 @@ func (authService *OpenIdAuthService) Name() string {
 func (authService *OpenIdAuthService) Authenticate(ctx context.Context) (Principal, error) {
 	token, err := grpc_auth.AuthFromMD(ctx, "bearer")
 	if err != nil {
-		return nil, missingCredentials
+		return nil, missingCredentialsErr
 	}
 
 	verifiedToken, err := authService.verifier.Verify(ctx, token)

--- a/internal/common/auth/authorization/oidc_test.go
+++ b/internal/common/auth/authorization/oidc_test.go
@@ -39,12 +39,12 @@ func TestOpenIdAuthService(t *testing.T) {
 	assert.True(t, principal.IsInGroup("test"))
 
 	_, e = service.Authenticate(context.Background())
-	assert.Equal(t, missingCredentials, e)
+	assert.Equal(t, missingCredentialsErr, e)
 
 	keySet.err = errors.New("wrong signature")
 	_, e = service.Authenticate(ctx)
 	assert.NotNil(t, e)
-	assert.NotEqual(t, missingCredentials, e)
+	assert.NotEqual(t, missingCredentialsErr, e)
 }
 
 type fakeKeySet struct {


### PR DESCRIPTION
Closes #1370 

Improve auth middleware logging by recording all auth services attempted along with principal names.

This does not currently address logging the action taking place. That seems like it should already be covered by other logging middleware.