### PR TITLE
Changed jobservice.db to /jobservice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ armadactl.yaml
 loadtest.yaml
 test_reports
 code_reports
-jobservice.db
+/jobservice
 
 # Binaries for programs and plugins
 *.exe

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ loadtest.yaml
 test_reports
 code_reports
 /jobservice
+jobservice.db
 
 # Binaries for programs and plugins
 *.exe


### PR DESCRIPTION
This should only ignore the `jobservice` dir in the root of the git repo. See https://stackoverflow.com/questions/23196518/git-ignore-directory-using-absolute-path

Closes #1581