### PR TITLE
Improve gRPC error message returned when auth fails.

### DIFF
--- a/internal/armada/server/authorization.go
+++ b/internal/armada/server/authorization.go
@@ -10,14 +10,14 @@ import (
 	"github.com/G-Research/armada/pkg/client/queue"
 )
 
-// ErrNoPermission represents an error that occurs when a client tries to perform some action
+// ErrUnauthorized represents an error that occurs when a client tries to perform some action
 // through the gRPC API for which it does not have permissions.
 // Produces error messages of the form
 // "Tom" does not own the queue and have SubmitJobs permissions, "Tom" does not have SubmitAnyJobs permissions
 //
 // The caller of a function that may produce this error should capture is using errors.As and prepend
 // whatever action the principal was attempting.
-type ErrNoPermission struct {
+type ErrUnauthorized struct {
 	// Principal that attempted the action
 	Principal authorization.Principal
 	// Reasons that the principal was not allowed to perform the action
@@ -25,7 +25,7 @@ type ErrNoPermission struct {
 	Reasons []string
 }
 
-func (err *ErrNoPermission) Error() string {
+func (err *ErrUnauthorized) Error() string {
 	principalName := err.Principal.GetName()
 	reasons := make([]string, len(err.Reasons), len(err.Reasons))
 	for i, reason := range err.Reasons {
@@ -34,8 +34,8 @@ func (err *ErrNoPermission) Error() string {
 	return strings.Join(reasons, ", ")
 }
 
-func MergePermissionErrors(errs ...*ErrNoPermission) *ErrNoPermission {
-	var filtered []*ErrNoPermission
+func MergePermissionErrors(errs ...*ErrUnauthorized) *ErrUnauthorized {
+	var filtered []*ErrUnauthorized
 	for _, err := range errs {
 		if err != nil {
 			filtered = append(filtered, err)
@@ -46,7 +46,7 @@ func MergePermissionErrors(errs ...*ErrNoPermission) *ErrNoPermission {
 		return nil
 	}
 
-	merged := &ErrNoPermission{
+	merged := &ErrUnauthorized{
 		Principal: filtered[0].Principal,
 		Reasons:   []string{},
 	}
@@ -57,12 +57,12 @@ func MergePermissionErrors(errs ...*ErrNoPermission) *ErrNoPermission {
 }
 
 // checkPermission is a helper function called by the gRPC handlers to check if a client has the
-// permissions required to perform some action. The error returned is of type ErrNoPermission.
+// permissions required to perform some action. The error returned is of type ErrUnauthorized.
 // After recovering the error (using errors.As), the caller can obtain the name of the user and the
 // requested permission programatically via this error type.
 func checkPermission(p authorization.PermissionChecker, ctx context.Context, permission permission.Permission) error {
 	if !p.UserHasPermission(ctx, permission) {
-		return &ErrNoPermission{
+		return &ErrUnauthorized{
 			Principal: authorization.GetPrincipal(ctx),
 			Reasons: []string{
 				fmt.Sprintf("does not have permission %s", permission),
@@ -110,7 +110,7 @@ func checkQueuePermission(
 		}
 	}
 
-	return &ErrNoPermission{
+	return &ErrUnauthorized{
 		Principal: principal,
 		Reasons: []string{
 			fmt.Sprintf("does not have permission %s", verb),

--- a/internal/armada/server/event.go
+++ b/internal/armada/server/event.go
@@ -237,10 +237,10 @@ func (s *EventServer) serveEventsFromRepository(request *api.JobSetRequest, even
 
 func validateUserHasWatchPermissions(ctx context.Context, permsChecker authorization.PermissionChecker, q queue.Queue, jobSetId string) error {
 	err := checkPermission(permsChecker, ctx, permissions.WatchAllEvents)
-	var globalPermErr *ErrNoPermission
+	var globalPermErr *ErrUnauthorized
 	if errors.As(err, &globalPermErr) {
 		err = checkQueuePermission(permsChecker, ctx, q, permissions.WatchEvents, queue.PermissionVerbWatch)
-		var queuePermErr *ErrNoPermission
+		var queuePermErr *ErrUnauthorized
 		if errors.As(err, &queuePermErr) {
 			return status.Errorf(codes.PermissionDenied, "error getting events for queue: %s, job set: %s: %s",
 				q.Name, jobSetId, MergePermissionErrors(globalPermErr, queuePermErr))

--- a/internal/armada/server/submit.go
+++ b/internal/armada/server/submit.go
@@ -93,10 +93,10 @@ func (server *SubmitServer) GetQueueInfo(ctx context.Context, req *api.QueueInfo
 	}
 
 	err = checkPermission(server.permissions, ctx, permissions.WatchAllEvents)
-	var globalPermErr *ErrNoPermission
+	var globalPermErr *ErrUnauthorized
 	if errors.As(err, &globalPermErr) {
 		err = checkQueuePermission(server.permissions, ctx, q, permissions.WatchEvents, queue.PermissionVerbWatch)
-		var queuePermErr *ErrNoPermission
+		var queuePermErr *ErrUnauthorized
 		if errors.As(err, &queuePermErr) {
 			return nil, status.Errorf(codes.PermissionDenied,
 				"[GetQueueInfo] error getting info for queue %s: %s", req.Name, MergePermissionErrors(globalPermErr, queuePermErr))
@@ -131,7 +131,7 @@ func (server *SubmitServer) GetQueue(ctx context.Context, req *api.QueueGetReque
 
 func (server *SubmitServer) CreateQueue(ctx context.Context, request *api.Queue) (*types.Empty, error) {
 	err := checkPermission(server.permissions, ctx, permissions.CreateQueue)
-	var ep *ErrNoPermission
+	var ep *ErrUnauthorized
 	if errors.As(err, &ep) {
 		return nil, status.Errorf(codes.PermissionDenied, "[CreateQueue] error creating queue %s: %s", request.Name, ep)
 	} else if err != nil {
@@ -180,7 +180,7 @@ func (server *SubmitServer) CreateQueues(ctx context.Context, request *api.Queue
 
 func (server *SubmitServer) UpdateQueue(ctx context.Context, request *api.Queue) (*types.Empty, error) {
 	err := checkPermission(server.permissions, ctx, permissions.CreateQueue)
-	var ep *ErrNoPermission
+	var ep *ErrUnauthorized
 	if errors.As(err, &ep) {
 		return nil, status.Errorf(codes.PermissionDenied, "[UpdateQueue] error updating queue %s: %s", request.Name, ep)
 	} else if err != nil {
@@ -224,7 +224,7 @@ func (server *SubmitServer) UpdateQueues(ctx context.Context, request *api.Queue
 
 func (server *SubmitServer) DeleteQueue(ctx context.Context, request *api.QueueDeleteRequest) (*types.Empty, error) {
 	err := checkPermission(server.permissions, ctx, permissions.DeleteQueue)
-	var ep *ErrNoPermission
+	var ep *ErrUnauthorized
 	if errors.As(err, &ep) {
 		return nil, status.Errorf(codes.PermissionDenied, "[DeleteQueue] error deleting queue %s: %s", request.Name, ep)
 	} else if err != nil {
@@ -275,10 +275,10 @@ func (server *SubmitServer) SubmitJobs(ctx context.Context, req *api.JobSubmitRe
 	}
 
 	err = checkPermission(server.permissions, ctx, permissions.SubmitAnyJobs)
-	var globalPermErr *ErrNoPermission
+	var globalPermErr *ErrUnauthorized
 	if errors.As(err, &globalPermErr) {
 		err = checkQueuePermission(server.permissions, ctx, *q, permissions.SubmitJobs, queue.PermissionVerbSubmit)
-		var queuePermErr *ErrNoPermission
+		var queuePermErr *ErrUnauthorized
 		if errors.As(err, &queuePermErr) {
 			return nil, status.Errorf(codes.PermissionDenied,
 				"[SubmitJobs] error submitting job in queue %s: %s", req.Queue, MergePermissionErrors(globalPermErr, queuePermErr))
@@ -454,7 +454,7 @@ func (server *SubmitServer) cancelJobsById(ctx context.Context, jobId string) (*
 	}
 
 	result, err := server.cancelJobs(ctx, jobs)
-	var e *ErrNoPermission
+	var e *ErrUnauthorized
 	if errors.As(err, &e) {
 		return nil, status.Errorf(codes.PermissionDenied, "[cancelJobsById] error canceling job with ID %s: %s", jobId, e)
 	} else if err != nil {
@@ -488,7 +488,7 @@ func (server *SubmitServer) cancelJobsByQueueAndSet(
 		}
 
 		result, err := server.cancelJobs(ctx, jobs)
-		var e *ErrNoPermission
+		var e *ErrUnauthorized
 		if errors.As(err, &e) {
 			return nil, status.Errorf(codes.PermissionDenied, "[cancelJobsBySetAndQueue] error canceling jobs: %s", e)
 		} else if err != nil {
@@ -556,10 +556,10 @@ func (server *SubmitServer) checkCancelPerms(ctx context.Context, jobs []*api.Jo
 		}
 
 		err = checkPermission(server.permissions, ctx, permissions.CancelAnyJobs)
-		var globalPermErr *ErrNoPermission
+		var globalPermErr *ErrUnauthorized
 		if errors.As(err, &globalPermErr) {
 			err = checkQueuePermission(server.permissions, ctx, q, permissions.CancelJobs, queue.PermissionVerbCancel)
-			var queuePermErr *ErrNoPermission
+			var queuePermErr *ErrUnauthorized
 			if errors.As(err, &queuePermErr) {
 				return MergePermissionErrors(globalPermErr, queuePermErr)
 			} else if err != nil {
@@ -598,7 +598,7 @@ func (server *SubmitServer) ReprioritizeJobs(ctx context.Context, request *api.J
 	}
 
 	err := server.checkReprioritizePerms(ctx, jobs)
-	var e *ErrNoPermission
+	var e *ErrUnauthorized
 	if errors.As(err, &e) {
 		return nil, status.Errorf(codes.PermissionDenied, "[ReprioritizeJobs] error: %s", e)
 	} else if err != nil {
@@ -679,10 +679,10 @@ func (server *SubmitServer) checkReprioritizePerms(ctx context.Context, jobs []*
 		}
 
 		err = checkPermission(server.permissions, ctx, permissions.ReprioritizeAnyJobs)
-		var globalPermErr *ErrNoPermission
+		var globalPermErr *ErrUnauthorized
 		if errors.As(err, &globalPermErr) {
 			err = checkQueuePermission(server.permissions, ctx, q, permissions.ReprioritizeJobs, queue.PermissionVerbReprioritize)
-			var queuePermErr *ErrNoPermission
+			var queuePermErr *ErrUnauthorized
 			if errors.As(err, &queuePermErr) {
 				return MergePermissionErrors(globalPermErr, queuePermErr)
 			} else if err != nil {

--- a/internal/armada/server/submit_to_log.go
+++ b/internal/armada/server/submit_to_log.go
@@ -540,7 +540,7 @@ func (srv *PulsarSubmitServer) Authorize(
 	}
 	if !srv.Permissions.UserHasPermission(ctx, anyPerm) {
 		if !principalHasQueuePermissions(principal, q, perm) {
-			err = &armadaerrors.ErrNoPermission{
+			err = &armadaerrors.ErrUnauthorized{
 				Principal:  principal.GetName(),
 				Permission: string(perm),
 				Action:     string(perm) + " for queue " + q.Name,

--- a/internal/common/armadaerrors/errors.go
+++ b/internal/common/armadaerrors/errors.go
@@ -663,6 +663,9 @@ func (err *ErrMissingCredentials) Error() (s string) {
 		err.Message)
 }
 
+// ErrInternalAuthServiceError is returned when an auth service encounters
+// an internal error that is not directly related to the supplied input/
+// credentials.
 type ErrInternalAuthServiceError struct {
 	// Optional message included with the error message.
 	Message string
@@ -678,9 +681,6 @@ func (err *ErrInternalAuthServiceError) GRPCStatus() *status.Status {
 	return status.New(codes.Unavailable, err.Error())
 }
 
-// ErrInternalAuthServiceError is returned when an auth service encounters
-// an internal error that is not directly related to the supplied input/
-// credentials.
 func (err *ErrInternalAuthServiceError) Error() string {
 	return craftFullErrorMessageForAuthRelatedErrors(
 		"Encountered an internal error",

--- a/internal/common/armadaerrors/errors.go
+++ b/internal/common/armadaerrors/errors.go
@@ -27,12 +27,12 @@ import (
 	"github.com/G-Research/armada/internal/common/requestid"
 )
 
-// ErrNoPermission represents an error that occurs when a client tries to perform some action
+// ErrUnauthorized represents an error that occurs when a client tries to perform some action
 // through the gRPC API for which it does not have permissions.
 //
 // It may be necessary populate the Action field by recovering this error at the gRPC endpoint (using errors.As)
 // and updating the field in-place.
-type ErrNoPermission struct {
+type ErrUnauthorized struct {
 	// Principal that attempted the action
 	Principal string
 	// The missing permission
@@ -43,7 +43,7 @@ type ErrNoPermission struct {
 	Message string
 }
 
-func (err *ErrNoPermission) Error() (s string) {
+func (err *ErrUnauthorized) Error() (s string) {
 	if err.Action != "" {
 		s = fmt.Sprintf("%s lacks permission %s required for action %s", err.Principal, err.Permission, err.Action)
 	} else {
@@ -400,7 +400,7 @@ func addActionUnary(err error, info *grpc.UnaryServerInfo) {
 		}
 	}
 	{
-		var e *ErrNoPermission
+		var e *ErrUnauthorized
 		if errors.As(err, &e) {
 			e.Action = info.FullMethod
 		}
@@ -416,7 +416,7 @@ func addActionStream(err error, info *grpc.StreamServerInfo) {
 		}
 	}
 	{
-		var e *ErrNoPermission
+		var e *ErrUnauthorized
 		if errors.As(err, &e) {
 			e.Action = info.FullMethod
 		}

--- a/internal/common/armadaerrors/errors.go
+++ b/internal/common/armadaerrors/errors.go
@@ -279,7 +279,7 @@ func CodeFromError(err error) codes.Code {
 		}
 	}
 	{
-		var e *ErrUnauthorized
+		var e *ErrUnauthenticated
 		if errors.As(err, &e) {
 			return codes.Unauthenticated
 		}
@@ -394,7 +394,7 @@ func IsNetworkError(err error) bool {
 // Add the action to th error if possible.
 func addActionUnary(err error, info *grpc.UnaryServerInfo) {
 	{
-		var e *ErrUnauthorized
+		var e *ErrUnauthenticated
 		if errors.As(err, &e) {
 			e.Action = info.FullMethod
 		}
@@ -410,7 +410,7 @@ func addActionUnary(err error, info *grpc.UnaryServerInfo) {
 // Add the action to th error if possible.
 func addActionStream(err error, info *grpc.StreamServerInfo) {
 	{
-		var e *ErrUnauthorized
+		var e *ErrUnauthenticated
 		if errors.As(err, &e) {
 			e.Action = info.FullMethod
 		}
@@ -591,12 +591,12 @@ func NewCombinedErrPodUnschedulable(errs ...error) *ErrPodUnschedulable {
 	return result
 }
 
-// ErrUnauthorized represents an error that occurs when a client tries to
+// ErrUnauthenticated represents an error that occurs when a client tries to
 // perform some action through the gRPC API for which it cannot authenticate.
 //
 // It may be necessary populate the Action field by recovering this error at
 // the gRPC endpoint (using errors.As) and updating the field in-place.
-type ErrUnauthorized struct {
+type ErrUnauthenticated struct {
 	// Principal that attempted the action.
 	Principal string
 	// The authorization service which attempted to authenticate the principal.
@@ -607,7 +607,7 @@ type ErrUnauthorized struct {
 	Message string
 }
 
-func (err *ErrUnauthorized) Error() (s string) {
+func (err *ErrUnauthenticated) Error() (s string) {
 	if err.Action != "" {
 		s = fmt.Sprintf("Could not authorize user %q via service %q while attempting action %q",
 			err.Principal, err.AuthService, err.Action)

--- a/internal/common/armadaerrors/errors.go
+++ b/internal/common/armadaerrors/errors.go
@@ -548,3 +548,32 @@ func NewCombinedErrPodUnschedulable(errs ...error) *ErrPodUnschedulable {
 	}
 	return result
 }
+
+// ErrUnauthorized represents an error that occurs when a client tries to
+// perform some action through the gRPC API for which it cannot authenticate.
+//
+// It may be necessary populate the Action field by recovering this error at
+// the gRPC endpoint (using errors.As) and updating the field in-place.
+type ErrUnauthorized struct {
+	// Principal that attempted the action.
+	Principal string
+	// The authorization service which attempted to authenticate the principal.
+	AuthService string
+	// The attempted action
+	Action string
+	// Optional message included with the error message
+	Message string
+}
+
+func (err *ErrUnauthorized) Error() (s string) {
+	if err.Action != "" {
+		s = fmt.Sprintf("Could not authorize user %q via service %q while attempting action %q",
+			err.Principal, err.AuthService, err.Action)
+	} else {
+		s = fmt.Sprintf("Could not authorized user %q via service %q", err.AuthService, err.Action)
+	}
+	if err.Message != "" {
+		s += fmt.Sprintf("; %s", err.Message)
+	}
+	return
+}

--- a/internal/common/armadaerrors/errors_test.go
+++ b/internal/common/armadaerrors/errors_test.go
@@ -54,7 +54,7 @@ func TestUnaryServerInterceptor(t *testing.T) {
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return nil, handlerErr
 	}
-	f := UnaryServerInterceptor(100)
+	f := UnaryServerInterceptor(1000)
 
 	// nils should be passed through as-is
 	handlerErr = nil
@@ -94,6 +94,22 @@ func TestUnaryServerInterceptor(t *testing.T) {
 	st, ok = status.FromError(err)
 	assert.True(t, ok)
 	assert.Contains(t, st.Message(), id)
+
+	// the action or method should get added to errors that support it.
+	unauthErr := &ErrUnauthorized{
+		Principal:   "testUser",
+		AuthService: "testService",
+		Message:     "invalid username/password combo",
+	}
+	handlerErr = errors.WithMessage(errors.WithStack(unauthErr), "foo")
+	ctx = context.Background()
+	ctx = metadata.NewIncomingContext(ctx, metadata.New(map[string]string{}))
+	_, err = f(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "testMethod"}, handler)
+	st, ok = status.FromError(err)
+	assert.True(t, ok)
+	assert.Equal(t, codes.Unauthenticated, st.Code())
+	assert.Equal(t, errors.WithMessage(unauthErr, "foo").Error(), st.Message())
+	assert.Contains(t, st.Message(), "testMethod")
 }
 
 func TestStreamServerInterceptor(t *testing.T) {
@@ -105,7 +121,7 @@ func TestStreamServerInterceptor(t *testing.T) {
 	handler := func(srv interface{}, stream grpc.ServerStream) error {
 		return handlerErr
 	}
-	f := StreamServerInterceptor(100)
+	f := StreamServerInterceptor(1000)
 
 	// nils should be passed through as-is
 	handlerErr = nil
@@ -146,6 +162,23 @@ func TestStreamServerInterceptor(t *testing.T) {
 	st, ok = status.FromError(err)
 	assert.True(t, ok)
 	assert.Contains(t, st.Message(), id)
+
+	// the action or method should get added to errors that support it.
+	unauthErr := &ErrUnauthorized{
+		Principal:   "testUser",
+		AuthService: "testService",
+		Message:     "invalid username/password combo",
+	}
+	handlerErr = errors.WithMessage(errors.WithStack(unauthErr), "foo")
+	ctx = context.Background()
+	ctx = metadata.NewIncomingContext(ctx, metadata.New(map[string]string{}))
+	stream.WrappedContext = ctx
+	err = f(ctx, stream, &grpc.StreamServerInfo{FullMethod: "testMethod"}, handler)
+	st, ok = status.FromError(err)
+	assert.True(t, ok)
+	assert.Equal(t, codes.Unauthenticated, st.Code())
+	assert.Equal(t, errors.WithMessage(unauthErr, "foo").Error(), st.Message())
+	assert.Contains(t, st.Message(), "testMethod")
 }
 
 func TestIsNetworkErrorRedis(t *testing.T) {

--- a/internal/common/armadaerrors/errors_test.go
+++ b/internal/common/armadaerrors/errors_test.go
@@ -97,9 +97,7 @@ func TestUnaryServerInterceptor(t *testing.T) {
 
 	// the action or method should get added to errors that support it.
 	unauthErr := &ErrUnauthenticated{
-		Principal:   "testUser",
-		AuthService: "testService",
-		Message:     "invalid username/password combo",
+		Message: "invalid username/password combo",
 	}
 	handlerErr = errors.WithMessage(errors.WithStack(unauthErr), "foo")
 	ctx = context.Background()
@@ -165,9 +163,7 @@ func TestStreamServerInterceptor(t *testing.T) {
 
 	// the action or method should get added to errors that support it.
 	unauthErr := &ErrUnauthenticated{
-		Principal:   "testUser",
-		AuthService: "testService",
-		Message:     "invalid username/password combo",
+		Message: "invalid username/password combo",
 	}
 	handlerErr = errors.WithMessage(errors.WithStack(unauthErr), "foo")
 	ctx = context.Background()

--- a/internal/common/armadaerrors/errors_test.go
+++ b/internal/common/armadaerrors/errors_test.go
@@ -96,7 +96,7 @@ func TestUnaryServerInterceptor(t *testing.T) {
 	assert.Contains(t, st.Message(), id)
 
 	// the action or method should get added to errors that support it.
-	unauthErr := &ErrUnauthorized{
+	unauthErr := &ErrUnauthenticated{
 		Principal:   "testUser",
 		AuthService: "testService",
 		Message:     "invalid username/password combo",
@@ -164,7 +164,7 @@ func TestStreamServerInterceptor(t *testing.T) {
 	assert.Contains(t, st.Message(), id)
 
 	// the action or method should get added to errors that support it.
-	unauthErr := &ErrUnauthorized{
+	unauthErr := &ErrUnauthenticated{
 		Principal:   "testUser",
 		AuthService: "testService",
 		Message:     "invalid username/password combo",

--- a/internal/common/auth/authorization/anonymous.go
+++ b/internal/common/auth/authorization/anonymous.go
@@ -4,6 +4,10 @@ import "context"
 
 type AnonymousAuthService struct{}
 
+func (authService *AnonymousAuthService) Name() string {
+	return "Anonymous"
+}
+
 func (AnonymousAuthService) Authenticate(ctx context.Context) (Principal, error) {
 	return anonymousPrincipal, nil
 }

--- a/internal/common/auth/authorization/basic.go
+++ b/internal/common/auth/authorization/basic.go
@@ -28,7 +28,7 @@ func (authService *BasicAuthService) Authenticate(ctx context.Context) (Principa
 	if err == nil {
 		payload, err := base64.StdEncoding.DecodeString(basicAuth)
 		if err != nil {
-			return nil, &armadaerrors.ErrMissingCredentials{
+			return nil, &armadaerrors.ErrInvalidCredentials{
 				AuthService: authService.Name(),
 				Message:     err.Error(),
 			}

--- a/internal/common/auth/authorization/basic.go
+++ b/internal/common/auth/authorization/basic.go
@@ -7,6 +7,7 @@ import (
 
 	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
 
+	"github.com/G-Research/armada/internal/common/armadaerrors"
 	"github.com/G-Research/armada/internal/common/auth/configuration"
 )
 
@@ -32,7 +33,9 @@ func (authService *BasicAuthService) Authenticate(ctx context.Context) (Principa
 		pair := strings.SplitN(string(payload), ":", 2)
 		return authService.loginUser(pair[0], pair[1])
 	}
-	return nil, missingCredentials
+	return nil, &armadaerrors.ErrMissingCredentials{
+		AuthService: authService.Name(),
+	}
 }
 
 func (authService *BasicAuthService) loginUser(username string, password string) (Principal, error) {
@@ -40,5 +43,8 @@ func (authService *BasicAuthService) loginUser(username string, password string)
 	if ok && userInfo.Password == password {
 		return NewStaticPrincipal(username, userInfo.Groups), nil
 	}
-	return nil, invalidCredentials
+	return nil, &armadaerrors.ErrInvalidCredentials{
+		Username:    username,
+		AuthService: authService.Name(),
+	}
 }

--- a/internal/common/auth/authorization/basic.go
+++ b/internal/common/auth/authorization/basic.go
@@ -18,6 +18,10 @@ func NewBasicAuthService(users map[string]configuration.UserInfo) *BasicAuthServ
 	return &BasicAuthService{users: users}
 }
 
+func (authService *BasicAuthService) Name() string {
+	return "Basic"
+}
+
 func (authService *BasicAuthService) Authenticate(ctx context.Context) (Principal, error) {
 	basicAuth, err := grpc_auth.AuthFromMD(ctx, "basic")
 	if err == nil {

--- a/internal/common/auth/authorization/basic.go
+++ b/internal/common/auth/authorization/basic.go
@@ -28,7 +28,10 @@ func (authService *BasicAuthService) Authenticate(ctx context.Context) (Principa
 	if err == nil {
 		payload, err := base64.StdEncoding.DecodeString(basicAuth)
 		if err != nil {
-			return nil, err
+			return nil, &armadaerrors.ErrMissingCredentials{
+				AuthService: authService.Name(),
+				Message:     err.Error(),
+			}
 		}
 		pair := strings.SplitN(string(payload), ":", 2)
 		return authService.loginUser(pair[0], pair[1])

--- a/internal/common/auth/authorization/basic_test.go
+++ b/internal/common/auth/authorization/basic_test.go
@@ -2,7 +2,6 @@ package authorization
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,7 +27,6 @@ func TestBasicAuthService(t *testing.T) {
 		metadata.NewIncomingContext(context.Background(), basicPassword("root", "test")))
 
 	assert.NotNil(t, e)
-	fmt.Println(e.Error())
 	var invalidCredsErr *armadaerrors.ErrInvalidCredentials
 	assert.ErrorAs(t, e, &invalidCredsErr)
 

--- a/internal/common/auth/authorization/basic_test.go
+++ b/internal/common/auth/authorization/basic_test.go
@@ -2,12 +2,14 @@ package authorization
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/metadata"
 
 	"github.com/G-Research/armada/internal/common"
+	"github.com/G-Research/armada/internal/common/armadaerrors"
 	"github.com/G-Research/armada/internal/common/auth/configuration"
 )
 
@@ -26,10 +28,13 @@ func TestBasicAuthService(t *testing.T) {
 		metadata.NewIncomingContext(context.Background(), basicPassword("root", "test")))
 
 	assert.NotNil(t, e)
-	assert.NotEqual(t, e, missingCredentials)
+	fmt.Println(e.Error())
+	var invalidCredsErr *armadaerrors.ErrInvalidCredentials
+	assert.ErrorAs(t, e, &invalidCredsErr)
 
 	_, e = service.Authenticate(context.Background())
-	assert.Equal(t, e, missingCredentials)
+	var missingCredsErr *armadaerrors.ErrMissingCredentials
+	assert.ErrorAs(t, e, &missingCredsErr)
 }
 
 func basicPassword(user, password string) map[string][]string {

--- a/internal/common/auth/authorization/common.go
+++ b/internal/common/auth/authorization/common.go
@@ -2,6 +2,7 @@ package authorization
 
 import (
 	"context"
+	"errors"
 
 	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
 	grpc_ctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
@@ -127,10 +128,10 @@ func CreateMiddlewareAuthFunction(authServices []AuthService) grpc_auth.AuthFunc
 	return func(ctx context.Context) (context.Context, error) {
 		for _, service := range authServices {
 			principal, err := service.Authenticate(ctx)
-			if err == missingCredentials {
+			if errors.Is(err, missingCredentials) {
 				// try next auth service
 				continue
-			} else if err == invalidCredentials {
+			} else if errors.Is(err, invalidCredentials) {
 				return nil, &armadaerrors.ErrUnauthorized{
 					Principal:   principal.GetName(),
 					AuthService: service.Name(),

--- a/internal/common/auth/authorization/common.go
+++ b/internal/common/auth/authorization/common.go
@@ -135,6 +135,7 @@ func CreateMiddlewareAuthFunction(authServices []AuthService) grpc_auth.AuthFunc
 			}
 			// record user name for request logging
 			grpc_ctxtags.Extract(ctx).Set("user", principal.GetName())
+			grpc_ctxtags.Extract(ctx).Set("authService", service.Name())
 			return WithPrincipal(ctx, principal), nil
 		}
 		return nil, status.Errorf(codes.Unauthenticated, "Request in not authenticated with any of the supported schemes.")

--- a/internal/common/auth/authorization/common.go
+++ b/internal/common/auth/authorization/common.go
@@ -132,7 +132,7 @@ func CreateMiddlewareAuthFunction(authServices []AuthService) grpc_auth.AuthFunc
 				// try next auth service
 				continue
 			} else if errors.Is(err, invalidCredentials) {
-				return nil, &armadaerrors.ErrUnauthorized{
+				return nil, &armadaerrors.ErrUnauthenticated{
 					Principal:   principal.GetName(),
 					AuthService: service.Name(),
 					Message:     invalidCredentials.Error(),

--- a/internal/common/auth/authorization/common.go
+++ b/internal/common/auth/authorization/common.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/G-Research/armada/internal/common/armadaerrors"
 	"github.com/G-Research/armada/internal/common/util"
 )
 
@@ -129,6 +130,12 @@ func CreateMiddlewareAuthFunction(authServices []AuthService) grpc_auth.AuthFunc
 			if err == missingCredentials {
 				// try next auth service
 				continue
+			} else if err == invalidCredentials {
+				return nil, &armadaerrors.ErrUnauthorized{
+					Principal:   principal.GetName(),
+					AuthService: service.Name(),
+					Message:     invalidCredentials.Error(),
+				}
 			}
 			if err != nil {
 				return nil, err

--- a/internal/common/auth/authorization/common.go
+++ b/internal/common/auth/authorization/common.go
@@ -108,6 +108,7 @@ func WithPrincipal(ctx context.Context, principal Principal) context.Context {
 // The gRPC server may be started with multiple AuthService to give several options for authentication.
 type AuthService interface {
 	Authenticate(ctx context.Context) (Principal, error)
+	Name() string
 }
 
 // CreateMiddlewareAuthFunction returns an authentication function that combines the given

--- a/internal/common/auth/authorization/common_test.go
+++ b/internal/common/auth/authorization/common_test.go
@@ -6,12 +6,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/G-Research/armada/internal/common/armadaerrors"
 )
 
 func TestCreateMiddlewareAuthFunction(t *testing.T) {
 	principal := NewStaticPrincipal("test", []string{"group"})
 	failingService := &fakeAuthService{nil, errors.New("failed")}
-	serviceWithoutCredentials := &fakeAuthService{nil, missingCredentials}
+	serviceWithoutCredentials := &fakeAuthService{nil, &armadaerrors.ErrMissingCredentials{}}
 	successfulService := &fakeAuthService{principal, nil}
 
 	_, e := CreateMiddlewareAuthFunction([]AuthService{failingService, successfulService})(context.Background())

--- a/internal/common/auth/authorization/common_test.go
+++ b/internal/common/auth/authorization/common_test.go
@@ -31,6 +31,10 @@ type fakeAuthService struct {
 	err       error
 }
 
+func (f *fakeAuthService) Name() string {
+	return "Fake"
+}
+
 func (f *fakeAuthService) Authenticate(ctx context.Context) (Principal, error) {
 	return f.principal, f.err
 }

--- a/internal/common/auth/authorization/kerberos.go
+++ b/internal/common/auth/authorization/kerberos.go
@@ -75,6 +75,7 @@ func (authService *KerberosAuthService) Authenticate(ctx context.Context) (Princ
 		_ = grpc.SetHeader(ctx, metadata.Pairs(spnego.HTTPHeaderAuthResponse, spnego.HTTPHeaderAuthResponseValueKey))
 		return nil, &armadaerrors.ErrMissingCredentials{
 			AuthService: authService.Name(),
+			Message:     err.Error(),
 		}
 	}
 
@@ -82,7 +83,7 @@ func (authService *KerberosAuthService) Authenticate(ctx context.Context) (Princ
 	if err != nil {
 		log.Errorf("SPNEGO invalid token, could not decode: %v", err)
 		return nil, &armadaerrors.ErrInvalidCredentials{
-			Message:     "SPNEGO invalid token",
+			Message:     "SPNEGO invalid token, could not decode",
 			AuthService: authService.Name(),
 		}
 	}
@@ -92,7 +93,7 @@ func (authService *KerberosAuthService) Authenticate(ctx context.Context) (Princ
 	if err != nil {
 		log.Errorf("SPNEGO invalid token, could not unmarshal : %v", err)
 		return nil, &armadaerrors.ErrInvalidCredentials{
-			Message:     "SPNEGO invalid token",
+			Message:     "SPNEGO invalid token, could not unmarshal",
 			AuthService: authService.Name(),
 		}
 	}

--- a/internal/common/auth/authorization/kerberos.go
+++ b/internal/common/auth/authorization/kerberos.go
@@ -64,6 +64,10 @@ func NewKerberosAuthService(config *configuration.KerberosAuthenticationConfig, 
 	}, nil
 }
 
+func (authService *KerberosAuthService) Name() string {
+	return "Kerberos"
+}
+
 func (authService *KerberosAuthService) Authenticate(ctx context.Context) (Principal, error) {
 	encodedToken, err := grpc_auth.AuthFromMD(ctx, spnego.HTTPHeaderAuthResponseValueKey)
 	if err != nil {

--- a/internal/common/auth/authorization/kubernetes.go
+++ b/internal/common/auth/authorization/kubernetes.go
@@ -71,6 +71,10 @@ type CacheData struct {
 	Valid bool   `json:"valid"`
 }
 
+func (authService *KubernetesNativeAuthService) Name() string {
+	return "KubernetesNative"
+}
+
 func (authService *KubernetesNativeAuthService) Authenticate(ctx context.Context) (Principal, error) {
 	// Retrieve token from context.
 	authHeader := strings.SplitN(metautils.ExtractIncoming(ctx).Get("authorization"), " ", 2)

--- a/internal/common/auth/authorization/kubernetes_test.go
+++ b/internal/common/auth/authorization/kubernetes_test.go
@@ -127,7 +127,7 @@ func createKubernetesAuthPayload(token string, ca string) string {
 	return "KubernetesAuth " + base64.RawURLEncoding.EncodeToString([]byte(body))
 }
 
-func TestAuthenticate(t *testing.T) {
+func TestAuthenticateKubernetes(t *testing.T) {
 	// Setup KID mapping directory
 	tempdir, err := os.MkdirTemp("", "kid-mapping")
 	defer os.Remove(tempdir)

--- a/internal/common/auth/authorization/oidc.go
+++ b/internal/common/auth/authorization/oidc.go
@@ -38,6 +38,10 @@ func NewOpenIdAuthService(verifier *oidc.IDTokenVerifier, groupsClaim string) *O
 	return &OpenIdAuthService{verifier, groupsClaim}
 }
 
+func (authService *OpenIdAuthService) Name() string {
+	return "OIDC"
+}
+
 func (authService *OpenIdAuthService) Authenticate(ctx context.Context) (Principal, error) {
 	token, err := grpc_auth.AuthFromMD(ctx, "bearer")
 	if err != nil {

--- a/internal/common/auth/authorization/oidc.go
+++ b/internal/common/auth/authorization/oidc.go
@@ -46,6 +46,7 @@ func (authService *OpenIdAuthService) Authenticate(ctx context.Context) (Princip
 	if err != nil {
 		return nil, &armadaerrors.ErrMissingCredentials{
 			AuthService: authService.Name(),
+			Message:     err.Error(),
 		}
 	}
 

--- a/internal/common/auth/authorization/oidc_test.go
+++ b/internal/common/auth/authorization/oidc_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/coreos/go-oidc"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/metadata"
+
+	"github.com/G-Research/armada/internal/common/armadaerrors"
 )
 
 func TestOpenIdAuthService(t *testing.T) {
@@ -39,12 +41,13 @@ func TestOpenIdAuthService(t *testing.T) {
 	assert.True(t, principal.IsInGroup("test"))
 
 	_, e = service.Authenticate(context.Background())
-	assert.Equal(t, missingCredentials, e)
+	var missingCredsErr *armadaerrors.ErrMissingCredentials
+	assert.ErrorAs(t, e, &missingCredsErr)
 
 	keySet.err = errors.New("wrong signature")
 	_, e = service.Authenticate(ctx)
 	assert.NotNil(t, e)
-	assert.NotEqual(t, missingCredentials, e)
+	assert.NotErrorIs(t, e, missingCredsErr)
 }
 
 type fakeKeySet struct {


### PR DESCRIPTION
Closes https://github.com/G-Research/armada/issues/1370

TODO
- [x] Wrap the rest of errors returned by the anonymous function created in `CreateMiddlewareAuthFunction` with `armadaerrors`.
- [x] Test that errors are actually surfaced with clients of armada.