### PR TITLE
move python to tests-e2e-python so we don't slow down non python step

### DIFF
--- a/makefile
+++ b/makefile
@@ -377,7 +377,7 @@ tests-e2e-teardown:
 	rmdir .kube || true
 
 .ONESHELL:
-setup-cluster: python
+setup-cluster:
 	kind create cluster --config e2e/setup/kind.yaml
 	# We need an ingress controller to enable cluster ingress
 	kubectl apply -f e2e/setup/ingress-nginx.yaml --context kind-armada-test
@@ -458,7 +458,7 @@ tests-e2e: build-armadactl build-docker-no-lookout tests-e2e-setup
 
 	# $(DOTNET_CMD) dotnet test client/DotNet/Armada.Client.Test/Armada.Client.Test.csproj
 .ONESHELL:
-tests-e2e-python:
+tests-e2e-python: python
 	docker run -v${PWD}/client/python:/code --workdir /code -e ARMADA_SERVER=server -e ARMADA_PORT=50051 --entrypoint python3 --network=kind armada-python-client-builder:latest -m pytest -v -s /code/tests/integration/test_no_auth.py
 
 # Output test results in Junit format, e.g., to display in Jenkins.


### PR DESCRIPTION
Python step needs to run before we run the python integration tests.  I moved the python step to tests-e2e-python.