### PR TITLE
Don't requeue job if we've already processed it

### DIFF
--- a/internal/armada/repository/job.go
+++ b/internal/armada/repository/job.go
@@ -1076,7 +1076,7 @@ local jobData = ARGV[3]
 local clientId = ARGV[4]
 
 
-local jobExists = redis.call('EXISTS', jobExistsKey, 'EX', 604800)
+local jobExists = redis.call('EXISTS', jobExistsKey)
 if jobExists == 1 then 
 	return '-1'
 end

--- a/internal/armada/repository/job.go
+++ b/internal/armada/repository/job.go
@@ -1089,7 +1089,7 @@ if clientId ~= '' then
 	redis.call('SET', jobClientIdKey, jobId, 'EX', 14400)
 end
 
-redis.call('SET', jobExistsKey, '1')
+redis.call('SET', jobExistsKey, '1', 'EX', 604800)
 redis.call('SET', jobKey, jobData)
 redis.call('SADD', jobSetKey, jobId)
 redis.call('SADD', jobSetQueueKey, jobId)

--- a/internal/armada/repository/job_test.go
+++ b/internal/armada/repository/job_test.go
@@ -871,7 +871,6 @@ func addTestJobInner(
 	requirements v1.ResourceRequirements,
 	tolerations []v1.Toleration,
 ) *SubmitJobResult {
-
 	if id == "" {
 		id = util.NewULID()
 	}

--- a/internal/armada/server/submit_from_log.go
+++ b/internal/armada/server/submit_from_log.go
@@ -391,7 +391,7 @@ func (srv *SubmitFromLog) SubmitJobs(
 				reason: fmt.Sprintf("Failed to save job in Armada: %s", submissionResult.Error.Error()),
 			})
 		} else if submissionResult.AlreadyProcessed {
-			log.Warn("Already Processed job id %s, this job submission will be discarded", submissionResult.JobId)
+			log.Warnf("Already Processed job id %s, this job submission will be discarded", submissionResult.JobId)
 		} else if submissionResult.DuplicateDetected {
 			doubleSubmits = append(doubleSubmits, submissionResult)
 		} else {

--- a/internal/armada/server/submit_from_log.go
+++ b/internal/armada/server/submit_from_log.go
@@ -384,13 +384,14 @@ func (srv *SubmitFromLog) SubmitJobs(
 	var doubleSubmits []*repository.SubmitJobResult
 	for i, submissionResult := range submissionResults {
 		jobResponse := &api.JobSubmitResponseItem{JobId: submissionResult.JobId}
-
 		if submissionResult.Error != nil {
 			jobResponse.Error = submissionResult.Error.Error()
 			jobFailures = append(jobFailures, &jobFailure{
 				job:    jobs[i],
 				reason: fmt.Sprintf("Failed to save job in Armada: %s", submissionResult.Error.Error()),
 			})
+		} else if submissionResult.AlreadyProcessed {
+			log.Warn("Already Processed job id %s, this job submission will be discarded", submissionResult.JobId)
 		} else if submissionResult.DuplicateDetected {
 			doubleSubmits = append(doubleSubmits, submissionResult)
 		} else {


### PR DESCRIPTION
This fixes #1600 

I've modified the addJobs script so that:
- We create marker key (expiration 1 week) that shows that we've added the job to redis
- We check the presence of the marker key before adding the job to the queue.  If the key exists then we don't re-add.

Note that I use a marker key rather than the actual job key, because the job key is several KB in size and so we want to expire that much quicker than the marker key.