### PR TITLE
Add PGX Connection errors to list of retryable errors

### DIFF
--- a/internal/common/armadaerrors/errors.go
+++ b/internal/common/armadaerrors/errors.go
@@ -509,6 +509,12 @@ func IsRetryablePostgresError(err error) bool {
 		_, ok := retryablePostgresErrors[err.Code]
 		return ok
 	}
+
+	// This is quite nasty: the connectError reported by pgx isn't exported so instead we use a string match
+	if strings.Contains(err.Error(), "failed to connect") {
+		return true
+	}
+
 	// Check to see if we have a wrapped network error
 	return IsNetworkError(cause)
 }


### PR DESCRIPTION
PGX  returns an unexported `connectionError` under various connection scenarios (e.g. validateConect fails).  We want to retry these errors so I've added a string match on the error string for now.  I'll raise an issue with PGX to get this type exported so we can make this more robust