### PR TITLE
Don't mark duplicate if originalId is empty string

### DIFF
--- a/internal/armada/server/submit_to_log.go
+++ b/internal/armada/server/submit_to_log.go
@@ -91,7 +91,7 @@ func (srv *PulsarSubmitServer) SubmitJobs(ctx context.Context, req *api.JobSubmi
 		// and generate a job duplicate found event.
 		originalId, found := originalIds[apiJob.GetId()]
 		if apiJob.ClientId != "" && originalId != apiJob.GetId() {
-			if found {
+			if found && originalId != "" {
 				jobDuplicateFoundEvents = append(jobDuplicateFoundEvents, &api.JobDuplicateFoundEvent{
 					JobId:         responses[i].JobId,
 					Queue:         req.Queue,


### PR DESCRIPTION
There seems to be some condition where `originalIId` ends up as the empty string when we check for duplicates.  The real solution here is to find out why this is and fix it, but in the meantime I've changed the code so that if `originalIId` is an empty string, we consider the job *not* a duplicate and log a warning.