### PR TITLE
[TestSuite] only check failure messages if there is a message to check

### DIFF
--- a/internal/testsuite/eventwatcher/validators.go
+++ b/internal/testsuite/eventwatcher/validators.go
@@ -24,11 +24,14 @@ func validateFailedEvent(actual *api.EventMessage, expected *api.EventMessage) e
 	if !ok {
 		return errors.New("error casting expected event as Failed event")
 	}
-	if expectedFailedEvent.Failed.Reason != receivedFailedEvent.Failed.Reason {
-		return errors.Errorf(
-			"error asserting failure reason: expected %s, got %s",
-			expectedFailedEvent.Failed.Reason, receivedFailedEvent.Failed.Reason,
-		)
+	// only check messages if there is an expected message to check
+	if len(expectedFailedEvent.Failed.GetReason()) > 0 {
+		if expectedFailedEvent.Failed.GetReason() != receivedFailedEvent.Failed.GetReason() {
+			return errors.Errorf(
+				"error asserting failure reason: expected %s, got %s",
+				expectedFailedEvent.Failed.GetReason(), receivedFailedEvent.Failed.GetReason(),
+			)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
The  testsuite has the ability to validate failure messages.  Currently this is being applied to *all* failure messages regardless if of whether the testspec actaully defines  what the failure message should be.  This means that if a failure message isn't provided, the test will always fail.

This PR changes the behaviour so that we only try to validate failure messages if the testspec defines one.