### PR TITLE
Fixes to Event Ingester

### DIFF
--- a/config/eventingester/config.yaml
+++ b/config/eventingester/config.yaml
@@ -17,3 +17,6 @@ batchDuration: 500ms
 pulsarReceiveTimeout: 5s
 pulsarBackoffTime: 1s
 minMessageCompressionSize: 1024
+eventRetention:
+  expiryEnabled: true
+  retentionDuration: 336h # Specified as a Go duration

--- a/internal/eventingester/configuration/types.go
+++ b/internal/eventingester/configuration/types.go
@@ -31,6 +31,8 @@ type EventIngesterConfiguration struct {
 	UpdateTopic string
 	// Time after which events will be deleted from the db
 	EventRetentionPolicy EventRetentionPolicy
+	// List of Regexes which will identify fatal errors when inserting into redis
+	FatalInsertionErrors []string
 }
 
 type EventRetentionPolicy struct {

--- a/internal/eventingester/ingester.go
+++ b/internal/eventingester/ingester.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"os/signal"
+	"regexp"
 	"sync"
 
 	"github.com/apache/pulsar-client-go/pulsar"
@@ -27,6 +28,16 @@ func Run(config *configuration.EventIngesterConfiguration) {
 	ctx := ctxlogrus.ToContext(createContextWithShutdown(), log)
 
 	log.Info("Event Ingester Starting")
+
+	fatalRegexes := make([]*regexp.Regexp, len(config.FatalInsertionErrors))
+	for i, str := range config.FatalInsertionErrors {
+		rgx, err := regexp.Compile(str)
+		if err != nil {
+			log.Errorf("Error compiling regex %s", str)
+			panic(err)
+		}
+		fatalRegexes[i] = rgx
+	}
 
 	rc := redis.NewUniversalClient(&config.Redis)
 	defer func() {
@@ -78,7 +89,7 @@ func Run(config *configuration.EventIngesterConfiguration) {
 	// Insert into database
 	maxSize := 4 * 1024 * 1024
 	maxRows := 500
-	inserted := store.InsertEvents(ctx, eventDb, events, 5, maxSize, maxRows)
+	inserted := store.InsertEvents(ctx, eventDb, events, 5, maxSize, maxRows, fatalRegexes)
 
 	// Waitgroup that wil fire when the pipeline has been torn down
 	wg := &sync.WaitGroup{}

--- a/internal/eventingester/store/insertion.go
+++ b/internal/eventingester/store/insertion.go
@@ -3,7 +3,7 @@ package store
 import (
 	"context"
 	"fmt"
-	"strings"
+	"regexp"
 	"time"
 
 	"github.com/pkg/errors"
@@ -18,12 +18,12 @@ import (
 // InsertEvents takes a channel of armada events and inserts them into the event db
 // the events are republished to an output channel for further processing (e.g. Ackking)
 func InsertEvents(ctx context.Context, db EventStore, msgs chan *model.BatchUpdate, bufferSize int,
-	maxSize int, maxRows int,
+	maxSize int, maxRows int, fatalErrors []*regexp.Regexp,
 ) chan []*pulsarutils.ConsumerMessageId {
 	out := make(chan []*pulsarutils.ConsumerMessageId, bufferSize)
 	go func() {
 		for msg := range msgs {
-			insert(db, msg.Events, maxSize, maxRows)
+			insert(db, msg.Events, maxSize, maxRows, fatalErrors)
 			out <- msg.MessageIds
 		}
 		close(out)
@@ -31,7 +31,7 @@ func InsertEvents(ctx context.Context, db EventStore, msgs chan *model.BatchUpda
 	return out
 }
 
-func insert(db EventStore, rows []*model.Event, maxSize int, maxRows int) {
+func insert(db EventStore, rows []*model.Event, maxSize int, maxRows int, fatalErrors []*regexp.Regexp) {
 	if len(rows) == 0 {
 		return
 	}
@@ -45,7 +45,7 @@ func insert(db EventStore, rows []*model.Event, maxSize int, maxRows int) {
 		newSize := currentSize + len(event.Event)
 		newRows := currentRows + 1
 		if newSize > maxSize || newRows > maxRows {
-			doInsert(db, batch)
+			doInsert(db, batch, fatalErrors)
 			batch = make([]*model.Event, 0, maxRows)
 			currentSize = 0
 			currentRows = 0
@@ -56,16 +56,16 @@ func insert(db EventStore, rows []*model.Event, maxSize int, maxRows int) {
 
 		// If this is the last element we need to flush
 		if i == len(rows)-1 {
-			doInsert(db, batch)
+			doInsert(db, batch, fatalErrors)
 		}
 	}
 }
 
-func doInsert(db EventStore, rows []*model.Event) {
+func doInsert(db EventStore, rows []*model.Event, fatalErrors []*regexp.Regexp) {
 	start := time.Now()
 	err := WithRetry(func() error {
 		return db.ReportEvents(rows)
-	})
+	}, fatalErrors)
 	if err != nil {
 		log.WithError(err).Warnf("Error inserting rows")
 	} else {
@@ -74,7 +74,7 @@ func doInsert(db EventStore, rows []*model.Event) {
 	}
 }
 
-func WithRetry(executeDb func() error) error {
+func WithRetry(executeDb func() error, nonRetryableErrors []*regexp.Regexp) error {
 	// TODO: arguably this should come from config
 	backOff := 1
 	const maxBackoff = 60
@@ -88,7 +88,7 @@ func WithRetry(executeDb func() error) error {
 			return nil
 		}
 
-		if armadaerrors.IsNetworkError(err) || IsRetryableRedisError(err) {
+		if armadaerrors.IsNetworkError(err) || IsRetryableRedisError(err, nonRetryableErrors) {
 			backOff = util.Min(2*backOff, maxBackoff)
 			numRetries++
 			log.WithError(err).Warnf("Retryable error encountered inserting to Redis, will wait for %d seconds before retrying", backOff)
@@ -106,26 +106,17 @@ func WithRetry(executeDb func() error) error {
 	}))
 }
 
-// IsRetryableRedisError is largely taken from https://github.com/go-redis/redis/blob/master/error.go#L28
-func IsRetryableRedisError(err error) bool {
+// IsRetryableRedisError returns true if the error doesn't match the list of nonRetryableErrors
+func IsRetryableRedisError(err error, nonRetryableErrors []*regexp.Regexp) bool {
 	if err == nil {
-		return false
+		return true
 	}
 	s := err.Error()
-	if s == "ERR max number of clients reached" {
-		return true
+	for _, r := range nonRetryableErrors {
+		if r.MatchString(s) {
+			log.Infof("Error %s matched regex %s and so will be considered fatal", s, r)
+			return false
+		}
 	}
-	if strings.HasPrefix(s, "LOADING ") {
-		return true
-	}
-	if strings.HasPrefix(s, "READONLY ") {
-		return true
-	}
-	if strings.HasPrefix(s, "CLUSTERDOWN ") {
-		return true
-	}
-	if strings.HasPrefix(s, "TRYAGAIN ") {
-		return true
-	}
-	return false
+	return true
 }

--- a/internal/eventingester/store/insertion_test.go
+++ b/internal/eventingester/store/insertion_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,6 +18,11 @@ type MockEventStore struct {
 const (
 	maxSize   = 1024
 	maxEvents = 500
+)
+
+var (
+	fatalError, _ = regexp.Compile("TOO LARGE")
+	fatalErrors   = []*regexp.Regexp{fatalError}
 )
 
 // If Errors contains errors then MockEventStore will pop the first error and return it
@@ -39,22 +45,22 @@ func (es *MockEventStore) Reset() {
 func TestHappyPath(t *testing.T) {
 	events := []*model.Event{{Queue: "queue1"}, {Queue: "queue2"}}
 	es := &MockEventStore{}
-	insert(es, events, maxSize, maxEvents)
+	insert(es, events, maxSize, maxEvents, fatalErrors)
 	assert.Equal(t, [][]*model.Event{events}, es.StoredEvents)
 }
 
 func TestRetryableError(t *testing.T) {
 	events := []*model.Event{{Queue: "queue1"}, {Queue: "queue2"}}
 	es := &MockEventStore{Errors: []error{fmt.Errorf("CLUSTERDOWN ")}}
-	insert(es, events, maxSize, maxEvents)
+	insert(es, events, maxSize, maxEvents, fatalErrors)
 	assert.Equal(t, [][]*model.Event{events}, es.StoredEvents)
 	assert.Equal(t, 0, len(es.Errors))
 }
 
 func TestNonRetryableError(t *testing.T) {
 	events := []*model.Event{{Queue: "queue1"}, {Queue: "queue2"}}
-	es := &MockEventStore{Errors: []error{fmt.Errorf("some random error")}}
-	insert(es, events, maxSize, maxEvents)
+	es := &MockEventStore{Errors: []error{fmt.Errorf("TOO LARGE TO fit")}}
+	insert(es, events, maxSize, maxEvents, fatalErrors)
 	assert.Equal(t, 0, len(es.StoredEvents))
 	assert.Equal(t, 0, len(es.Errors))
 }
@@ -64,16 +70,16 @@ func TestSplit(t *testing.T) {
 	es := &MockEventStore{}
 
 	// No splitting
-	insert(es, events, maxSize, maxEvents)
+	insert(es, events, maxSize, maxEvents, fatalErrors)
 	assert.Equal(t, [][]*model.Event{events}, es.StoredEvents)
 	es.Reset()
 
 	// Split by size
-	insert(es, events, 1, maxEvents)
+	insert(es, events, 1, maxEvents, fatalErrors)
 	assert.Equal(t, [][]*model.Event{{events[0]}, {events[1]}}, es.StoredEvents)
 	es.Reset()
 
 	// split by rows
-	insert(es, events, maxSize, 1)
+	insert(es, events, maxSize, 1, fatalErrors)
 	assert.Equal(t, [][]*model.Event{{events[0]}, {events[1]}}, es.StoredEvents)
 }


### PR DESCRIPTION
* Default `eventRetention` in EventIngester to 336 hours (matches the current default in the server)
* EventIngester no longer has a hard coded list of retryable redis errors. Instead by default, it considers all errors as retryable, and only gives up if the error matches one of a (config-defined) number of regexes. 