### PR TITLE
Allow the use of quotes to specify job queue name exactly

### DIFF
--- a/internal/lookout/repository/jobs.go
+++ b/internal/lookout/repository/jobs.go
@@ -103,7 +103,11 @@ func (r *SQLJobRepository) createWhereFilters(opts *lookout.GetJobsRequest) []go
 	var filters []goqu.Expression
 
 	if opts.Queue != "" {
-		filters = append(filters, StartsWith(job_queue, opts.Queue))
+		if quotedString, ok := getQuotedString(opts.Queue); ok {
+			filters = append(filters, Exactly(job_queue, quotedString))
+		} else {
+			filters = append(filters, StartsWith(job_queue, opts.Queue))
+		}
 	}
 
 	if opts.JobId != "" {

--- a/internal/lookout/repository/util.go
+++ b/internal/lookout/repository/util.go
@@ -50,6 +50,10 @@ func StartsWith(field exp.IdentifierExpression, pattern string) goqu.Expression 
 	return field.Like(pattern + "%")
 }
 
+func Exactly(field exp.IdentifierExpression, pattern string) goqu.Expression {
+	return field.Eq(pattern)
+}
+
 func NewNullString(s string) sql.NullString {
 	if len(s) == 0 {
 		return sql.NullString{}
@@ -100,4 +104,12 @@ func ParseNullTimeDefault(nullTime sql.NullTime) time.Time {
 		return time.Time{}
 	}
 	return nullTime.Time
+}
+
+func getQuotedString(haystack string) (string, bool) {
+	// TODO: This only handles the case of one quoted string in the haystack.
+	if strings.Count(haystack, "\"") != 2 {
+		return "", false
+	}
+	return strings.Split(haystack, "\"")[1], true
 }

--- a/internal/lookout/repository/utils_test.go
+++ b/internal/lookout/repository/utils_test.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -254,4 +255,27 @@ func (js *JobSimulator) Duplicate(originalJobId string) *JobSimulator {
 	}
 	assert.NoError(js.t, js.jobStore.RecordJobDuplicate(duplicateFoundEvent))
 	return js
+}
+
+func TestGetQuotedString(t *testing.T) {
+	testCases := []struct {
+		haystack        string
+		expectedQString string
+		expectedOk      bool
+	}{
+		{"test", "", false},
+		{"\"test\"", "test", true},
+		{"\"test\"\"", "", false}, // We only handle the 2 quotes case.
+		{"\"asdf", "", false},     // No closing quote.
+		{"\"\"", "", true},
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("Test getQuotedString(%q)=>(%q,%t)",
+			tc.haystack, tc.expectedQString, tc.expectedOk),
+			func(t *testing.T) {
+				s, ok := getQuotedString(tc.haystack)
+				assert.Equal(t, s, tc.expectedQString)
+				assert.Equal(t, ok, tc.expectedOk)
+			})
+	}
 }


### PR DESCRIPTION
Lookout's UI allows a user to filter jobs by job queue name via the table displayed on the jobs tab. This commit enables a quoted string within `lookout.GetJobsRequest.Queue` to enable an exact match search and not just a prefix search on job queue name.

Partial #908 