### PR TITLE
Fix issues in default config files

### DIFF
--- a/config/armada/config.yaml
+++ b/config/armada/config.yaml
@@ -61,8 +61,6 @@ scheduling:
   maxPodSpecSizeBytes: 65535
   minJobResources:
     memory: 1Mi
-  preemption:
-    enabled: false
   minTerminationGracePeriod: 0s
   maxTerminationGracePeriod: 300s
   defaultTerminationGracePeriod: 5s

--- a/config/executor/config.yaml
+++ b/config/executor/config.yaml
@@ -42,7 +42,7 @@ kubernetes:
     - "admission webhook"
     - "namespaces \".*\" not found"
   pendingPodChecks:
-    timeWithoutEventsOrStatus: 10m
+    deadlineForUpdates: 10m
     events:
       - regexp: "Failed to pull image.*desc = failed to pull and unpack image"            # Suggests genuine problem with image name, no point in waiting around too long.
         type: Warning


### PR DESCRIPTION
 - Remove duplicate preemption config
 - Fix name of `timeWithoutEventsOrStatus` to `deadlineForUpdates`
   - This was using the wrong name, meaning it was getting set to 0