### PR TITLE
Clean up termination config/defaults

### DIFF
--- a/config/armada/config.yaml
+++ b/config/armada/config.yaml
@@ -63,7 +63,6 @@ scheduling:
     memory: 1Mi
   minTerminationGracePeriod: 0s
   maxTerminationGracePeriod: 300s
-  defaultTerminationGracePeriod: 5s
 queueManagement:
   defaultPriorityFactor: 1000
   defaultQueuedJobsLimit: 0  # No Limit

--- a/config/armada/config.yaml
+++ b/config/armada/config.yaml
@@ -61,7 +61,7 @@ scheduling:
   maxPodSpecSizeBytes: 65535
   minJobResources:
     memory: 1Mi
-  minTerminationGracePeriod: 0s
+  minTerminationGracePeriod: 1s
   maxTerminationGracePeriod: 300s
 queueManagement:
   defaultPriorityFactor: 1000

--- a/e2e/setup/server/armada-config.yaml
+++ b/e2e/setup/server/armada-config.yaml
@@ -22,6 +22,6 @@ scheduling:
       operator: "Equal"
       value: "true"
       effect: "NoSchedule"
-  minTerminationGracePeriod: 0s
+  minTerminationGracePeriod: 1s
   maxTerminationGracePeriod: 30s
 defaultToLegacyEvents: true

--- a/e2e/setup/server/armada-config.yaml
+++ b/e2e/setup/server/armada-config.yaml
@@ -24,5 +24,4 @@ scheduling:
       effect: "NoSchedule"
   minTerminationGracePeriod: 0s
   maxTerminationGracePeriod: 30s
-  defaultTerminationGracePeriod: 0s
 defaultToLegacyEvents: true

--- a/internal/armada/configuration/types.go
+++ b/internal/armada/configuration/types.go
@@ -151,10 +151,27 @@ type SchedulingConfig struct {
 	// If not set, all taints are indexed.
 	//
 	// Applies only to the new scheduler.
-	IndexedTaints                 map[string]interface{}
-	MinTerminationGracePeriod     time.Duration
-	MaxTerminationGracePeriod     time.Duration
-	DefaultTerminationGracePeriod time.Duration
+	IndexedTaints map[string]interface{}
+	// Kubernetes pods may specify a termination grace period.
+	// When Pods are cancelled/preempted etc., they are first sent a SIGTERM.
+	// If a pod has not exited within its termination grace period,
+	// it is killed forcefully by Kubernetes sending it a SIGKILL.
+	//
+	// This is the minimum allowed termination grace period.
+	// It should normally be set to a positive value, e.g., 1 second.
+	// Since a zero grace period causes Kubernetes to force delete pods,
+	// which may causes issues where resources associated with the pod, e.g.,
+	// containers, are not cleaned up correctly.
+	//
+	// The grace period of pods that either
+	// - do not set a grace period, or
+	// - explicitly set a grace period of 0 seconds,
+	// is automatically set to MinTerminationGracePeriod.
+	MinTerminationGracePeriod time.Duration
+	// Max allowed grace period.
+	// Should normally not be set greater than single-digit minutes,
+	// since cancellation and preemption may need to wait for this amount of time.
+	MaxTerminationGracePeriod time.Duration
 }
 
 // NewSchedulerConfig stores config for the new Pulsar-based scheduler.

--- a/internal/armada/server/submit.go
+++ b/internal/armada/server/submit.go
@@ -903,17 +903,26 @@ func (server *SubmitServer) applyDefaultsToPodSpec(spec *v1.PodSpec) {
 		spec.PriorityClassName = defaultPriorityClass
 	}
 
-	// add missing TerminationGracePeriod if needed
 	server.applyTerminationGracePeriodDefault(spec)
 }
 
-// applyTerminationGracePeriodDefault will give the podspec a default if needed
+// applyTerminationGracePeriodDefault sets the termination grace period
+// of the pod equal to the minimum if
+// - the pod does not explicitly set a termination period, or
+// - the pod explicitly sets a termination period of 0.
 func (server *SubmitServer) applyTerminationGracePeriodDefault(spec *v1.PodSpec) {
-	specNeedsTerminationGracePeriod := spec.TerminationGracePeriodSeconds == nil
-	defaultTerminationGracePeriod := int64(server.schedulingConfig.DefaultTerminationGracePeriod.Seconds())
-
-	if specNeedsTerminationGracePeriod {
-		spec.TerminationGracePeriodSeconds = &defaultTerminationGracePeriod
+	var podTerminationGracePeriodSeconds int64
+	if spec.TerminationGracePeriodSeconds != nil {
+		podTerminationGracePeriodSeconds = *spec.TerminationGracePeriodSeconds
+	}
+	if podTerminationGracePeriodSeconds == 0 {
+		defaultTerminationGracePeriodSeconds := int64(
+			server.schedulingConfig.MinTerminationGracePeriod.Seconds(),
+		)
+		if defaultTerminationGracePeriodSeconds < 0 {
+			panic("MinTerminationGracePeriod is negative")
+		}
+		spec.TerminationGracePeriodSeconds = &defaultTerminationGracePeriodSeconds
 	}
 }
 

--- a/internal/armada/server/submit.go
+++ b/internal/armada/server/submit.go
@@ -919,9 +919,6 @@ func (server *SubmitServer) applyTerminationGracePeriodDefault(spec *v1.PodSpec)
 		defaultTerminationGracePeriodSeconds := int64(
 			server.schedulingConfig.MinTerminationGracePeriod.Seconds(),
 		)
-		if defaultTerminationGracePeriodSeconds < 0 {
-			panic("MinTerminationGracePeriod is negative")
-		}
 		spec.TerminationGracePeriodSeconds = &defaultTerminationGracePeriodSeconds
 	}
 }

--- a/internal/armada/server/submit_test.go
+++ b/internal/armada/server/submit_test.go
@@ -1737,7 +1737,7 @@ func TestSubmitServer_CreateJobs_WithJobIdReplacement(t *testing.T) {
 							Effect:   "NoSchedule",
 						},
 					},
-					TerminationGracePeriodSeconds: pointer.Int64(60),
+					TerminationGracePeriodSeconds: pointer.Int64(30),
 					PriorityClassName:             "high",
 				},
 			},

--- a/internal/armada/server/submit_test.go
+++ b/internal/armada/server/submit_test.go
@@ -293,7 +293,7 @@ func TestSubmitServer_SubmitJob_ApplyDefaults(t *testing.T) {
 				Effect:   v1.TaintEffectNoSchedule,
 			},
 		}
-		expectedTerminationGracePeriodSeconds := int64(s.schedulingConfig.DefaultTerminationGracePeriod.Seconds())
+		expectedTerminationGracePeriodSeconds := int64(s.schedulingConfig.MinTerminationGracePeriod.Seconds())
 
 		assert.Equal(t, expectedResources, retrievedJob[0].PodSpec.Containers[0].Resources.Requests)
 		assert.Equal(t, expectedResources, retrievedJob[0].PodSpec.Containers[0].Resources.Limits)
@@ -1648,9 +1648,8 @@ func withSubmitServerAndRepos(action func(s *SubmitServer, jobRepo repository.Jo
 			DefaultPriorityClass: "high",
 			PriorityClasses:      map[string]int32{"high": 0},
 		},
-		DefaultTerminationGracePeriod: time.Duration(60 * time.Second),
-		MinTerminationGracePeriod:     time.Duration(30 * time.Second),
-		MaxTerminationGracePeriod:     time.Duration(300 * time.Second),
+		MinTerminationGracePeriod: time.Duration(30 * time.Second),
+		MaxTerminationGracePeriod: time.Duration(300 * time.Second),
 	}
 
 	server := NewSubmitServer(

--- a/internal/common/validation/podspec.go
+++ b/internal/common/validation/podspec.go
@@ -68,12 +68,12 @@ func validateTerminationGracePeriod(spec *v1.PodSpec, config *configuration.Sche
 		exceedsBounds = (terminationGracePeriodSeconds < int64(config.MinTerminationGracePeriod.Seconds()) ||
 			terminationGracePeriodSeconds > int64(config.MaxTerminationGracePeriod.Seconds()))
 	}
-
 	if exceedsBounds {
-		return errors.Errorf("terminationGracePeriodSeconds of %v must be between %v and %v, or omitted",
+		return errors.Errorf("terminationGracePeriodSeconds of %v must be in [%d, %d]s, or omitted",
 			terminationGracePeriodSeconds,
-			config.MinTerminationGracePeriod.Seconds(),
-			config.MaxTerminationGracePeriod.Seconds())
+			int64(config.MinTerminationGracePeriod.Seconds()),
+			int64(config.MaxTerminationGracePeriod.Seconds()),
+		)
 	}
 	return nil
 }

--- a/internal/common/validation/podspec_test.go
+++ b/internal/common/validation/podspec_test.go
@@ -64,9 +64,8 @@ func Test_ValidatePodSpec_terminationGracePeriod(t *testing.T) {
 			DefaultPriorityClass: "high",
 			PriorityClasses:      map[string]int32{"high": 0},
 		},
-		DefaultTerminationGracePeriod: time.Duration(20 * time.Second),
-		MinTerminationGracePeriod:     time.Duration(30 * time.Second),
-		MaxTerminationGracePeriod:     time.Duration(300 * time.Second),
+		MinTerminationGracePeriod: time.Duration(30 * time.Second),
+		MaxTerminationGracePeriod: time.Duration(300 * time.Second),
 	}
 
 	podspecWithinRange := &v1.PodSpec{


### PR DESCRIPTION
For pods that set no grace period or explicitly set it to zero, automatically change it to the minimum allowed. Remove the default grace period setting and instead use the minimum as the default.