### PR TITLE
Temporary removal of out-dated documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,7 @@ For an overview of the architecture and design of Armada, and instructions for s
 - [User guide](./docs/user.md)
 
 For instructions of how to setup and develop Armada, see:
-- [Quickstart](./docs/quickstart/index.md)
 - [Development guide](./docs/developer.md)
-- [Installation in production](./docs/production-install.md)
 
 For API reference, see:
 - [API Documentation](./docs/api.md)

--- a/docs/user.md
+++ b/docs/user.md
@@ -54,42 +54,6 @@ Now, the job can be submitted to Armada using the `armadactl` command-line utili
 
 where `<jobspec.yaml>` is the path of the file containing the jobspec. Armada automatically handles creating and running the necessary containers.
 
-## Multi-node jobs
-
-All containers part of the same podspec will be run on the same node (a physical or virtual machine), i.e., the amount of CPU and memory the above job could consume is limited by what the nodes that make up the clusters are equipped with. To overcome this limitation, jobs need to specify several podspecs, each of which may be scheduled on different nodes within a Kubernetes cluster. For example:
-
-```yaml
-queue: test
-jobSetId: set1
-jobs:
-  - priority: 0
-    podSpecs:
-      - terminationGracePeriodSeconds: 0
-        restartPolicy: Never
-        containers:
-          - name: sleep
-            imagePullPolicy: IfNotPresent
-            image: busybox:latest
-            args:
-              - sleep
-              - 60s
-            resources:
-              limits:
-                memory: 64Mi
-                cpu: 150m
-              requests:
-                memory: 64Mi
-                cpu: 150m
-      - terminationGracePeriodSeconds: 0
-        restartPolicy: Never
-        containers:
-          ...
-```
-
-All pods part of the same job will be run simultaneously and within a single Kubernetes cluster. If any of the pods that make up the job fails to start within a certain timeout (specified by the `stuckPodExpiry` parameter), the entire job is cancelled and all pods belonging to it removed. Armada may attempt to re-schedule jobs experiencing transient issues. Events relating to a multi-node job contain a `podNumber` identifier, corresponding to the index of pod in the `podSpecs` list that the event refers to.
-
-Jobs are submitted using either the `armadactl` command-line utility, with `armadactl submit <jobspec.yaml>`, or using the gRPC or REST API.
-
 ## Preemptive jobs
 
 Armada supports submitting preemptive jobs, i.e. jobs which can preempt other lower priority jobs when there aren't enough


### PR DESCRIPTION
We don't want to have any docs which are out of date or incorrect. Aim to replace these post-KubeCon when they have been updated.