### PR TITLE
[EventIngester] Fix Default Configuration For EventRetentionPolicy

### DIFF
--- a/config/eventingester/config.yaml
+++ b/config/eventingester/config.yaml
@@ -17,6 +17,6 @@ batchDuration: 500ms
 pulsarReceiveTimeout: 5s
 pulsarBackoffTime: 1s
 minMessageCompressionSize: 1024
-eventRetention:
+eventRetentionPolicy:
   expiryEnabled: true
   retentionDuration: 336h # Specified as a Go duration


### PR DESCRIPTION
EventIngester's defualt configuration had an `EventRetention` block rather than an `EventRetentionPolicy` block. As a result defualt installations would never expire any events.