### PR TITLE
Add lookout_url_template to ArmadaOperator

### DIFF
--- a/docs/python_airflow_operator.md
+++ b/docs/python_airflow_operator.md
@@ -12,7 +12,7 @@ This class provides integration with Airflow and Armada
 ## armada.operators.armada module
 
 
-### _class_ armada.operators.armada.ArmadaOperator(name, armada_client, job_service_client, armada_queue, job_request_items, \*\*kwargs)
+### _class_ armada.operators.armada.ArmadaOperator(name, armada_client, job_service_client, armada_queue, job_request_items, lookout_url_template, \*\*kwargs)
 Bases: `BaseOperator`
 
 Implementation of an ArmadaOperator for airflow.
@@ -37,6 +37,13 @@ Airflow operators inherit from BaseOperator.
 
 
     * **job_request_items** – A PodSpec that is used by Armada for submitting a job
+
+
+    * **lookout_url_template** (*str*) – A URL template to be used to provide users
+    a valid link to the related lookout job in this operator’s log.
+    The format should be:
+    “[https://lookout.armada.domain/jobs](https://lookout.armada.domain/jobs)?job_id=<job_id>” where <job_id> will
+    be replaced with the actual job ID.
 
 
 

--- a/third_party/airflow/armada/operators/armada.py
+++ b/third_party/airflow/armada/operators/armada.py
@@ -115,6 +115,5 @@ class ArmadaOperator(BaseOperator):
         )
         airflow_error(job_state, self.name, job_id)
 
-
     def get_lookout_url(self, job_id: str) -> str:
         return self.lookout_url_template.replace("<job_id>", job_id)

--- a/third_party/airflow/armada/operators/armada.py
+++ b/third_party/airflow/armada/operators/armada.py
@@ -99,7 +99,7 @@ class ArmadaOperator(BaseOperator):
 
         armada_logger.info("Running Armada job %s with id %s", self.name, job_id)
 
-        lookout_url = self.get_lookout_url(job_id)
+        lookout_url = self._get_lookout_url(job_id)
         if len(lookout_url) > 0:
             armada_logger.info("Lookout URL: %s", lookout_url)
 
@@ -115,5 +115,5 @@ class ArmadaOperator(BaseOperator):
         )
         airflow_error(job_state, self.name, job_id)
 
-    def get_lookout_url(self, job_id: str) -> str:
+    def _get_lookout_url(self, job_id: str) -> str:
         return self.lookout_url_template.replace("<job_id>", job_id)

--- a/third_party/airflow/examples/bad_armada.py
+++ b/third_party/airflow/examples/bad_armada.py
@@ -76,6 +76,7 @@ with DAG(
         job_service_client=job_service_client,
         armada_client=no_auth_client,
         job_request_items=submit_sleep_container(image="busybox"),
+        lookout_url_template="http://127.0.0.1:8089/jobs?job_id=<job_id>",
     )
     """
     This task is used to verify that if an Armada Job
@@ -88,6 +89,7 @@ with DAG(
         job_service_client=job_service_client,
         armada_client=no_auth_client,
         job_request_items=submit_sleep_container(image="nonexistant"),
+        lookout_url_template="http://127.0.0.1:8089/jobs?job_id=<job_id>",
     )
     good_armada = ArmadaOperator(
         task_id="good_armada",
@@ -96,6 +98,7 @@ with DAG(
         job_service_client=job_service_client,
         armada_client=no_auth_client,
         job_request_items=submit_sleep_container(image="busybox"),
+        lookout_url_template="http://127.0.0.1:8089/jobs?job_id=<job_id>",
     )
     """
     Airflow syntax to say

--- a/third_party/airflow/examples/hello_armada.py
+++ b/third_party/airflow/examples/hello_armada.py
@@ -87,6 +87,7 @@ with DAG(
         job_service_client=job_service_client,
         armada_client=no_auth_client,
         job_request_items=submit_sleep_job(),
+        lookout_url_template="http://127.0.0.1:8089/jobs?job_id=<job_id>",
     )
     """
     Airflow dag syntax for running op and then armada.

--- a/third_party/airflow/tests/unit/test_armada_operator.py
+++ b/third_party/airflow/tests/unit/test_armada_operator.py
@@ -30,4 +30,4 @@ def test_get_lookout_url(lookout_url_template, job_id, expected_url):
         lookout_url_template=lookout_url_template,
     )
 
-    assert operator.get_lookout_url(job_id) == expected_url
+    assert operator._get_lookout_url(job_id) == expected_url

--- a/third_party/airflow/tests/unit/test_armada_operator.py
+++ b/third_party/airflow/tests/unit/test_armada_operator.py
@@ -1,0 +1,21 @@
+from armada.operators.armada import ArmadaOperator
+import pytest
+
+get_lookout_url_test_cases = [
+    ("http://localhost:8089/jobs?job_id=<job_id>", "test_id", "http://localhost:8089/jobs?job_id=test_id"),
+    ("https://lookout.armada.domain/jobs?job_id=<job_id>", "test_id", "https://lookout.armada.domain/jobs?job_id=test_id"),
+    ("", "test_id", ""),
+]
+
+@pytest.mark.parametrize("lookout_url_template, job_id, expected_url", get_lookout_url_test_cases)
+def test_get_lookout_url(lookout_url_template, job_id, expected_url):
+    operator = ArmadaOperator(
+                    task_id="test_task_id",
+                    name="test_task",
+                    armada_client=None,
+                    job_service_client=None,
+                    armada_queue="test_queue",
+                    job_request_items=[],
+                    lookout_url_template=lookout_url_template)
+
+    assert operator.get_lookout_url(job_id) == expected_url

--- a/third_party/airflow/tests/unit/test_armada_operator.py
+++ b/third_party/airflow/tests/unit/test_armada_operator.py
@@ -2,20 +2,32 @@ from armada.operators.armada import ArmadaOperator
 import pytest
 
 get_lookout_url_test_cases = [
-    ("http://localhost:8089/jobs?job_id=<job_id>", "test_id", "http://localhost:8089/jobs?job_id=test_id"),
-    ("https://lookout.armada.domain/jobs?job_id=<job_id>", "test_id", "https://lookout.armada.domain/jobs?job_id=test_id"),
+    (
+        "http://localhost:8089/jobs?job_id=<job_id>",
+        "test_id",
+        "http://localhost:8089/jobs?job_id=test_id",
+    ),
+    (
+        "https://lookout.armada.domain/jobs?job_id=<job_id>",
+        "test_id",
+        "https://lookout.armada.domain/jobs?job_id=test_id",
+    ),
     ("", "test_id", ""),
 ]
 
-@pytest.mark.parametrize("lookout_url_template, job_id, expected_url", get_lookout_url_test_cases)
+
+@pytest.mark.parametrize(
+    "lookout_url_template, job_id, expected_url", get_lookout_url_test_cases
+)
 def test_get_lookout_url(lookout_url_template, job_id, expected_url):
     operator = ArmadaOperator(
-                    task_id="test_task_id",
-                    name="test_task",
-                    armada_client=None,
-                    job_service_client=None,
-                    armada_queue="test_queue",
-                    job_request_items=[],
-                    lookout_url_template=lookout_url_template)
+        task_id="test_task_id",
+        name="test_task",
+        armada_client=None,
+        job_service_client=None,
+        armada_queue="test_queue",
+        job_request_items=[],
+        lookout_url_template=lookout_url_template,
+    )
 
     assert operator.get_lookout_url(job_id) == expected_url


### PR DESCRIPTION
Setting lookout_url_template properly causes ArmadaOperator to log the lookout URL of the job ID created upon execution.

Closes #1603 