### PR TITLE
Allow setting log format from environmental variable

### DIFF
--- a/internal/common/startup.go
+++ b/internal/common/startup.go
@@ -97,7 +97,7 @@ func ConfigureCommandLineLogging() {
 
 func ConfigureLogging() {
 	log.SetLevel(readEnvironmentLogLevel())
-	log.SetFormatter(&log.TextFormatter{ForceColors: true, FullTimestamp: true})
+	log.SetFormatter(readEnvironmentLogFormat())
 	log.SetOutput(os.Stdout)
 }
 
@@ -110,6 +110,24 @@ func readEnvironmentLogLevel() log.Level {
 		}
 	}
 	return log.InfoLevel
+}
+
+func readEnvironmentLogFormat() log.Formatter {
+	formatStr, ok := os.LookupEnv("LOG_FORMAT")
+	if !ok {
+		formatStr = "colorful"
+	}
+	switch strings.ToLower(formatStr) {
+	case "json":
+		return &log.JSONFormatter{}
+	case "colorful":
+		return &log.TextFormatter{ForceColors: true, FullTimestamp: true}
+	case "text":
+		return &log.TextFormatter{DisableColors: true, FullTimestamp: true}
+	default:
+		println(os.Stderr, fmt.Sprintf("Unknown log format %s, defaulting to colorful format", formatStr))
+		return &log.TextFormatter{ForceColors: true, FullTimestamp: true}
+	}
 }
 
 func ServeMetrics(port uint16) (shutdown func()) {

--- a/internal/common/startup.go
+++ b/internal/common/startup.go
@@ -115,17 +115,17 @@ func readEnvironmentLogLevel() log.Level {
 func readEnvironmentLogFormat() log.Formatter {
 	formatStr, ok := os.LookupEnv("LOG_FORMAT")
 	if !ok {
-		formatStr = "colorful"
+		formatStr = "colourful"
 	}
 	switch strings.ToLower(formatStr) {
 	case "json":
 		return &log.JSONFormatter{}
-	case "colorful":
+	case "colourful":
 		return &log.TextFormatter{ForceColors: true, FullTimestamp: true}
 	case "text":
 		return &log.TextFormatter{DisableColors: true, FullTimestamp: true}
 	default:
-		println(os.Stderr, fmt.Sprintf("Unknown log format %s, defaulting to colorful format", formatStr))
+		println(os.Stderr, fmt.Sprintf("Unknown log format %s, defaulting to colourful format", formatStr))
 		return &log.TextFormatter{ForceColors: true, FullTimestamp: true}
 	}
 }


### PR DESCRIPTION
Allow setting the log format from an environmental variable.

Options are:

`colorful`: Coloured plain text formatted
`text`: Plain text log format
`json` Json log format

If the variable is not set, or does not match one of these values, then `colorful` log format will be used for backwards compatibility.