### PR TITLE
Armadatctl: Don't swallow Error on Invalid Config

### DIFF
--- a/cmd/armadactl/cmd/params.go
+++ b/cmd/armadactl/cmd/params.go
@@ -11,7 +11,10 @@ import (
 // initParams initialises the command parameters, flags, and a configuration file.
 func initParams(cmd *cobra.Command, params *armadactl.Params) error {
 	// Stuff above this is from the example
-	client.LoadCommandlineArgs()
+	err := client.LoadCommandlineArgs()
+	if err != nil {
+		return err
+	}
 	params.ApiConnectionDetails = client.ExtractCommandlineArmadaApiConnectionDetails()
 
 	// Setup the armadactl to use pkg/client as its backend for queue-related commands

--- a/cmd/armadactl/main.go
+++ b/cmd/armadactl/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/G-Research/armada/cmd/armadactl/cmd"
 	"github.com/G-Research/armada/internal/common"
 )
@@ -9,7 +11,8 @@ import (
 func main() {
 	common.ConfigureCommandLineLogging()
 	root := cmd.RootCmd()
-	// root.execute returns an error, but we can ignore this as the error will already be
-	// printed to stderr by cobra
-	root.Execute()
+	if err := root.Execute(); err != nil {
+		// We don't need to log the error here because cobra has already done this for us
+		os.Exit(1)
+	}
 }

--- a/cmd/armadactl/main.go
+++ b/cmd/armadactl/main.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"log"
-
 	"github.com/G-Research/armada/cmd/armadactl/cmd"
 	"github.com/G-Research/armada/internal/common"
 )
@@ -11,7 +9,7 @@ import (
 func main() {
 	common.ConfigureCommandLineLogging()
 	root := cmd.RootCmd()
-	if err := root.Execute(); err != nil {
-		log.Fatal(err)
-	}
+	// root.execute returns an error, but we can ignore this as the error will already be
+	// printed to stderr by cobra
+	root.Execute()
 }


### PR DESCRIPTION
Armadactl was swallowing the error from `client.LoadCommandlineArgs()` which meant that if e.g. the user specified a config file that didn't exist, it would happily still try to execute the command.

I've fixed this and also removed logging of the error in `main()`.  This error is already sent to stderr by cobra so all we were doing is printing it twice.