### PR TITLE
[Scheduler] Hitting a limit at a higher priority shouldn't block lower priority jobs

### DIFF
--- a/internal/scheduler/legacyscheduler_test.go
+++ b/internal/scheduler/legacyscheduler_test.go
@@ -841,7 +841,7 @@ func TestSchedule(t *testing.T) {
 				"A": {0, 1, 2, 5, 6, 7, 8, 9},
 			},
 		},
-		"per priority  limits 2": {
+		"per priority per queue limits equal limits": {
 			SchedulingConfig: withPerPriorityLimits(
 				map[int32]map[string]float64{
 					0: {"cpu": 0.9}, // 28 cpu
@@ -870,6 +870,37 @@ func TestSchedule(t *testing.T) {
 			},
 			ExpectedIndicesByQueue: map[string][]int{
 				"A": {0},
+			},
+		},
+		"limit hit at higher priority doesn't block jobs at lower priority": {
+			SchedulingConfig: withPerPriorityLimits(
+				map[int32]map[string]float64{
+					0: {"cpu": 0.9}, // 28 cpu
+					1: {"cpu": 0.5}, // 14 cpu
+				}, testSchedulingConfig()),
+			Nodes: testNCpuNode(1, testPriorities),
+			ReqsByQueue: map[string][]*schedulerobjects.PodRequirements{
+				"A": append(testNSmallCpuJob(1, 1), testNSmallCpuJob(0, 5)...),
+			},
+			PriorityFactorByQueue: map[string]float64{
+				"A": 1,
+			},
+			InitialUsageByQueue: map[string]schedulerobjects.QuantityByPriorityAndResourceType{
+				"A": {
+					0: schedulerobjects.ResourceList{
+						Resources: map[string]resource.Quantity{
+							"cpu": resource.MustParse("7"), // under limit
+						},
+					},
+					1: schedulerobjects.ResourceList{
+						Resources: map[string]resource.Quantity{
+							"cpu": resource.MustParse("20"), // over limit
+						},
+					},
+				},
+			},
+			ExpectedIndicesByQueue: map[string][]int{
+				"A": {1},
 			},
 		},
 		"fairness two queues": {


### PR DESCRIPTION
Previously we would block job scheduling if a per priority limit was hit at any level.  This meant that in certain edge cases (most likely when a limit was lowered) valid jobs could be blocked from being scheduled.  As a worked example, consider the following:

* User has 0 cores at level 1 and  10 cores at level 2.  The user is within the limits at both levels.
* Limits are lowered to 9 cores at level 2 and  20 cores at level 1.
* User tries to schedule a job at level 0.  Scheduling would be blocked because they fail the level 2 check.

This PR changes the behaviour so that we only apply per priority limits at levels at or below the candidate job.