### PR TITLE
[Ingesters] Bug In Batcher When No Message Received In Timeout

### DIFF
--- a/config/eventingester/config.yaml
+++ b/config/eventingester/config.yaml
@@ -8,14 +8,14 @@ redis:
 pulsar:
   URL: "pulsar://localhost:6650"
   jobsetEventsTopic: "jobset-events"
-
-paralellism: 1
+  receiveTimeout: 5s
+  backoffTime: 1s
+  
 subscriptionName: "events-ingester"
 batchSize: 1048576  #1MB
 batchMessages: 10000
 batchDuration: 500ms
-pulsarReceiveTimeout: 5s
-pulsarBackoffTime: 1s
+
 minMessageCompressionSize: 1024
 eventRetentionPolicy:
   expiryEnabled: true

--- a/config/lookoutingester/config.yaml
+++ b/config/lookoutingester/config.yaml
@@ -16,13 +16,13 @@ metrics:
 pulsar:
   enabled: true
   URL: "pulsar://localhost:6650"
-  jobsetEventsTopic: "persistent://armada/armada/events"
+  jobsetEventsTopic: "events"
+  receiveTimeout: 5s
+  backofftime: 1s
 
 paralellism: 1
 subscriptionName: "lookout-ingester"
 batchSize: 10000
 batchDuration: 500ms
-pulsarReceiveTimeout: 5s
-pulsarBackoffTime: 1s
 minJobSpecCompressionSize: 1024
 userAnnotationPrefix: "armadaproject.io/"

--- a/internal/common/ingest/batch.go
+++ b/internal/common/ingest/batch.go
@@ -58,8 +58,8 @@ func (b *Batcher[T]) Run(ctx context.Context) {
 				b.mutex.Lock()
 				if len(b.buffer) > 0 {
 					b.callback(b.buffer)
-					appendToBatch = false
 				}
+				appendToBatch = false
 				b.mutex.Unlock()
 			}
 		}

--- a/internal/common/ingest/batch_test.go
+++ b/internal/common/ingest/batch_test.go
@@ -98,7 +98,7 @@ func TestBatch_Time_WithIntialQuiet(t *testing.T) {
 		batcher.Run(ctx)
 	}()
 
-	// intial quiet period
+	// initial quiet period
 	testClock.Step(5 * time.Second)
 
 	inputChan <- 1

--- a/internal/common/ingest/ingestion_pipeline.go
+++ b/internal/common/ingest/ingestion_pipeline.go
@@ -104,6 +104,7 @@ func (ingester *IngestionPipeline[T]) Run(ctx context.Context) error {
 		defer closePulsar()
 	}
 	pulsarMsgs := pulsarutils.Receive(ctx, ingester.consumer, ingester.pulsarConfig.ReceiveTimeout, ingester.pulsarConfig.BackoffTime, ingester.metrics)
+
 	// Setup a context that n seconds after ctx
 	// This gives the rest of the pipeline a chance to flush pending messages
 	pipelineShutdownContext, cancel := context.WithCancel(context.Background())
@@ -120,7 +121,6 @@ func (ingester *IngestionPipeline[T]) Run(ctx context.Context) error {
 
 	// Batch up messages
 	batchedMsgs := make(chan []pulsar.Message)
-
 	batcher := NewBatcher[pulsar.Message](pulsarMsgs, ingester.pulsarBatchSize, ingester.pulsarBatchDuration, func(b []pulsar.Message) { batchedMsgs <- b })
 	go func() {
 		batcher.Run(pipelineShutdownContext)

--- a/internal/common/ingest/ingestion_pipeline.go
+++ b/internal/common/ingest/ingestion_pipeline.go
@@ -104,7 +104,6 @@ func (ingester *IngestionPipeline[T]) Run(ctx context.Context) error {
 		defer closePulsar()
 	}
 	pulsarMsgs := pulsarutils.Receive(ctx, ingester.consumer, ingester.pulsarConfig.ReceiveTimeout, ingester.pulsarConfig.BackoffTime, ingester.metrics)
-
 	// Setup a context that n seconds after ctx
 	// This gives the rest of the pipeline a chance to flush pending messages
 	pipelineShutdownContext, cancel := context.WithCancel(context.Background())
@@ -121,6 +120,7 @@ func (ingester *IngestionPipeline[T]) Run(ctx context.Context) error {
 
 	// Batch up messages
 	batchedMsgs := make(chan []pulsar.Message)
+
 	batcher := NewBatcher[pulsar.Message](pulsarMsgs, ingester.pulsarBatchSize, ingester.pulsarBatchDuration, func(b []pulsar.Message) { batchedMsgs <- b })
 	go func() {
 		batcher.Run(pipelineShutdownContext)


### PR DESCRIPTION
The batcher was only resetting when it flushed its buffer. In cases where the buffer was empty the batcher was not being reset which meant it only released its messages when the buffer became full and not when the time condition fired.

This PR addresses the above issue and adds a test confirming the fix

As a bonus fix- I've also corrected the default config for `receiveTimeout` and `backoffTime` for the lookout and event ingesters.  Previously we moved this config into `PulsarConfig` but the config files were not updated.