### PR TITLE
[Ingesters] Log how long insertion took

### DIFF
--- a/internal/common/ingest/ingestion_pipeline.go
+++ b/internal/common/ingest/ingestion_pipeline.go
@@ -158,7 +158,7 @@ func (ingester *IngestionPipeline[T]) Run(ctx context.Context) error {
 			if err != nil {
 				log.WithError(err).Warn("Error inserting messages")
 			} else {
-				log.Infof("Ingested %d pulsar messages in %dms", len(msg.GetMessageIDs()), taken.Milliseconds())
+				log.Infof("Inserted %d pulsar messages in %dms", len(msg.GetMessageIDs()), taken.Milliseconds())
 			}
 			if errors.Is(err, context.DeadlineExceeded) {
 				// This occurs when we're shutting down- it's a signal to stop processing immediately

--- a/internal/common/ingest/ingestion_pipeline.go
+++ b/internal/common/ingest/ingestion_pipeline.go
@@ -152,11 +152,14 @@ func (ingester *IngestionPipeline[T]) Run(ctx context.Context) error {
 		for msg := range instructions {
 			// The sink is responsible for retrying any messages so if we get a message here we know we can give up
 			// and just ACK the ids
+			start := time.Now()
 			err := ingester.sink.Store(pipelineShutdownContext, msg)
+			taken := time.Now().Sub(start)
 			if err != nil {
 				log.WithError(err).Warn("Error inserting messages")
+			} else {
+				log.Infof("Ingested %d pulsar messages in %dms", len(msg.GetMessageIDs()), taken.Milliseconds())
 			}
-
 			if errors.Is(err, context.DeadlineExceeded) {
 				// This occurs when we're shutting down- it's a signal to stop processing immediately
 				break


### PR DESCRIPTION
All ingesters will now log something like `Ingested 3 pulsar messages in 0ms` every time they write to the sink.