### PR TITLE
Revert "Use `env` namespace for environment vars."

### DIFF
--- a/.github/workflows/upload-docker-images.yml
+++ b/.github/workflows/upload-docker-images.yml
@@ -32,7 +32,7 @@ jobs:
             TAG="${{github.ref_name}}-$TAG_SUFFIX"
           fi
 
-          echo ${env.DOCKERHUB_PASS} | docker login -u ${env.DOCKERHUB_USER} --password-stdin
+          echo ${DOCKERHUB_PASS} | docker login -u ${DOCKERHUB_USER} --password-stdin
 
           IMAGES_TO_UPLOAD=(
             "armada-server"


### PR DESCRIPTION
Reverts G-Research/armada#1815

Since it broke the build. 