### PR TITLE
Fix variable expansion for Docker Hub login creds in workflow

### DIFF
--- a/.github/workflows/upload-docker-images.yml
+++ b/.github/workflows/upload-docker-images.yml
@@ -32,7 +32,7 @@ jobs:
             TAG="${{github.ref_name}}-$TAG_SUFFIX"
           fi
 
-          echo ${env.DOCKERHUB_PASS} | docker login -u ${env.DOCKERHUB_USER} --password-stdin
+          echo ${{ env.DOCKERHUB_PASS }} | docker login -u ${{ env.DOCKERHUB_USER }} --password-stdin
 
           IMAGES_TO_UPLOAD=(
             "armada-server"


### PR DESCRIPTION
Fix the variable expansion for GH Actions context vars (they require `${{ var }}` unlike plain shell vars in the Bash chunks of GH Actions).