### PR TITLE
Disable dockerhub upload

### DIFF
--- a/.github/workflows/build-release-images.yml
+++ b/.github/workflows/build-release-images.yml
@@ -50,7 +50,7 @@ jobs:
           name: docker-images
           path: docker-images.tar.gz
           if-no-files-found: error
-  invoke-image-push:
-    name: Push Docker Image artifacts to Docker Hub
-    needs: test-and-build-images
-    uses: ./.github/workflows/upload-docker-images.yml
+# invoke-image-push:
+#   name: Push Docker Image artifacts to Docker Hub
+#   needs: test-and-build-images
+#   uses: ./.github/workflows/upload-docker-images.yml

--- a/.github/workflows/upload-docker-images.yml
+++ b/.github/workflows/upload-docker-images.yml
@@ -32,7 +32,7 @@ jobs:
             TAG="${{github.ref_name}}-$TAG_SUFFIX"
           fi
 
-          echo ${{ env.DOCKERHUB_PASS }} | docker login -u ${{ env.DOCKERHUB_USER }} --password-stdin
+          echo ${DOCKERHUB_PASS} | docker login -u ${DOCKERHUB_USER} --password-stdin
 
           IMAGES_TO_UPLOAD=(
             "armada-server"


### PR DESCRIPTION
For now, just disable the docker hub upload workflow. It will have to be tested/deployed a different way.
