### PR TITLE
Fix Panic In Prometheus metrics code

### DIFF
--- a/internal/armada/metrics/metrics.go
+++ b/internal/armada/metrics/metrics.go
@@ -145,7 +145,7 @@ var medianJobRunDurationDesc = prometheus.NewDesc(
 var jobRunDurationDesc = prometheus.NewDesc(
 	MetricPrefix+"job_run_time_seconds",
 	"Run time for Armada jobs",
-	[]string{"pool", "queueName"},
+	[]string{"pool", "priorityClass", "queueName"},
 	nil,
 )
 


### PR DESCRIPTION
`job_run_time_seconds` was updated to have a priorityClass label, but the actual description was not updated to reflect this.  As a result we had a panic when values were produced.

This wasn't spotted previously because the metrics file has no unit test.  I've fixed this now for expediency but I'll follow up with something that adds tests for this file