### PR TITLE
handle duplicates in lookout ingester

### DIFF
--- a/internal/lookoutingester/instructions/instructions.go
+++ b/internal/lookoutingester/instructions/instructions.go
@@ -201,12 +201,11 @@ func (c *InstructionConverter) handleJobDuplicateDetected(ts time.Time, event *a
 	jobId, err := armadaevents.UlidStringFromProtoUuid(event.GetNewJobId())
 	if err != nil {
 		c.metrics.RecordPulsarMessageError(metrics.PulsarMessageErrorProcessing)
-		return err
 	}
-
 	jobUpdate := model.UpdateJobInstruction{
 		JobId:     jobId,
 		Duplicate: pointer.Bool(true),
+		State:     pointer.Int32(int32(repository.JobDuplicateOrdinal)),
 		Updated:   ts,
 	}
 	update.JobsToUpdate = append(update.JobsToUpdate, &jobUpdate)

--- a/internal/lookoutingester/instructions/instructions.go
+++ b/internal/lookoutingester/instructions/instructions.go
@@ -201,6 +201,7 @@ func (c *InstructionConverter) handleJobDuplicateDetected(ts time.Time, event *a
 	jobId, err := armadaevents.UlidStringFromProtoUuid(event.GetNewJobId())
 	if err != nil {
 		c.metrics.RecordPulsarMessageError(metrics.PulsarMessageErrorProcessing)
+		return err
 	}
 	jobUpdate := model.UpdateJobInstruction{
 		JobId:     jobId,

--- a/internal/lookoutingester/instructions/instructions_test.go
+++ b/internal/lookoutingester/instructions/instructions_test.go
@@ -625,6 +625,34 @@ func TestHandlePodUnschedulable(t *testing.T) {
 	assert.Equal(t, expected, instructions)
 }
 
+func TestHandleDuplicate(t *testing.T) {
+
+	duplicate := &armadaevents.EventSequence_Event{
+		Created: &baseTime,
+		Event: &armadaevents.EventSequence_Event_JobDuplicateDetected{
+			JobDuplicateDetected: &armadaevents.JobDuplicateDetected{
+				NewJobId: jobIdProto,
+			},
+		},
+	}
+
+	svc := SimpleInstructionConverter()
+	msg := NewMsg(duplicate)
+	instructions := svc.Convert(context.Background(), msg)
+	expected := &model.InstructionSet{
+		JobsToUpdate: []*model.UpdateJobInstruction{
+			{
+				JobId:     jobIdString,
+				State:     pointer.Int32(repository.JobDuplicateOrdinal),
+				Updated:   baseTime,
+				Duplicate: pointer.Bool(true),
+			},
+		},
+		MessageIds: msg.MessageIds,
+	}
+	assert.Equal(t, expected, instructions)
+}
+
 func TestSubmitWithNullChar(t *testing.T) {
 	msg := NewMsg(&armadaevents.EventSequence_Event{
 		Created: &baseTime,

--- a/internal/lookoutingester/instructions/instructions_test.go
+++ b/internal/lookoutingester/instructions/instructions_test.go
@@ -626,7 +626,6 @@ func TestHandlePodUnschedulable(t *testing.T) {
 }
 
 func TestHandleDuplicate(t *testing.T) {
-
 	duplicate := &armadaevents.EventSequence_Event{
 		Created: &baseTime,
 		Event: &armadaevents.EventSequence_Event_JobDuplicateDetected{


### PR DESCRIPTION
Lookout ingester wasn't setting the state of the jobs to "duplicate" which meant that duplicated jobs stayed in a queued state forever.

Note that lookout v2 doesn't (yet?) have a duplicate state so I haven't done anything for that.  We'll need to discuss how to handle duplicate jobs in that case.