### PR TITLE
Lookout v1 remove fakeDataEnabled from config

### DIFF
--- a/config/lookout/config.yaml
+++ b/config/lookout/config.yaml
@@ -19,7 +19,6 @@ uiConfig:
   overviewAutoRefreshMs: 15000
   jobSetsAutoRefreshMs: 15000
   jobsAutoRefreshMs: 30000
-  fakeDataEnabled: false
   lookoutV2ApiBaseUrl: "http://localhost:10000"
 
 postgres:

--- a/internal/lookout/configuration/types.go
+++ b/internal/lookout/configuration/types.go
@@ -23,7 +23,6 @@ type LookoutUIConfig struct {
 	JobSetsAutoRefreshMs  int
 	JobsAutoRefreshMs     int
 
-	FakeDataEnabled     bool
 	LookoutV2ApiBaseUrl string
 }
 


### PR DESCRIPTION
Parsed from query parameter client side, no need for it to be here