### PR TITLE
Lookout v2 - make sure annotations are returned by API

### DIFF
--- a/internal/lookoutv2/repository/getjobs_test.go
+++ b/internal/lookoutv2/repository/getjobs_test.go
@@ -56,7 +56,19 @@ func TestGetJobsSingle(t *testing.T) {
 		store := lookoutdb.NewLookoutDb(db, metrics.Get(), 3, 10)
 
 		job := NewJobSimulator(userAnnotationPrefix, converter, store).
-			Submit(queue, jobSet, owner, baseTime, basicJobOpts).
+			Submit(queue, jobSet, owner, baseTime, &JobOptions{
+				JobId:            jobId,
+				Priority:         priority,
+				PriorityClass:    "other-than-default",
+				Cpu:              cpu,
+				Memory:           memory,
+				EphemeralStorage: ephemeralStorage,
+				Gpu:              gpu,
+				Annotations: map[string]string{
+					"step_path": "/1/2/3",
+					"hello":     "world",
+				},
+			}).
 			Pending(runId, cluster, baseTime).
 			Running(runId, node, baseTime).
 			RunSucceeded(runId, baseTime).

--- a/internal/lookoutv2/repository/util.go
+++ b/internal/lookoutv2/repository/util.go
@@ -147,7 +147,7 @@ func (js *JobSimulator) Submit(queue, jobSet, owner string, timestamp time.Time,
 	js.apiJob = apiJob
 
 	js.job = &model.Job{
-		Annotations:        make(map[string]string),
+		Annotations:        opts.Annotations,
 		Cpu:                opts.Cpu.MilliValue(),
 		EphemeralStorage:   opts.EphemeralStorage.Value(),
 		Gpu:                opts.Gpu.Value(),


### PR DESCRIPTION
Previously was just fetching the rows without adding the annotations to the Job struct