### PR TITLE
Cancel stale requests in Lookout V2

### DIFF
--- a/internal/lookout/ui/src/containers/lookoutV2/JobsTableContainer.tsx
+++ b/internal/lookout/ui/src/containers/lookoutV2/JobsTableContainer.tsx
@@ -120,6 +120,7 @@ export const JobsTableContainer = ({
   // Sorting
   const [sorting, setSorting] = useState<SortingState>([{ id: "jobId", desc: true }])
 
+  // Data
   const {data, pageCount, rowsToFetch, setRowsToFetch, totalRowCount} = useFetchJobsTableData({
     groupedColumns: grouping, 
     expandedState: expanded,

--- a/internal/lookout/ui/src/containers/lookoutV2/JobsTableContainer.tsx
+++ b/internal/lookout/ui/src/containers/lookoutV2/JobsTableContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react"
+import React, { useCallback, useMemo, useState } from "react"
 
 import {
   TableContainer,
@@ -35,14 +35,14 @@ import { JobsTableActionBar } from "components/lookoutV2/JobsTableActionBar"
 import { HeaderCell } from "components/lookoutV2/JobsTableCell"
 import { JobsTableRow } from "components/lookoutV2/JobsTableRow"
 import { Sidebar } from "components/lookoutV2/sidebar/Sidebar"
+import { useFetchJobsTableData } from "hooks/useJobsTableData"
 import _ from "lodash"
-import { JobTableRow, isJobGroupRow, JobRow, JobGroupRow } from "models/jobsTableModels"
+import { JobTableRow, isJobGroupRow, JobRow } from "models/jobsTableModels"
 import { Job, JobFilter, JobId } from "models/lookoutV2Models"
 import { useSnackbar } from "notistack"
 import { IGetJobsService } from "services/lookoutV2/GetJobsService"
 import { IGroupJobsService } from "services/lookoutV2/GroupJobsService"
 import { UpdateJobsService } from "services/lookoutV2/UpdateJobsService"
-import { getErrorMessage } from "utils"
 import {
   ColumnId,
   DEFAULT_COLUMN_VISIBILITY,
@@ -54,21 +54,14 @@ import {
 } from "utils/jobsTableColumns"
 import {
   convertRowPartsToFilters,
-  fetchJobGroups,
-  fetchJobs,
-  groupsToRows,
-  jobsToRows,
   diffOfKeys,
   updaterToValue,
   convertColumnFiltersToFilters,
-  FetchRowRequest,
-  PendingData,
   pendingDataForAllVisibleData,
 } from "utils/jobsTableUtils"
-import { fromRowId, mergeSubRows, RowId } from "utils/reactTableUtils"
+import { fromRowId, RowId } from "utils/reactTableUtils"
 
 import styles from "./JobsTableContainer.module.css"
-import { useFetchJobsTableData } from "hooks/useJobsTableData"
 
 const DEFAULT_PAGE_SIZE = 30
 
@@ -121,18 +114,18 @@ export const JobsTableContainer = ({
   const [sorting, setSorting] = useState<SortingState>([{ id: "jobId", desc: true }])
 
   // Data
-  const {data, pageCount, rowsToFetch, setRowsToFetch, totalRowCount} = useFetchJobsTableData({
-    groupedColumns: grouping, 
+  const { data, pageCount, rowsToFetch, setRowsToFetch, totalRowCount } = useFetchJobsTableData({
+    groupedColumns: grouping,
     expandedState: expanded,
-    paginationState: pagination, 
-    sortingState: sorting, 
-    columnFilters: columnFilterState, 
-    allColumns, 
-    selectedRows, 
-    updateSelectedRows: setSelectedRows, 
-    getJobsService, 
-    groupJobsService, 
-    enqueueSnackbar, 
+    paginationState: pagination,
+    sortingState: sorting,
+    columnFilters: columnFilterState,
+    allColumns,
+    selectedRows,
+    updateSelectedRows: setSelectedRows,
+    getJobsService,
+    groupJobsService,
+    enqueueSnackbar,
   })
 
   const onRefresh = useCallback(() => {

--- a/internal/lookout/ui/src/hooks/useJobsTableData.ts
+++ b/internal/lookout/ui/src/hooks/useJobsTableData.ts
@@ -1,0 +1,163 @@
+import { SortingState, ColumnFiltersState, RowSelectionState, PaginationState, ExpandedStateList } from "@tanstack/react-table"
+import { JobTableRow, JobRow, JobGroupRow } from "models/jobsTableModels"
+import { SnackbarProvider } from "notistack"
+import { useEffect, useState } from "react"
+import { IGetJobsService } from "services/lookoutV2/GetJobsService"
+import { IGroupJobsService } from "services/lookoutV2/GroupJobsService"
+import { getErrorMessage } from "utils"
+import { ColumnId, JobTableColumn } from "utils/jobsTableColumns"
+import { PendingData, FetchRowRequest, convertRowPartsToFilters, convertColumnFiltersToFilters, fetchJobs, jobsToRows, fetchJobGroups, groupsToRows } from "utils/jobsTableUtils"
+import { fromRowId, mergeSubRows } from "utils/reactTableUtils"
+
+
+export interface UseFetchJobsTableDataArgs {
+  groupedColumns: ColumnId[]
+  expandedState: ExpandedStateList
+  sortingState: SortingState
+  paginationState: PaginationState
+  columnFilters: ColumnFiltersState
+  allColumns: JobTableColumn[]
+  selectedRows: RowSelectionState
+  updateSelectedRows: (newState: RowSelectionState) => void
+  getJobsService: IGetJobsService
+  groupJobsService: IGroupJobsService
+  enqueueSnackbar: SnackbarProvider['enqueueSnackbar']
+}
+export interface UseFetchJobsTableDataResult {
+  data: JobTableRow[]
+  pageCount: number
+  rowsToFetch: PendingData[], 
+  setRowsToFetch: React.Dispatch<React.SetStateAction<PendingData[]>>, 
+  totalRowCount: number,
+}
+export const useFetchJobsTableData = ({
+  groupedColumns, 
+  expandedState,
+  sortingState,
+  paginationState,
+  columnFilters, 
+  allColumns, 
+  selectedRows,
+  updateSelectedRows,
+  getJobsService, 
+  groupJobsService, 
+  enqueueSnackbar, 
+}: UseFetchJobsTableDataArgs): UseFetchJobsTableDataResult => {
+  const [data, setData] = useState<JobTableRow[]>([])
+  const [pendingData, setPendingData] = useState<PendingData[]>([{ parentRowId: "ROOT", skip: 0 }])
+  const [totalRowCount, setTotalRowCount] = useState(0)
+  const [pageCount, setPageCount] = useState<number>(-1)
+
+  useEffect(() => {
+    const abortController = new AbortController();
+
+    async function fetchData() {
+      if (pendingData.length === 0) {
+        return
+      }
+
+      const [nextRequest, ...restOfRequests] = pendingData
+
+      const parentRowInfo = nextRequest.parentRowId !== "ROOT" ? fromRowId(nextRequest.parentRowId) : undefined
+
+      const groupingLevel = groupedColumns.length
+      const expandedLevel = parentRowInfo ? parentRowInfo.rowIdPathFromRoot.length : 0
+      const isJobFetch = expandedLevel === groupingLevel
+
+      const sortedField = sortingState[0]
+
+      const rowRequest: FetchRowRequest = {
+        filters: [
+          ...convertRowPartsToFilters(parentRowInfo?.rowIdPartsPath ?? []),
+          ...convertColumnFiltersToFilters(columnFilters, allColumns),
+        ],
+        skip: nextRequest.skip ?? 0,
+        take: nextRequest.take ?? paginationState.pageSize,
+        order: { field: sortedField.id, direction: sortedField.desc ? "DESC" : "ASC" },
+      }
+
+      let newData, totalCount
+      try {
+        if (isJobFetch) {
+          const { jobs, count: totalJobs } = await fetchJobs(rowRequest, getJobsService, abortController.signal)
+          newData = jobsToRows(jobs)
+          totalCount = totalJobs
+        } else {
+          const groupedCol = groupedColumns[expandedLevel]
+
+          // TODO: Wire in aggregatable+visible columns (maybe use column metadata?)
+          const colsToAggregate: string[] = []
+          const { groups, count: totalGroups } = await fetchJobGroups(
+            rowRequest,
+            groupJobsService,
+            groupedCol,
+            colsToAggregate,
+            abortController.signal
+          )
+          newData = groupsToRows(groups, parentRowInfo?.rowId, groupedCol)
+          totalCount = totalGroups
+        }
+      } catch (err) {
+        if (abortController.signal.aborted) {
+          return
+        }
+        
+        const errMsg = await getErrorMessage(err)
+        enqueueSnackbar("Failed to retrieve jobs. Error: " + errMsg, { variant: "error" })
+        return
+      }
+
+      const { rootData, parentRow } = mergeSubRows<JobRow, JobGroupRow>(
+        data,
+        newData,
+        parentRowInfo?.rowId,
+        Boolean(nextRequest.append)
+      )
+
+      if (parentRow) {
+        parentRow.subRowCount = totalCount
+
+        // Update any new children of selected rows
+        if (parentRow.rowId in selectedRows) {
+          const newSelectedRows = parentRow.subRows.reduce(
+            (newSelectedSubRows, subRow) => {
+              newSelectedSubRows[subRow.rowId] = true
+              return newSelectedSubRows
+            },
+            { ...selectedRows }
+          )
+          updateSelectedRows(newSelectedRows)
+        }
+      }
+
+      setData([...rootData]) // ReactTable will only re-render if the array identity changes
+      setPendingData(restOfRequests)
+      if (parentRowInfo === undefined) {
+        setPageCount(Math.ceil(totalCount / paginationState.pageSize))
+        setTotalRowCount(totalCount)
+      }
+    }
+
+    fetchData().catch(console.error)
+
+    return () => {
+      abortController.abort("Request is no longer needed")
+    }
+  }, [
+    pendingData, 
+    paginationState, 
+    groupedColumns, 
+    expandedState, 
+    columnFilters, 
+    sortingState, 
+    allColumns
+  ])
+
+  return {
+    data,
+    pageCount,
+    rowsToFetch: pendingData,
+    setRowsToFetch: setPendingData,
+    totalRowCount,
+  }
+}

--- a/internal/lookout/ui/src/hooks/useJobsTableData.ts
+++ b/internal/lookout/ui/src/hooks/useJobsTableData.ts
@@ -1,14 +1,29 @@
-import { SortingState, ColumnFiltersState, RowSelectionState, PaginationState, ExpandedStateList } from "@tanstack/react-table"
+import { useEffect, useState } from "react"
+
+import {
+  SortingState,
+  ColumnFiltersState,
+  RowSelectionState,
+  PaginationState,
+  ExpandedStateList,
+} from "@tanstack/react-table"
 import { JobTableRow, JobRow, JobGroupRow } from "models/jobsTableModels"
 import { SnackbarProvider } from "notistack"
-import { useEffect, useState } from "react"
 import { IGetJobsService } from "services/lookoutV2/GetJobsService"
 import { IGroupJobsService } from "services/lookoutV2/GroupJobsService"
 import { getErrorMessage } from "utils"
 import { ColumnId, JobTableColumn } from "utils/jobsTableColumns"
-import { PendingData, FetchRowRequest, convertRowPartsToFilters, convertColumnFiltersToFilters, fetchJobs, jobsToRows, fetchJobGroups, groupsToRows } from "utils/jobsTableUtils"
+import {
+  PendingData,
+  FetchRowRequest,
+  convertRowPartsToFilters,
+  convertColumnFiltersToFilters,
+  fetchJobs,
+  jobsToRows,
+  fetchJobGroups,
+  groupsToRows,
+} from "utils/jobsTableUtils"
 import { fromRowId, mergeSubRows } from "utils/reactTableUtils"
-
 
 export interface UseFetchJobsTableDataArgs {
   groupedColumns: ColumnId[]
@@ -21,27 +36,27 @@ export interface UseFetchJobsTableDataArgs {
   updateSelectedRows: (newState: RowSelectionState) => void
   getJobsService: IGetJobsService
   groupJobsService: IGroupJobsService
-  enqueueSnackbar: SnackbarProvider['enqueueSnackbar']
+  enqueueSnackbar: SnackbarProvider["enqueueSnackbar"]
 }
 export interface UseFetchJobsTableDataResult {
   data: JobTableRow[]
   pageCount: number
-  rowsToFetch: PendingData[], 
-  setRowsToFetch: React.Dispatch<React.SetStateAction<PendingData[]>>, 
-  totalRowCount: number,
+  rowsToFetch: PendingData[]
+  setRowsToFetch: (toFetch: PendingData[]) => void
+  totalRowCount: number
 }
 export const useFetchJobsTableData = ({
-  groupedColumns, 
+  groupedColumns,
   expandedState,
   sortingState,
   paginationState,
-  columnFilters, 
-  allColumns, 
+  columnFilters,
+  allColumns,
   selectedRows,
   updateSelectedRows,
-  getJobsService, 
-  groupJobsService, 
-  enqueueSnackbar, 
+  getJobsService,
+  groupJobsService,
+  enqueueSnackbar,
 }: UseFetchJobsTableDataArgs): UseFetchJobsTableDataResult => {
   const [data, setData] = useState<JobTableRow[]>([])
   const [pendingData, setPendingData] = useState<PendingData[]>([{ parentRowId: "ROOT", skip: 0 }])
@@ -49,7 +64,7 @@ export const useFetchJobsTableData = ({
   const [pageCount, setPageCount] = useState<number>(-1)
 
   useEffect(() => {
-    const abortController = new AbortController();
+    const abortController = new AbortController()
 
     async function fetchData() {
       if (pendingData.length === 0) {
@@ -92,7 +107,7 @@ export const useFetchJobsTableData = ({
             groupJobsService,
             groupedCol,
             colsToAggregate,
-            abortController.signal
+            abortController.signal,
           )
           newData = groupsToRows(groups, parentRowInfo?.rowId, groupedCol)
           totalCount = totalGroups
@@ -111,7 +126,7 @@ export const useFetchJobsTableData = ({
         data,
         newData,
         parentRowInfo?.rowId,
-        Boolean(nextRequest.append)
+        Boolean(nextRequest.append),
       )
 
       if (parentRow) {
@@ -124,7 +139,7 @@ export const useFetchJobsTableData = ({
               newSelectedSubRows[subRow.rowId] = true
               return newSelectedSubRows
             },
-            { ...selectedRows }
+            { ...selectedRows },
           )
           updateSelectedRows(newSelectedRows)
         }
@@ -145,15 +160,7 @@ export const useFetchJobsTableData = ({
     return () => {
       abortController.abort("Request is no longer needed")
     }
-  }, [
-    pendingData, 
-    paginationState, 
-    groupedColumns, 
-    expandedState, 
-    columnFilters, 
-    sortingState, 
-    allColumns
-  ])
+  }, [pendingData, paginationState, groupedColumns, expandedState, columnFilters, sortingState, allColumns])
 
   return {
     data,

--- a/internal/lookout/ui/src/hooks/useJobsTableData.ts
+++ b/internal/lookout/ui/src/hooks/useJobsTableData.ts
@@ -101,7 +101,7 @@ export const useFetchJobsTableData = ({
         if (abortController.signal.aborted) {
           return
         }
-        
+
         const errMsg = await getErrorMessage(err)
         enqueueSnackbar("Failed to retrieve jobs. Error: " + errMsg, { variant: "error" })
         return
@@ -140,6 +140,8 @@ export const useFetchJobsTableData = ({
 
     fetchData().catch(console.error)
 
+    // This will run when the current invocation is no longer needed (either because the
+    // component is unmounted, or the effect needs to run again)
     return () => {
       abortController.abort("Request is no longer needed")
     }

--- a/internal/lookout/ui/src/services/lookoutV2/GetJobsService.ts
+++ b/internal/lookout/ui/src/services/lookoutV2/GetJobsService.ts
@@ -6,7 +6,7 @@ export interface IGetJobsService {
     order: JobOrder,
     skip: number,
     take: number,
-    signal: AbortSignal | undefined,
+    abortSignal: AbortSignal | undefined,
   ): Promise<GetJobsResponse>
 }
 
@@ -23,7 +23,7 @@ export class GetJobsService implements IGetJobsService {
     order: JobOrder,
     skip: number,
     take: number,
-    signal: AbortSignal | undefined,
+    abortSignal: AbortSignal | undefined,
   ): Promise<GetJobsResponse> {
     const response = await fetch(this.apiBase + "/api/v1/jobs", {
       method: "POST",
@@ -33,8 +33,8 @@ export class GetJobsService implements IGetJobsService {
         order,
         skip,
         take,
-        signal,
       }),
+      signal: abortSignal,
     })
 
     const json = await response.json()

--- a/internal/lookout/ui/src/services/lookoutV2/GroupJobsService.ts
+++ b/internal/lookout/ui/src/services/lookoutV2/GroupJobsService.ts
@@ -8,7 +8,7 @@ export interface IGroupJobsService {
     aggregates: string[],
     skip: number,
     take: number,
-    signal: AbortSignal | undefined,
+    abortSignal: AbortSignal | undefined,
   ): Promise<GroupJobsResponse>
 }
 
@@ -27,7 +27,7 @@ export class GroupJobsService implements IGroupJobsService {
     aggregates: string[],
     skip: number,
     take: number,
-    signal: AbortSignal | undefined,
+    abortSignal: AbortSignal | undefined,
   ): Promise<GroupJobsResponse> {
     const response = await fetch(this.apiBase + "/api/v1/jobGroups", {
       method: "POST",
@@ -39,8 +39,8 @@ export class GroupJobsService implements IGroupJobsService {
         aggregates,
         skip,
         take,
-        signal,
       }),
+      signal: abortSignal,
     })
 
     const json = await response.json()

--- a/internal/lookout/ui/src/services/lookoutV2/mocks/FakeGetJobsService.ts
+++ b/internal/lookout/ui/src/services/lookoutV2/mocks/FakeGetJobsService.ts
@@ -14,7 +14,7 @@ export default class FakeGetJobsService implements IGetJobsService {
   ): Promise<GetJobsResponse> {
     console.log("Making GetJobs call with params:", { filters, order, skip, take, signal })
     if (this.simulateApiWait) {
-      await simulateApiWait()
+      await simulateApiWait(signal)
     }
 
     const filtered = this.jobs.filter(mergeFilters(filters)).sort(comparator(order))

--- a/internal/lookout/ui/src/utils/fakeJobsUtils.ts
+++ b/internal/lookout/ui/src/utils/fakeJobsUtils.ts
@@ -34,7 +34,7 @@ export function seededUuid(rand: () => number): () => string {
 export async function simulateApiWait(abortSignal?: AbortSignal): Promise<void> {
   await new Promise((resolve, reject) => {
     const timeoutId = setTimeout(resolve, randomInt(200, 1000, Math.random))
-    abortSignal?.addEventListener('abort', () => {
+    abortSignal?.addEventListener("abort", () => {
       clearTimeout(timeoutId)
       reject()
     })

--- a/internal/lookout/ui/src/utils/fakeJobsUtils.ts
+++ b/internal/lookout/ui/src/utils/fakeJobsUtils.ts
@@ -31,8 +31,14 @@ export function seededUuid(rand: () => number): () => string {
     })
 }
 
-export async function simulateApiWait(): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, randomInt(200, 1000, Math.random)))
+export async function simulateApiWait(abortSignal?: AbortSignal): Promise<void> {
+  await new Promise((resolve, reject) => {
+    const timeoutId = setTimeout(resolve, randomInt(200, 1000, Math.random))
+    abortSignal?.addEventListener('abort', () => {
+      clearTimeout(timeoutId)
+      reject()
+    })
+  })
 }
 
 export function makeTestJobs(nJobs: number, seed: number, nQueues = 10, nJobSets = 100): Job[] {

--- a/internal/lookout/ui/src/utils/jobsTableUtils.ts
+++ b/internal/lookout/ui/src/utils/jobsTableUtils.ts
@@ -67,9 +67,13 @@ export interface FetchRowRequest {
   filters: JobFilter[]
   skip: number
   take: number
-  order: JobOrder,
+  order: JobOrder
 }
-export const fetchJobs = async (rowRequest: FetchRowRequest, getJobsService: IGetJobsService, abortSignal: AbortSignal) => {
+export const fetchJobs = async (
+  rowRequest: FetchRowRequest,
+  getJobsService: IGetJobsService,
+  abortSignal: AbortSignal,
+) => {
   const { filters, skip, take, order } = rowRequest
 
   return await getJobsService.getJobs(filters, order, skip, take, abortSignal)
@@ -80,7 +84,7 @@ export const fetchJobGroups = async (
   groupJobsService: IGroupJobsService,
   groupedColumn: string,
   columnsToAggregate: string[],
-  abortSignal: AbortSignal
+  abortSignal: AbortSignal,
 ) => {
   const { filters, skip, take } = rowRequest
   let { order } = rowRequest

--- a/internal/lookout/ui/src/utils/jobsTableUtils.ts
+++ b/internal/lookout/ui/src/utils/jobsTableUtils.ts
@@ -67,12 +67,12 @@ export interface FetchRowRequest {
   filters: JobFilter[]
   skip: number
   take: number
-  order: JobOrder
+  order: JobOrder,
 }
-export const fetchJobs = async (rowRequest: FetchRowRequest, getJobsService: IGetJobsService) => {
+export const fetchJobs = async (rowRequest: FetchRowRequest, getJobsService: IGetJobsService, abortSignal: AbortSignal) => {
   const { filters, skip, take, order } = rowRequest
 
-  return await getJobsService.getJobs(filters, order, skip, take, undefined)
+  return await getJobsService.getJobs(filters, order, skip, take, abortSignal)
 }
 
 export const fetchJobGroups = async (
@@ -80,6 +80,7 @@ export const fetchJobGroups = async (
   groupJobsService: IGroupJobsService,
   groupedColumn: string,
   columnsToAggregate: string[],
+  abortSignal: AbortSignal
 ) => {
   const { filters, skip, take } = rowRequest
   let { order } = rowRequest
@@ -90,7 +91,7 @@ export const fetchJobGroups = async (
     direction: "DESC",
   }
 
-  return await groupJobsService.groupJobs(filters, order, groupedColumn, columnsToAggregate, skip, take, undefined)
+  return await groupJobsService.groupJobs(filters, order, groupedColumn, columnsToAggregate, skip, take, abortSignal)
 }
 
 export const jobsToRows = (jobs: Job[]): JobRow[] => {


### PR DESCRIPTION
#### What type of PR is this?

This is a UI PR for Lookout V2.

#### What this PR does / why we need it:

- Moves data fetching logic to it's own hook so it stops polluting the table component's state (refactor)
- Cancels outstanding API calls if the results are no longer needed and/or would cause race conditions.
  - This fixes issues seen where old slow requests would return data *after* newer fast requests, causing the data shown to not match the current table state.

#### Which issue(s) this PR fixes:

Part of https://github.com/G-Research/armada/issues/1869

#### Special notes for your reviewer:

No visual changes, so no screenshots. Happy path is covered by the existing test cases still, but testing aborting is very awkward so I don't think it's worth it currently. 

I tested the functionality locally using Chrome network throttling to simulate slow API calls. It works as expected by cancelling the previous request, and making a new request when the table state changes.
