### PR TITLE
Allow startsWith filtering on annotation columns in Lookout V2

### DIFF
--- a/internal/lookout/ui/src/components/lookoutV2/ColumnSelect.tsx
+++ b/internal/lookout/ui/src/components/lookoutV2/ColumnSelect.tsx
@@ -26,7 +26,7 @@ type ColumnSelectProps = {
   onAddAnnotation: (annotationKey: string) => void
   onToggleColumn: (columnId: ColumnId) => void
   onRemoveAnnotation: (columnId: ColumnId) => void
-  onEditAnnotation: (columnId: ColumnId, annotationKey: string) => void
+  onEditAnnotation: (columnId: ColumnId, newDisplayName: string) => void
 }
 
 export default function ColumnSelect({
@@ -49,7 +49,7 @@ export default function ColumnSelect({
   }
 
   function saveNewAnnotation() {
-    onAddAnnotation(newAnnotationKey)
+    onAddAnnotation(newAnnotationKey.trim())
     clearAddAnnotation()
   }
 
@@ -69,7 +69,7 @@ export default function ColumnSelect({
 
   return (
     <>
-      <FormControl sx={{ m: 0, width: 200 }} focused={false}>
+      <FormControl sx={{ m: 0, mt: "4px", width: 200 }} focused={false}>
         <InputLabel id="checkbox-select-label">Columns</InputLabel>
         <Select
           labelId="checkbox-select-label"
@@ -89,7 +89,7 @@ export default function ColumnSelect({
                 const colIsGrouped = groupedColumns.includes(colId)
                 const colIsVisible = visibleColumns.includes(colId)
                 const colMetadata = getColumnMetadata(column)
-                const colIsAnnotation = colMetadata.isAnnotation ?? false
+                const colIsAnnotation = colMetadata.annotation ?? false
                 return (
                   <MenuItem key={colId} value={colMetadata.displayName} disabled={colIsGrouped}>
                     <Checkbox checked={colIsVisible} onClick={() => onToggleColumn(colId)} />
@@ -101,6 +101,7 @@ export default function ColumnSelect({
                               label="Annotation Key"
                               size="small"
                               variant="standard"
+                              autoFocus
                               value={currentlyEditing.get(colId)}
                               onChange={(e) => edit(colId, e.target.value)}
                               style={{
@@ -128,7 +129,7 @@ export default function ColumnSelect({
                                 overflowX: "auto",
                               }}
                             />
-                            <IconButton onClick={() => edit(colId, colId)}>
+                            <IconButton onClick={() => edit(colId, colMetadata.displayName)}>
                               <Edit />
                             </IconButton>
                           </>
@@ -171,6 +172,7 @@ export default function ColumnSelect({
                       label="Annotation Key"
                       size="small"
                       sx={{ width: "100%" }}
+                      autoFocus
                       value={newAnnotationKey}
                       onChange={(e) => {
                         setNewAnnotationKey(e.target.value)

--- a/internal/lookout/ui/src/components/lookoutV2/JobsTableActionBar.tsx
+++ b/internal/lookout/ui/src/components/lookoutV2/JobsTableActionBar.tsx
@@ -45,23 +45,22 @@ export const JobsTableActionBar = memo(
 
     const selectableColumns = useMemo(() => allColumns.filter((col) => col.enableHiding !== false), [allColumns])
 
-    function toggleColumn(key: ColumnId) {
-      toggleColumnVisibility(key)
-    }
-
-    function addAnnotationColumn(name: string) {
-      const newColumns = allColumns.concat([createAnnotationColumn(name)])
+    function addAnnotationColumn(name: string, existingColumns = allColumns) {
+      const annotationCol = createAnnotationColumn(name)
+      const newColumns = existingColumns.concat([annotationCol])
       onColumnsChanged(newColumns)
+      toggleColumnVisibility(annotationCol.id as ColumnId)
     }
 
     function removeAnnotationColumn(key: ColumnId) {
       const filtered = allColumns.filter((col) => col.id !== key)
       onColumnsChanged(filtered)
+      return filtered
     }
 
-    function editAnnotationColumn(key: ColumnId, newName: string) {
-      removeAnnotationColumn(key)
-      addAnnotationColumn(newName)
+    function renameAnnotationColumn(key: ColumnId, newName: string) {
+      const remainingCols = removeAnnotationColumn(key)
+      addAnnotationColumn(newName, remainingCols)
     }
 
     const numSelectedItems = selectedItemFilters.length
@@ -97,8 +96,8 @@ export const JobsTableActionBar = memo(
             groupedColumns={groupedColumns}
             visibleColumns={visibleColumns}
             onAddAnnotation={addAnnotationColumn}
-            onToggleColumn={toggleColumn}
-            onEditAnnotation={editAnnotationColumn}
+            onToggleColumn={toggleColumnVisibility}
+            onEditAnnotation={renameAnnotationColumn}
             onRemoveAnnotation={removeAnnotationColumn}
           />
           <Divider orientation="vertical" />

--- a/internal/lookout/ui/src/components/lookoutV2/JobsTableFilter.tsx
+++ b/internal/lookout/ui/src/components/lookoutV2/JobsTableFilter.tsx
@@ -111,7 +111,7 @@ const TextFilter = ({ currentFilter, label, onFilterChange }: TextFilterProps) =
   return (
     <DebouncedTextField
       debounceWaitMs={300}
-      debouncedOnChange={onFilterChange}
+      debouncedOnChange={(newFilter) => onFilterChange(newFilter.trim())}
       textFieldProps={{
         type: "text",
         size: "small",

--- a/internal/lookout/ui/src/containers/lookoutV2/JobsTableContainer.test.tsx
+++ b/internal/lookout/ui/src/containers/lookoutV2/JobsTableContainer.test.tsx
@@ -296,6 +296,21 @@ describe("JobsTableContainer", () => {
       await toggleEnumFilterOption("State", formatJobState(jobs[0].state))
       await assertNumDataRowsShown(jobs.length)
     })
+
+    it("allows filtering on annotation columns", async () => {
+      const { findByRole } = renderComponent()
+      await waitForFinishedLoading()
+
+      await addAnnotationColumn("hyperparameter")
+      await assertNumDataRowsShown(numJobs)
+
+      const testAnnotationValue = jobs[0].annotations["hyperparameter"]
+      expect(testAnnotationValue).toBe("59052f3d-cfd1-4a3e-8f23-173f92764c3f")
+      await findByRole("cell", { name: testAnnotationValue })
+
+      await filterTextColumnTo("hyperparameter", testAnnotationValue)
+      await assertNumDataRowsShown(1)
+    })
   })
 
   describe("Sorting", () => {
@@ -495,5 +510,23 @@ describe("JobsTableContainer", () => {
   async function triggerRefresh() {
     const button = await screen.findByRole("button", { name: "Refresh" })
     await userEvent.click(button)
+  }
+
+  async function addAnnotationColumn(annotationKey: string) {
+    const editColumnsButton = await screen.findByRole("button", { name: /columns selected/i })
+    await userEvent.click(editColumnsButton)
+
+    const addColumnButton = await screen.findByRole("button", { name: /Add column/i })
+    await userEvent.click(addColumnButton)
+
+    const textbox = await screen.findByRole("textbox", { name: /Annotation key/i })
+    await userEvent.type(textbox, annotationKey)
+
+    const saveButton = await screen.findByRole("button", { name: /Save/i })
+    await userEvent.click(saveButton)
+
+    // Close pop up
+    await userEvent.click(screen.getByText(/Click here to add an annotation column/i))
+    await userEvent.keyboard("{Escape}")
   }
 })

--- a/internal/lookout/ui/src/containers/lookoutV2/JobsTableContainer.test.tsx
+++ b/internal/lookout/ui/src/containers/lookoutV2/JobsTableContainer.test.tsx
@@ -292,6 +292,7 @@ describe("JobsTableContainer", () => {
     it("allows filtering on annotation columns", async () => {
       const { findByRole } = renderComponent()
       await waitForFinishedLoading()
+      await clearAllGroupings()
 
       await addAnnotationColumn("hyperparameter")
       await assertNumDataRowsShown(numJobs)

--- a/internal/lookout/ui/src/models/lookoutV2Models.ts
+++ b/internal/lookout/ui/src/models/lookoutV2Models.ts
@@ -97,6 +97,7 @@ export enum Match {
 }
 
 export type JobFilter = {
+  isAnnotation?: boolean
   field: string
   value: string | number | string[] | number[]
   match: Match

--- a/internal/lookout/ui/src/services/lookoutV2/mocks/FakeGroupJobsService.ts
+++ b/internal/lookout/ui/src/services/lookoutV2/mocks/FakeGroupJobsService.ts
@@ -16,7 +16,7 @@ export default class FakeGroupJobsService implements IGroupJobsService {
   ): Promise<GroupJobsResponse> {
     console.log("GroupJobs called with params:", { filters, order, groupedField, aggregates, skip, take, signal })
     if (this.simulateApiWait) {
-      await simulateApiWait()
+      await simulateApiWait(signal)
     }
     await simulateApiWait()
     const filtered = this.jobs.filter(mergeFilters(filters))

--- a/internal/lookout/ui/src/utils/fakeJobsUtils.ts
+++ b/internal/lookout/ui/src/utils/fakeJobsUtils.ts
@@ -121,12 +121,14 @@ export function mergeFilters(filters: JobFilter[]): (job: Job) => boolean {
 
 export function filterFn(filter: JobFilter): (job: Job) => boolean {
   return (job) => {
-    if (!Object.prototype.hasOwnProperty.call(job, filter.field)) {
-      console.error(`Unknown filter field provided: ${filter.field}`)
+    const objectToFilter = filter.isAnnotation ? job.annotations : job
+
+    if (!Object.prototype.hasOwnProperty.call(objectToFilter, filter.field)) {
+      console.error(`Unknown filter field provided: ${filter}`)
       return false
     }
     const matcher = getMatch(filter.match)
-    return matcher(job[filter.field as JobKey], filter.value)
+    return matcher(objectToFilter[filter.field as JobKey], filter.value)
   }
 }
 

--- a/internal/lookout/ui/src/utils/jobsTableColumns.tsx
+++ b/internal/lookout/ui/src/utils/jobsTableColumns.tsx
@@ -24,7 +24,9 @@ export interface JobTableColumnMetadata {
   enumFitlerValues?: EnumFilterOption[]
   defaultMatchType?: Match
 
-  isAnnotation?: boolean
+  annotation?: {
+    annotationKey: string
+  }
 }
 
 export enum StandardColumnId {
@@ -260,8 +262,15 @@ export const createAnnotationColumn = (annotationKey: string): JobTableColumn =>
     id: `annotation_${annotationKey}`,
     accessor: (jobTableRow) => jobTableRow.annotations?.[annotationKey],
     displayName: annotationKey,
+    additionalOptions: {
+      enableColumnFilter: true,
+    },
     additionalMetadata: {
-      isAnnotation: true,
+      annotation: {
+        annotationKey,
+      },
+      filterType: FilterType.Text,
+      defaultMatchType: Match.StartsWith,
     },
   })
 }

--- a/internal/lookout/ui/src/utils/jobsTableUtils.ts
+++ b/internal/lookout/ui/src/utils/jobsTableUtils.ts
@@ -56,7 +56,8 @@ export const convertColumnFiltersToFilters = (filters: ColumnFiltersState, colum
     const columnInfo = columns.find((col) => col.id === id)
     const metadata = columnInfo ? getColumnMetadata(columnInfo) : undefined
     return {
-      field: id,
+      isAnnotation: Boolean(metadata?.annotation),
+      field: metadata?.annotation?.annotationKey ?? id,
       value: isArray ? (value as string[]) : (value as string),
       match: metadata?.defaultMatchType ?? (isArray ? Match.AnyOf : Match.StartsWith),
     }


### PR DESCRIPTION
#### What type of PR is this?

This is a UI PR for Lookout V2.

#### What this PR does / why we need it:

- Adds textbox filtering for annotation columns
- Fixes some minor usability issues when adding/editing annotation columns
- Adds support for annotation filtering in fake jobs helpers
- Adds a test for text filtering in annotation columns

#### Which issue(s) this PR fixes:

Part of https://github.com/G-Research/armada/issues/1869

#### Special notes for your reviewer:

**"hyperparameter" annotation column has a text input box now**
![image](https://user-images.githubusercontent.com/3807889/208716045-f4f4b01d-520f-4e1f-b441-6722eddc943a.png)

**And it allows filtering**
![image](https://user-images.githubusercontent.com/3807889/208716107-3b843603-be23-482e-9fa8-ebbfd99e1955.png)

