### PR TITLE
Group Lookout V2 by queue+jobset by default

### DIFF
--- a/internal/lookout/ui/src/components/lookoutV2/GroupBySelect.tsx
+++ b/internal/lookout/ui/src/components/lookoutV2/GroupBySelect.tsx
@@ -18,7 +18,7 @@ function GroupColumn({ columns, currentlySelected, onSelect, onDelete }: GroupCo
   const actionText = isGrouped ? "Grouped by" : "Group by"
   const labelId = `select-column-group-${currentlySelected}`
   return (
-    <FormControl size="small" focused={false} sx={{mt: "4px"}}>
+    <FormControl size="small" focused={false} sx={{ mt: "4px" }}>
       <InputLabel id={labelId} size="small">
         {actionText}
       </InputLabel>

--- a/internal/lookout/ui/src/components/lookoutV2/GroupBySelect.tsx
+++ b/internal/lookout/ui/src/components/lookoutV2/GroupBySelect.tsx
@@ -18,7 +18,7 @@ function GroupColumn({ columns, currentlySelected, onSelect, onDelete }: GroupCo
   const actionText = isGrouped ? "Grouped by" : "Group by"
   const labelId = `select-column-group-${currentlySelected}`
   return (
-    <FormControl size="small" focused={false}>
+    <FormControl size="small" focused={false} sx={{mt: "4px"}}>
       <InputLabel id={labelId} size="small">
         {actionText}
       </InputLabel>

--- a/internal/lookout/ui/src/components/lookoutV2/JobsTableCell.tsx
+++ b/internal/lookout/ui/src/components/lookoutV2/JobsTableCell.tsx
@@ -93,7 +93,7 @@ export const BodyCell = ({ cell, rowIsGroup, rowIsExpanded, onExpandedChange, su
     >
       {rowIsGroup && cell.column.getIsGrouped() && cellHasValue ? (
         // If it's a grouped cell, add an expander and row count
-        <Box sx={{display: "flex", gap: "0.25em"}}>
+        <Box sx={{ display: "flex", gap: "0.25em" }}>
           <IconButton size="small" sx={{ padding: 0 }} edge="start" onClick={() => onExpandedChange()}>
             {rowIsExpanded ? (
               <KeyboardArrowDown fontSize="small" aria-label="Collapse row" aria-hidden="false" />

--- a/internal/lookout/ui/src/components/lookoutV2/JobsTableCell.tsx
+++ b/internal/lookout/ui/src/components/lookoutV2/JobsTableCell.tsx
@@ -1,5 +1,5 @@
 import { KeyboardArrowRight, KeyboardArrowDown } from "@mui/icons-material"
-import { TableCell, IconButton, TableSortLabel } from "@mui/material"
+import { TableCell, IconButton, TableSortLabel, Box } from "@mui/material"
 import { Cell, flexRender, Header } from "@tanstack/react-table"
 import { JobRow } from "models/jobsTableModels"
 import { Match } from "models/lookoutV2Models"
@@ -93,7 +93,7 @@ export const BodyCell = ({ cell, rowIsGroup, rowIsExpanded, onExpandedChange, su
     >
       {rowIsGroup && cell.column.getIsGrouped() && cellHasValue ? (
         // If it's a grouped cell, add an expander and row count
-        <>
+        <Box sx={{display: "flex", gap: "0.25em"}}>
           <IconButton size="small" sx={{ padding: 0 }} edge="start" onClick={() => onExpandedChange()}>
             {rowIsExpanded ? (
               <KeyboardArrowDown fontSize="small" aria-label="Collapse row" aria-hidden="false" />
@@ -102,7 +102,7 @@ export const BodyCell = ({ cell, rowIsGroup, rowIsExpanded, onExpandedChange, su
             )}
           </IconButton>
           {flexRender(cell.column.columnDef.cell, cell.getContext())} ({subCount})
-        </>
+        </Box>
       ) : cell.getIsAggregated() ? (
         // If the cell is aggregated, use the Aggregated
         // renderer for cell

--- a/internal/lookout/ui/src/components/lookoutV2/JobsTableRow.module.css
+++ b/internal/lookout/ui/src/components/lookoutV2/JobsTableRow.module.css
@@ -1,4 +1,4 @@
 .rowDepthIndicator {
-  background-image: linear-gradient(rgba(224, 224, 224, 1), rgba(224, 224, 224, 1));
+  background-image: linear-gradient(rgb(51, 187, 231, 1), rgb(51, 187, 231, 1));
   background-repeat: no-repeat;
 }

--- a/internal/lookout/ui/src/containers/lookoutV2/JobsTableContainer.test.tsx
+++ b/internal/lookout/ui/src/containers/lookoutV2/JobsTableContainer.test.tsx
@@ -60,6 +60,12 @@ describe("JobsTableContainer", () => {
         count: 0,
       }),
     )
+    groupJobsService.groupJobs = jest.fn(() =>
+      Promise.resolve({
+        groups: [],
+        count: 0,
+      }),
+    )
     const { findByText } = renderComponent()
     await waitForFinishedLoading()
 
@@ -67,24 +73,36 @@ describe("JobsTableContainer", () => {
     await findByText("0–0 of 0")
   })
 
-  it("should show jobs by default", async () => {
-    const { findByRole } = renderComponent()
-    await waitForFinishedLoading()
-
-    // Check all details for the first job are shown
-    const jobToSearchFor = jobs[0]
-    const matchingRow = await findByRole("row", { name: "jobId:" + jobToSearchFor.jobId })
-
-    within(matchingRow).getByText(jobToSearchFor.jobId)
-    within(matchingRow).getByText(jobToSearchFor.jobSet)
-    within(matchingRow).getByText(jobToSearchFor.queue)
-    within(matchingRow).getByText(formatJobState(jobToSearchFor.state))
-    within(matchingRow).getByText(formatUtcDate(jobToSearchFor.submitted))
-
-    await assertNumDataRowsShown(jobs.length)
-  })
-
   describe("Grouping", () => {
+    it("should be grouped by queue+jobset by default", async () => {
+      jobs = makeTestJobs(6, 1, numQueues, numJobSets)
+      getJobsService = new FakeGetJobsService(jobs, false)
+      groupJobsService = new FakeGroupJobsService(jobs, false)
+
+      const {getByText, findByRole} = renderComponent()
+      await waitForFinishedLoading()
+
+      await assertNumDataRowsShown(numQueues)
+
+      const job = jobs[1] // Pick the second job as a bit of variation
+
+      // Expand the first level
+      await expandRow(job.queue)
+      await assertNumDataRowsShown(numQueues + numJobSets)
+
+      // Expand the second level
+      await expandRow(job.jobSet)
+      await assertNumDataRowsShown(numQueues + numJobSets + 1)
+
+      // Should be able to see job-level information
+      const matchingRow = await findByRole("row", { name: "jobId:" + job.jobId })
+      within(matchingRow).getByText(job.jobId)
+      within(matchingRow).getByText(job.jobSet)
+      within(matchingRow).getByText(job.queue)
+      within(matchingRow).getByText(formatJobState(job.state))
+      within(matchingRow).getByText(formatUtcDate(job.submitted))
+    })
+
     it.each([
       ["Job Set", "jobSet"],
       ["Queue", "queue"],
@@ -96,6 +114,8 @@ describe("JobsTableContainer", () => {
 
       renderComponent()
       await waitForFinishedLoading()
+
+      await clearAllGroupings()
 
       await groupByColumn(displayString)
 
@@ -111,34 +131,10 @@ describe("JobsTableContainer", () => {
       await assertNumDataRowsShown(numUniqueForJobKey + numShownJobs)
     })
 
-    it("should allow 2 level grouping", async () => {
-      jobs = makeTestJobs(6, 1, numQueues, numJobSets)
-      getJobsService = new FakeGetJobsService(jobs)
-      groupJobsService = new FakeGroupJobsService(jobs)
-
-      renderComponent()
-      await waitForFinishedLoading()
-
-      // Group to both levels
-      await groupByColumn("Queue")
-      await groupByColumn("Job Set")
-      await assertNumDataRowsShown(numQueues)
-
-      const job = jobs[1] // Pick the second job as a bit of variation
-
-      // Expand the first level
-      await expandRow(job.queue)
-      await assertNumDataRowsShown(numQueues + numJobSets)
-
-      // Expand the second level
-      await expandRow(job.jobSet)
-      await assertNumDataRowsShown(numQueues + numJobSets + 1)
-    })
-
     it("should allow 3 level grouping", async () => {
       jobs = makeTestJobs(1000, 1, numQueues, numJobSets)
-      getJobsService = new FakeGetJobsService(jobs)
-      groupJobsService = new FakeGroupJobsService(jobs)
+      getJobsService = new FakeGetJobsService(jobs, false)
+      groupJobsService = new FakeGroupJobsService(jobs, false)
 
       const numStates = new Set(jobs.map((j) => j.state)).size
 
@@ -147,22 +143,20 @@ describe("JobsTableContainer", () => {
 
       // Group to 3 levels
       await groupByColumn("State")
-      await groupByColumn("Job Set")
-      await groupByColumn("Queue")
-      await assertNumDataRowsShown(numStates)
+      await assertNumDataRowsShown(numQueues)
 
       const job = jobs[0]
 
       // Expand the first level
-      await expandRow(job.state)
-      await assertNumDataRowsShown(numStates + numJobSets)
+      await expandRow(job.queue)
+      await assertNumDataRowsShown(numQueues + numJobSets)
 
       // Expand the second level
       await expandRow(job.jobSet)
-      await assertNumDataRowsShown(numStates + numJobSets + numQueues)
+      await assertNumDataRowsShown(numQueues + numJobSets + numStates)
 
       // Expand the third level
-      await expandRow(job.queue)
+      await expandRow(job.state)
       const numJobsExpectedToShow = jobs.filter(
         (j) => j.state === job.state && j.jobSet === job.jobSet && j.queue === job.queue,
       ).length
@@ -171,13 +165,11 @@ describe("JobsTableContainer", () => {
 
     it("should reset currently-expanded if grouping changes", async () => {
       jobs = makeTestJobs(5, 1, numQueues, numJobSets)
-      getJobsService = new FakeGetJobsService(jobs)
-      groupJobsService = new FakeGroupJobsService(jobs)
+      getJobsService = new FakeGetJobsService(jobs, false)
+      groupJobsService = new FakeGroupJobsService(jobs, false)
 
       const { getByRole, queryAllByRole } = renderComponent()
       await waitForFinishedLoading()
-
-      await groupByColumn("Queue")
 
       // Check we're only showing one row for each queue
       await assertNumDataRowsShown(numQueues)
@@ -187,14 +179,13 @@ describe("JobsTableContainer", () => {
       await expandRow(job.queue)
 
       // Check the row right number of rows is being shown
-      const numShownJobs = jobs.filter((j) => j.queue === job.queue).length
-      await assertNumDataRowsShown(numQueues + numShownJobs)
+      await assertNumDataRowsShown(numQueues + numJobSets)
 
       // Assert arrow down icon is shown
       getByRole("button", { name: "Collapse row" })
 
       // Group by another header
-      await groupByColumn("Job Set")
+      await groupByColumn("State")
 
       // Verify all rows are now collapsed
       await waitFor(() => expect(queryAllByRole("button", { name: "Collapse row" }).length).toBe(0))
@@ -202,25 +193,26 @@ describe("JobsTableContainer", () => {
   })
 
   describe("Selecting", () => {
-    it("should allow selecting of jobs", async () => {
+    it("should allow selecting rows", async () => {
       const { findByRole } = renderComponent()
       await waitForFinishedLoading()
 
       expect(await findByRole("button", { name: "Cancel selected" })).toBeDisabled()
       expect(await findByRole("button", { name: "Reprioritize selected" })).toBeDisabled()
 
-      await toggleSelectedRow("jobId", jobs[0].jobId)
-      await toggleSelectedRow("jobId", jobs[2].jobId)
+      expect(jobs[0].queue).not.toBe(jobs[1].queue)
+      await toggleSelectedRow("queue", jobs[0].queue)
+      await toggleSelectedRow("queue", jobs[1].queue)
 
       expect(await findByRole("button", { name: "Cancel selected" })).toBeEnabled()
       expect(await findByRole("button", { name: "Cancel selected" })).toBeEnabled()
 
-      await toggleSelectedRow("jobId", jobs[2].jobId)
+      await toggleSelectedRow("queue", jobs[1].queue)
 
       expect(await findByRole("button", { name: "Cancel selected" })).toBeEnabled()
       expect(await findByRole("button", { name: "Cancel selected" })).toBeEnabled()
 
-      await toggleSelectedRow("jobId", jobs[0].jobId)
+      await toggleSelectedRow("queue", jobs[0].queue)
 
       expect(await findByRole("button", { name: "Cancel selected" })).toBeDisabled()
       expect(await findByRole("button", { name: "Cancel selected" })).toBeDisabled()
@@ -233,6 +225,9 @@ describe("JobsTableContainer", () => {
 
       const { findByRole } = renderComponent()
       await waitForFinishedLoading()
+
+      await expandRow(jobs[0].queue)
+      await expandRow(jobs[0].jobSet)
 
       await toggleSelectedRow("jobId", jobs[0].jobId)
 
@@ -248,8 +243,6 @@ describe("JobsTableContainer", () => {
 
       const { findByRole } = renderComponent()
       await waitForFinishedLoading()
-
-      await groupByColumn("Queue")
 
       // Wait for table to update
       await assertNumDataRowsShown(numQueues)
@@ -271,23 +264,22 @@ describe("JobsTableContainer", () => {
     it("should allow text filtering", async () => {
       renderComponent()
       await waitForFinishedLoading()
-      await assertNumDataRowsShown(jobs.length)
+      await assertNumDataRowsShown(numQueues)
 
       await filterTextColumnTo("Queue", jobs[0].queue)
-      await assertNumDataRowsShown(jobs.filter((j) => j.queue === jobs[0].queue).length)
-
-      await filterTextColumnTo("Job ID", jobs[0].jobId)
       await assertNumDataRowsShown(1)
 
       await filterTextColumnTo("Queue", "")
       await filterTextColumnTo("Job ID", "")
 
-      await assertNumDataRowsShown(jobs.length)
+      await assertNumDataRowsShown(numQueues)
     })
 
     it("should allow enum filtering", async () => {
       renderComponent()
       await waitForFinishedLoading()
+      await clearAllGroupings()
+
       await assertNumDataRowsShown(jobs.length)
 
       await toggleEnumFilterOption("State", formatJobState(jobs[0].state))
@@ -302,6 +294,7 @@ describe("JobsTableContainer", () => {
     it("should allow sorting jobs", async () => {
       const { getAllByRole } = renderComponent()
       await waitForFinishedLoading()
+      await clearAllGroupings()
 
       await toggleSorting("Job ID")
 
@@ -322,40 +315,13 @@ describe("JobsTableContainer", () => {
         expect(rows[rows.length - 2]).toHaveTextContent("1") // Job ID
       })
     })
-
-    // Commented out until sorting by group name is supported
-    // it("should allow sorting groups", async () => {
-    //   const { getAllByRole, getByRole } = renderComponent()
-    //   await waitForFinishedLoading()
-
-    //   await groupByColumn("Queue")
-    //   await assertNumDataRowsShown(numQueues)
-
-    //   await toggleSorting("Queue")
-
-    //   await waitFor(() => {
-    //     const rows = getAllByRole("row")
-    //     // Skipping header and footer rows
-    //     expect(rows[1]).toHaveTextContent("queue-1")
-    //     expect(rows[rows.length - 2]).toHaveTextContent("queue-2")
-    //   })
-
-    //   await toggleSorting("Queue")
-
-    //   await waitFor(() => {
-    //     const rows = getAllByRole("row")
-
-    //     // Order should be reversed now
-    //     expect(rows[1]).toHaveTextContent("queue-2")
-    //     expect(rows[rows.length - 2]).toHaveTextContent("queue-1")
-    //   })
-    // })
   })
 
   describe("Refreshing data", () => {
     it("should allow refreshing data", async () => {
       const { findByRole } = renderComponent()
       await waitForFinishedLoading()
+      await clearAllGroupings()
       await assertNumDataRowsShown(numJobs)
 
       const firstRow = await findByRole("row", { name: new RegExp(jobs[0].jobId) })
@@ -377,9 +343,9 @@ describe("JobsTableContainer", () => {
     it("should maintain grouping and filtering state when refreshing", async () => {
       const { findByText } = renderComponent()
       await waitForFinishedLoading()
-      await assertNumDataRowsShown(numJobs)
 
       // Applying grouping and filtering
+      await clearAllGroupings()
       await groupByColumn("Queue")
       await filterTextColumnTo("Job ID", jobs[0].jobId)
 
@@ -403,8 +369,11 @@ describe("JobsTableContainer", () => {
       await waitForFinishedLoading()
 
       const firstJob = jobs[0]
-      const firstRow = await findByRole("row", { name: new RegExp(firstJob.jobId) })
-      await userEvent.click(within(firstRow).getByText(firstJob.jobId))
+      await expandRow(firstJob.queue)
+      await expandRow(firstJob.jobSet)
+
+      const jobRow = await findByRole("row", { name: new RegExp(firstJob.jobId) })
+      await userEvent.click(within(jobRow).getByText(firstJob.jobId))
 
       const sidebar = getByRole("complementary")
       within(sidebar).getByText(firstJob.jobId)
@@ -412,9 +381,6 @@ describe("JobsTableContainer", () => {
 
     it("clicking grouped row should not open", async () => {
       const { findByRole, queryByRole } = renderComponent()
-      await waitForFinishedLoading()
-
-      await groupByColumn("Queue")
       await waitForFinishedLoading()
 
       const firstJob = jobs[0]
@@ -448,12 +414,20 @@ describe("JobsTableContainer", () => {
     await userEvent.click(colToGroup)
   }
 
+  async function clearAllGroupings() {
+    const clearGroupingButtons = screen.queryAllByRole("button", {name: /Clear grouping/i})
+    for (let clearGroupingButton of clearGroupingButtons) {
+      await userEvent.click(clearGroupingButton)
+    }
+  }
+
   async function expandRow(buttonText: string) {
     const rowToExpand = await screen.findByRole("row", {
       name: new RegExp(buttonText),
     })
     const expandButton = within(rowToExpand).getByRole("button", { name: "Expand row" })
     await userEvent.click(expandButton)
+    await waitForFinishedLoading()
   }
 
   async function toggleSelectedRow(rowType: string, rowId: string) {

--- a/internal/lookout/ui/src/containers/lookoutV2/JobsTableContainer.test.tsx
+++ b/internal/lookout/ui/src/containers/lookoutV2/JobsTableContainer.test.tsx
@@ -79,7 +79,7 @@ describe("JobsTableContainer", () => {
       getJobsService = new FakeGetJobsService(jobs, false)
       groupJobsService = new FakeGroupJobsService(jobs, false)
 
-      const {getByText, findByRole} = renderComponent()
+      const { findByRole } = renderComponent()
       await waitForFinishedLoading()
 
       await assertNumDataRowsShown(numQueues)
@@ -415,8 +415,8 @@ describe("JobsTableContainer", () => {
   }
 
   async function clearAllGroupings() {
-    const clearGroupingButtons = screen.queryAllByRole("button", {name: /Clear grouping/i})
-    for (let clearGroupingButton of clearGroupingButtons) {
+    const clearGroupingButtons = screen.queryAllByRole("button", { name: /Clear grouping/i })
+    for (const clearGroupingButton of clearGroupingButtons) {
       await userEvent.click(clearGroupingButton)
     }
   }

--- a/internal/lookout/ui/src/containers/lookoutV2/JobsTableContainer.tsx
+++ b/internal/lookout/ui/src/containers/lookoutV2/JobsTableContainer.tsx
@@ -63,7 +63,8 @@ import { fromRowId, RowId } from "utils/reactTableUtils"
 
 import styles from "./JobsTableContainer.module.css"
 
-const DEFAULT_PAGE_SIZE = 30
+const DEFAULT_PAGE_SIZE = 50
+const PAGE_SIZE_OPTIONS = [5, 25, 50, 100]
 
 interface JobsTableContainerProps {
   getJobsService: IGetJobsService
@@ -333,7 +334,7 @@ export const JobsTableContainer = ({
             <TableFooter>
               <TableRow>
                 <TablePagination
-                  rowsPerPageOptions={[3, 10, 20, 30, 40, 50]}
+                  rowsPerPageOptions={PAGE_SIZE_OPTIONS}
                   count={totalRowCount}
                   rowsPerPage={pageSize}
                   page={pageIndex}

--- a/internal/lookout/ui/src/services/lookoutV2/mocks/FakeGroupJobsService.ts
+++ b/internal/lookout/ui/src/services/lookoutV2/mocks/FakeGroupJobsService.ts
@@ -18,7 +18,7 @@ export default class FakeGroupJobsService implements IGroupJobsService {
     if (this.simulateApiWait) {
       await simulateApiWait()
     }
-    
+
     const filtered = this.jobs.filter(mergeFilters(filters))
     const groups = groupBy(filtered, groupedField)
     const sliced = groups.sort(comparator(order)).slice(skip, skip + take)

--- a/internal/lookout/ui/src/services/lookoutV2/mocks/FakeGroupJobsService.ts
+++ b/internal/lookout/ui/src/services/lookoutV2/mocks/FakeGroupJobsService.ts
@@ -18,7 +18,7 @@ export default class FakeGroupJobsService implements IGroupJobsService {
     if (this.simulateApiWait) {
       await simulateApiWait()
     }
-    await simulateApiWait()
+    
     const filtered = this.jobs.filter(mergeFilters(filters))
     const groups = groupBy(filtered, groupedField)
     const sliced = groups.sort(comparator(order)).slice(skip, skip + take)

--- a/internal/lookout/ui/src/utils/jobsTableColumns.tsx
+++ b/internal/lookout/ui/src/utils/jobsTableColumns.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react"
+import { useCallback } from "react"
 
 import { Checkbox } from "@mui/material"
 import { ColumnDef, createColumnHelper, VisibilityState } from "@tanstack/table-core"
@@ -97,7 +97,7 @@ export const JOB_COLUMNS: JobTableColumn[] = [
         indeterminate={table.getIsSomeRowsSelected()}
         onChange={table.getToggleAllRowsSelectedHandler()}
         size="small"
-        sx={{p: 0}}
+        sx={{ p: 0 }}
       />
     ),
     cell: ({ row }) => (
@@ -252,10 +252,7 @@ export const DEFAULT_COLUMN_VISIBILITY: VisibilityState = Object.values(Standard
   {},
 )
 
-export const DEFAULT_GROUPING: ColumnId[] = [
-  StandardColumnId.Queue,
-  StandardColumnId.JobSet,
-]
+export const DEFAULT_GROUPING: ColumnId[] = [StandardColumnId.Queue, StandardColumnId.JobSet]
 
 export const createAnnotationColumn = (annotationKey: string): JobTableColumn => {
   return accessorColumn({

--- a/internal/lookout/ui/src/utils/jobsTableColumns.tsx
+++ b/internal/lookout/ui/src/utils/jobsTableColumns.tsx
@@ -97,6 +97,7 @@ export const JOB_COLUMNS: JobTableColumn[] = [
         indeterminate={table.getIsSomeRowsSelected()}
         onChange={table.getToggleAllRowsSelectedHandler()}
         size="small"
+        sx={{p: 0}}
       />
     ),
     cell: ({ row }) => (
@@ -106,12 +107,10 @@ export const JOB_COLUMNS: JobTableColumn[] = [
         onChange={useCallback(row.getToggleSelectedHandler(), [row])}
         onClick={(e) => e.stopPropagation()}
         size="small"
-        sx={useMemo(
-          () => ({
-            marginLeft: `${row.depth * 6}px`,
-          }),
-          [],
-        )}
+        sx={{
+          p: 0,
+          ml: `${row.depth * 6}px`,
+        }}
       />
     ),
     meta: {
@@ -253,7 +252,10 @@ export const DEFAULT_COLUMN_VISIBILITY: VisibilityState = Object.values(Standard
   {},
 )
 
-export const DEFAULT_GROUPING: ColumnId[] = []
+export const DEFAULT_GROUPING: ColumnId[] = [
+  StandardColumnId.Queue,
+  StandardColumnId.JobSet,
+]
 
 export const createAnnotationColumn = (annotationKey: string): JobTableColumn => {
   return accessorColumn({


### PR DESCRIPTION
#### What type of PR is this?

This is a UI PR for Lookout V2.

#### What this PR does / why we need it:

- Sets up the table to group by Queue + JobSet by default
  - Updates tests which assumed there was no default grouping
- Changes "depth indicator" colour to blue to make it more obvious
- Reduce the thickness of rows significantly - making it closer to Lookout V1
- Increases the number of rows shown by default (30 -> 50)
- Fixes a styling issue when grouping by state

#### Which issue(s) this PR fixes:

Part of https://github.com/G-Research/armada/issues/1869

#### Special notes for your reviewer:

**On page load**
![image](https://user-images.githubusercontent.com/3807889/208933938-9223ce24-c95e-4559-9e92-8d7eb62e331c.png)

**Expanding out jobs**
![image](https://user-images.githubusercontent.com/3807889/208934016-4df09cf7-e73b-4e91-965e-f3aa0089791e.png)

**Grouped by state**
![image](https://user-images.githubusercontent.com/3807889/208934187-d68e7393-b06d-450e-b33d-17295f408cf3.png)
