### PR TITLE
Save Lookout V2 table preferences to URL query params

### DIFF
--- a/internal/lookout/ui/.eslintrc.js
+++ b/internal/lookout/ui/.eslintrc.js
@@ -40,6 +40,15 @@ module.exports = {
         },
       },
     ],
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_",
+        "caughtErrorsIgnorePattern": "^_"
+      }
+    ],
+    "@typescript-eslint/no-empty-function": "warn",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "react/display-name": "off",

--- a/internal/lookout/ui/package.json
+++ b/internal/lookout/ui/package.json
@@ -46,6 +46,7 @@
     "js-yaml": "^4.0.0",
     "notistack": "^2.0.8",
     "prettier": "^2.3.0",
+    "qs": "^6.11.0",
     "query-string": "^6.13.7",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/internal/lookout/ui/src/App.tsx
+++ b/internal/lookout/ui/src/App.tsx
@@ -8,6 +8,7 @@ import { SnackbarProvider } from "notistack"
 import { Route, BrowserRouter as Router, Switch } from "react-router-dom"
 import { IGetJobsService } from "services/lookoutV2/GetJobsService"
 import { IGroupJobsService } from "services/lookoutV2/GroupJobsService"
+import { JobsTablePreferencesService } from "services/lookoutV2/JobsTablePreferencesService"
 import { UpdateJobsService } from "services/lookoutV2/UpdateJobsService"
 
 import NavBar from "./components/NavBar"
@@ -59,6 +60,7 @@ const themeV5 = createThemeV5(theme)
 
 type AppProps = {
   jobService: JobService
+  v2JobsTablePrefsService: JobsTablePreferencesService
   v2GetJobsService: IGetJobsService
   v2GroupJobsService: IGroupJobsService
   v2UpdateJobsService: UpdateJobsService
@@ -90,6 +92,7 @@ export function App(props: AppProps) {
                     </Route>
                     <Route exact path="/v2">
                       <JobsTableContainer
+                        jobsTablePreferencesService={props.v2JobsTablePrefsService}
                         getJobsService={props.v2GetJobsService}
                         groupJobsService={props.v2GroupJobsService}
                         updateJobsService={props.v2UpdateJobsService}

--- a/internal/lookout/ui/src/containers/lookoutV2/JobsTableContainer.tsx
+++ b/internal/lookout/ui/src/containers/lookoutV2/JobsTableContainer.tsx
@@ -141,7 +141,7 @@ export const JobsTableContainer = ({
     [sidebarJobId, jobInfoMap],
   )
 
-  // Update query params + local storage with table state
+  // Update query params with table state
   useEffect(() => {
     jobsTablePreferencesService.saveNewPrefs({
       groupedColumns: grouping,

--- a/internal/lookout/ui/src/hooks/useJobsTableData.ts
+++ b/internal/lookout/ui/src/hooks/useJobsTableData.ts
@@ -8,6 +8,7 @@ import {
   ExpandedStateList,
 } from "@tanstack/react-table"
 import { JobTableRow, JobRow, JobGroupRow } from "models/jobsTableModels"
+import { Job, JobId } from "models/lookoutV2Models"
 import { SnackbarProvider } from "notistack"
 import { IGetJobsService } from "services/lookoutV2/GetJobsService"
 import { IGroupJobsService } from "services/lookoutV2/GroupJobsService"
@@ -40,6 +41,7 @@ export interface UseFetchJobsTableDataArgs {
 }
 export interface UseFetchJobsTableDataResult {
   data: JobTableRow[]
+  jobInfoMap: Map<JobId, Job>
   pageCount: number
   rowsToFetch: PendingData[]
   setRowsToFetch: (toFetch: PendingData[]) => void
@@ -59,7 +61,8 @@ export const useFetchJobsTableData = ({
   enqueueSnackbar,
 }: UseFetchJobsTableDataArgs): UseFetchJobsTableDataResult => {
   const [data, setData] = useState<JobTableRow[]>([])
-  const [pendingData, setPendingData] = useState<PendingData[]>([{ parentRowId: "ROOT", skip: 0 }])
+  const [jobInfoMap, setJobInfoMap] = useState<Map<JobId, Job>>(new Map())
+  const [pendingData, setPendingData] = useState<PendingData[]>([])
   const [totalRowCount, setTotalRowCount] = useState(0)
   const [pageCount, setPageCount] = useState<number>(-1)
 
@@ -97,6 +100,8 @@ export const useFetchJobsTableData = ({
           const { jobs, count: totalJobs } = await fetchJobs(rowRequest, getJobsService, abortController.signal)
           newData = jobsToRows(jobs)
           totalCount = totalJobs
+
+          setJobInfoMap(new Map([...jobInfoMap.entries(), ...jobs.map((j): [JobId, Job] => [j.jobId, j])]))
         } else {
           const groupedCol = groupedColumns[expandedLevel]
 
@@ -164,6 +169,7 @@ export const useFetchJobsTableData = ({
 
   return {
     data,
+    jobInfoMap,
     pageCount,
     rowsToFetch: pendingData,
     setRowsToFetch: setPendingData,

--- a/internal/lookout/ui/src/index.tsx
+++ b/internal/lookout/ui/src/index.tsx
@@ -1,6 +1,8 @@
+import { createBrowserHistory } from "history"
 import ReactDOM from "react-dom"
 import { GetJobsService } from "services/lookoutV2/GetJobsService"
 import { GroupJobsService } from "services/lookoutV2/GroupJobsService"
+import { JobsTablePreferencesService } from "services/lookoutV2/JobsTablePreferencesService"
 import { UpdateJobsService } from "services/lookoutV2/UpdateJobsService"
 import FakeGetJobsService from "services/lookoutV2/mocks/FakeGetJobsService"
 import FakeGroupJobsService from "services/lookoutV2/mocks/FakeGroupJobsService"
@@ -41,6 +43,7 @@ import "./index.css"
   const fakeDataEnabled = uiConfig.fakeDataEnabled
   const lookoutV2BaseUrl = uiConfig.lookoutV2ApiBaseUrl
 
+  const v2JobsTablePrefsService = new JobsTablePreferencesService(createBrowserHistory())
   const v2TestJobs = fakeDataEnabled ? makeTestJobs(10000, 42) : []
   const v2GetJobsService = fakeDataEnabled ? new FakeGetJobsService(v2TestJobs) : new GetJobsService(lookoutV2BaseUrl)
   const v2GroupJobsService = fakeDataEnabled
@@ -51,6 +54,7 @@ import "./index.css"
   ReactDOM.render(
     <App
       jobService={jobService}
+      v2JobsTablePrefsService={v2JobsTablePrefsService}
       v2GetJobsService={v2GetJobsService}
       v2GroupJobsService={v2GroupJobsService}
       v2UpdateJobsService={v2UpdateJobsService}

--- a/internal/lookout/ui/src/services/lookoutV2/JobsTablePreferencesService.test.ts
+++ b/internal/lookout/ui/src/services/lookoutV2/JobsTablePreferencesService.test.ts
@@ -1,0 +1,185 @@
+import { createMemoryHistory, History } from "history"
+import { ColumnId, createAnnotationColumn, JOB_COLUMNS } from "utils/jobsTableColumns"
+
+import { DEFAULT_PREFERENCES, JobsTablePreferences, JobsTablePreferencesService } from "./JobsTablePreferencesService"
+
+describe("JobsTablePreferencesService", () => {
+  let history: History, service: JobsTablePreferencesService
+
+  beforeEach(() => {
+    history = createMemoryHistory()
+    service = new JobsTablePreferencesService(history)
+  })
+
+  describe("getInitialUserPrefs", () => {
+    it("gives default preferences if no query params", () => {
+      expect(service.getInitialUserPrefs()).toStrictEqual(DEFAULT_PREFERENCES)
+    })
+
+    it("merges defaults with provided query params", () => {
+      history.push({
+        search: `?page=3&g[0]=state&sort[0][id]=jobId&sort[0][desc]=false`,
+      })
+
+      expect(service.getInitialUserPrefs()).toMatchObject<Partial<JobsTablePreferences>>({
+        // From query string above
+        pageIndex: 3,
+        groupedColumns: ["state" as ColumnId],
+        sortingState: [{id: "jobId", desc: false}],
+
+        // Some defaults not provided via query string
+        pageSize: 50,
+        allColumnsInfo: JOB_COLUMNS
+      })
+    })
+  })
+
+  describe("saveNewPrefs", () => {
+    it("does not remove other unrelated query params", () => {
+      history.push({
+        search: '?debug&someOtherKey=test'
+      })
+
+      service.saveNewPrefs(DEFAULT_PREFERENCES)
+
+      expect(history.location.search).toContain("debug")
+      expect(history.location.search).toContain("someOtherKey=test")
+    })
+  })
+
+  describe("Page index", () => {
+    it("round-trips 0", () => {
+      savePrefWithDefaults({ pageIndex: 0 })
+      expect(history.location.search).toContain("page=0")
+      expect(service.getInitialUserPrefs().pageIndex).toStrictEqual(0)
+    })
+
+    it("round-trips non-zero", () => {
+      savePrefWithDefaults({ pageIndex: 5 })
+      expect(history.location.search).toContain("page=5")
+      expect(service.getInitialUserPrefs().pageIndex).toStrictEqual(5)
+    })
+  })
+
+  describe("Grouped columns", () => {
+    it("round-trips columns", () => {
+      savePrefWithDefaults({ groupedColumns: ["queue", "state"] as ColumnId[] })
+      expect(history.location.search).toContain("g[0]=queue&g[1]=state")
+      expect(service.getInitialUserPrefs().groupedColumns).toStrictEqual(["queue", "state"])
+    })
+
+    it("round-trips empty list", () => {
+      savePrefWithDefaults({ groupedColumns: [] })
+      // Since the default is non-empty, then we assert that it's still in the query params
+      expect(history.location.search).toContain("g[0]")
+      expect(service.getInitialUserPrefs().groupedColumns).toStrictEqual([])
+    })
+  })
+
+  describe("Column filters", () => {
+    it("round-trips column filters", () => {
+      savePrefWithDefaults({ filterState: [{ id: "queue", value: "test" }] })
+      expect(history.location.search).toContain("f[0][id]=queue&f[0][value]=test")
+      expect(service.getInitialUserPrefs().filterState).toStrictEqual([{ id: "queue", value: "test" }])
+    })
+
+    it("round-trips special characters", () => {
+      savePrefWithDefaults({ filterState: [{ id: "queue", value: "test & why / do $ this" }] })
+      expect(history.location.search).toContain("f[0][id]=queue&f[0][value]=test%20%26%20why%20%2F%20do%20%24%20this")
+      expect(service.getInitialUserPrefs().filterState).toStrictEqual([{ id: "queue", value: "test & why / do $ this" }])
+    })
+
+    it("round-trips empty list", () => {
+      savePrefWithDefaults({ filterState: [] })
+      expect(service.getInitialUserPrefs().filterState).toStrictEqual([])
+    })
+  })
+
+  describe("Sort order", () => {
+    it("round-trips asc sort order", () => {
+      savePrefWithDefaults({ sortingState: [{ id: "queue", desc: false }] })
+      expect(history.location.search).toContain("sort[0][id]=queue&sort[0][desc]=false")
+      expect(service.getInitialUserPrefs().sortingState).toStrictEqual([{ id: "queue", desc: false }])
+    })
+
+    it("round-trips desc sort order", () => {
+      savePrefWithDefaults({ sortingState: [{ id: "queue", desc: true }] })
+      expect(history.location.search).toContain("sort[0][id]=queue&sort[0][desc]=true")
+      expect(service.getInitialUserPrefs().sortingState).toStrictEqual([{ id: "queue", desc: true }])
+    })
+  })
+
+  describe("Column visibility", () => {
+    it("round-trips visible columns", () => {
+      savePrefWithDefaults({ visibleColumns: { queue: true, jobSet: false } })
+      expect(history.location.search).toContain("vCols[0]=queue")
+      expect(service.getInitialUserPrefs().visibleColumns).toMatchObject({ queue: true, jobSet: false })
+    })
+
+    it("includes annotation columns", () => {
+      savePrefWithDefaults({
+        visibleColumns: { queue: true, jobSet: false, annotation_test: true, annotation_otherTest: false },
+        allColumnsInfo: [...JOB_COLUMNS, createAnnotationColumn("test"), createAnnotationColumn("otherTest")],
+      })
+      expect(history.location.search).toContain("vCols[0]=queue&vCols[1]=annotation_test")
+      expect(service.getInitialUserPrefs().visibleColumns).toMatchObject({
+        queue: true,
+        jobSet: false,
+        annotation_test: true,
+        annotation_otherTest: false,
+      })
+    })
+  })
+
+  describe("Annotation columns", () => {
+    it("round-trips user-added columns", () => {
+      savePrefWithDefaults({ allColumnsInfo: [...JOB_COLUMNS, createAnnotationColumn("myAnnotation")] })
+      expect(history.location.search).toContain("aCols[0]=myAnnotation")
+      const cols = service.getInitialUserPrefs().allColumnsInfo
+      expect(cols.filter(({ id }) => id === "annotation_myAnnotation").length).toStrictEqual(1)
+    })
+  })
+
+  describe("Expanded rows", () => {
+    it("round-trips expanded rows", () => {
+      savePrefWithDefaults({ expandedState: { myRowId: true, jobSet: false } })
+      expect(history.location.search).toContain("e[0]=myRowId")
+      expect(service.getInitialUserPrefs().expandedState).toMatchObject({ myRowId: true })
+    })
+
+    it("round-trips zero expanded rows", () => {
+      savePrefWithDefaults({ expandedState: {} })
+      expect(history.location.search).not.toContain("e[0]=")
+      expect(service.getInitialUserPrefs().expandedState).toMatchObject({})
+    })
+  })
+
+  describe("Page size", () => {
+    it("round-trips page size", () => {
+      savePrefWithDefaults({ pageSize: 123 })
+      expect(history.location.search).toContain("pS=123")
+      expect(service.getInitialUserPrefs().pageSize).toStrictEqual(123)
+    })
+  })
+
+  describe("Sidebar Job ID", () => {
+    it("round-trips selected job", () => {
+      savePrefWithDefaults({ sidebarJobId: "myJobId123" })
+      expect(history.location.search).toContain("sb=myJobId123")
+      expect(service.getInitialUserPrefs().sidebarJobId).toStrictEqual("myJobId123")
+    })
+
+    it("round-trips no selected job", () => {
+      savePrefWithDefaults({ sidebarJobId: undefined })
+      expect(history.location.search).not.toContain("sb=")
+      expect(service.getInitialUserPrefs().sidebarJobId).toStrictEqual(undefined)
+    })
+  })
+
+  const savePrefWithDefaults = (prefsToSave: Partial<JobsTablePreferences>) => {
+    service.saveNewPrefs({
+      ...DEFAULT_PREFERENCES,
+      ...prefsToSave,
+    })
+  }
+})

--- a/internal/lookout/ui/src/services/lookoutV2/JobsTablePreferencesService.test.ts
+++ b/internal/lookout/ui/src/services/lookoutV2/JobsTablePreferencesService.test.ts
@@ -25,11 +25,11 @@ describe("JobsTablePreferencesService", () => {
         // From query string above
         pageIndex: 3,
         groupedColumns: ["state" as ColumnId],
-        sortingState: [{id: "jobId", desc: false}],
+        sortingState: [{ id: "jobId", desc: false }],
 
         // Some defaults not provided via query string
         pageSize: 50,
-        allColumnsInfo: JOB_COLUMNS
+        allColumnsInfo: JOB_COLUMNS,
       })
     })
   })
@@ -37,7 +37,7 @@ describe("JobsTablePreferencesService", () => {
   describe("saveNewPrefs", () => {
     it("does not remove other unrelated query params", () => {
       history.push({
-        search: '?debug&someOtherKey=test'
+        search: "?debug&someOtherKey=test",
       })
 
       service.saveNewPrefs(DEFAULT_PREFERENCES)
@@ -86,7 +86,9 @@ describe("JobsTablePreferencesService", () => {
     it("round-trips special characters", () => {
       savePrefWithDefaults({ filterState: [{ id: "queue", value: "test & why / do $ this" }] })
       expect(history.location.search).toContain("f[0][id]=queue&f[0][value]=test%20%26%20why%20%2F%20do%20%24%20this")
-      expect(service.getInitialUserPrefs().filterState).toStrictEqual([{ id: "queue", value: "test & why / do $ this" }])
+      expect(service.getInitialUserPrefs().filterState).toStrictEqual([
+        { id: "queue", value: "test & why / do $ this" },
+      ])
     })
 
     it("round-trips empty list", () => {

--- a/internal/lookout/ui/src/services/lookoutV2/JobsTablePreferencesService.ts
+++ b/internal/lookout/ui/src/services/lookoutV2/JobsTablePreferencesService.ts
@@ -1,0 +1,210 @@
+import { ExpandedStateList, ColumnFiltersState, SortingState, VisibilityState } from "@tanstack/react-table"
+import { History } from "history"
+import { JobId } from "models/lookoutV2Models"
+import qs from "qs"
+import {
+  ANNOTATION_COLUMN_PREFIX,
+  ColumnId,
+  createAnnotationColumn,
+  DEFAULT_COLUMN_VISIBILITY,
+  DEFAULT_GROUPING,
+  JobTableColumn,
+  JOB_COLUMNS,
+} from "../../utils/jobsTableColumns"
+
+export interface JobsTablePreferences {
+  allColumnsInfo: JobTableColumn[]
+  visibleColumns: VisibilityState
+  groupedColumns: ColumnId[]
+  expandedState: ExpandedStateList
+  pageIndex: number
+  pageSize: number
+  sortingState: SortingState
+  filterState: ColumnFiltersState
+  sidebarJobId: JobId | undefined
+}
+
+export const DEFAULT_PREFERENCES: JobsTablePreferences = {
+  allColumnsInfo: JOB_COLUMNS,
+  visibleColumns: DEFAULT_COLUMN_VISIBILITY,
+  groupedColumns: DEFAULT_GROUPING,
+  expandedState: {},
+  pageIndex: 0,
+  pageSize: 50,
+  sortingState: [{ id: "jobId", desc: true }],
+  filterState: [],
+  sidebarJobId: undefined,
+}
+
+// Reflects the type of data stored in the URL query params
+// Keys are shortened to keep URL size lower
+interface QueryStringSafePrefs {
+  // Visible columns
+  vCols: string[]
+
+  // Annotation keys added
+  aCols: string[]
+
+  // Grouped columns
+  g: string[] | [null]
+
+  // Expanded rows
+  e: string[]
+
+  // Current page number
+  page: string
+
+  // Page size
+  pS: string
+
+  // Sorting information
+  sort: {
+    id: string
+    desc: string // boolean
+  }[]
+
+  // Column filters
+  f: {
+    id: string
+    value: string
+  }[]
+
+  // Sidebar job ID
+  sb: string | undefined
+}
+
+const toQueryStringSafe = (prefs: JobsTablePreferences): QueryStringSafePrefs => {
+  // QS lib will remove params with empty array values unless they explicitly have a null value
+  // This is useful where the default value is non-empty
+  const padEmptyArrayWithNull = <T>(arr: T[]): T[] | [null] => (arr.length === 0 ? [null] : arr)
+
+  // The order of these keys are the order they'll show in the URL bar (in modern browsers)
+  return {
+    // Current page number
+    page: prefs.pageIndex.toString(),
+
+    // Grouped columns
+    g: padEmptyArrayWithNull(prefs.groupedColumns),
+
+    // Column filters
+    f: prefs.filterState.map(({ id, value }) => ({ id, value: value as string })),
+
+    // Sorting order
+    sort: prefs.sortingState.map(({ id, desc }) => ({ id, desc: desc.toString() })),
+
+    // Visible columns
+    vCols: Object.entries(prefs.visibleColumns)
+      .filter(([_, visible]) => visible)
+      .map(([columnId]) => columnId),
+
+    // Annotation columns
+    // TODO: Re-use constant, or add a helper
+    aCols: prefs.allColumnsInfo
+      .filter((col) => col.id?.startsWith(ANNOTATION_COLUMN_PREFIX))
+      .map((col) => col.id?.slice(ANNOTATION_COLUMN_PREFIX.length))
+      .filter((annotationKey): annotationKey is string => annotationKey !== undefined),
+
+    // Expanded rows
+    e: Object.entries(prefs.expandedState)
+      .filter(([_, expanded]) => expanded)
+      .map(([rowId, _]) => rowId),
+
+    // Page size
+    pS: prefs.pageSize.toString(),
+
+    // Sidebar job
+    sb: prefs.sidebarJobId,
+  }
+}
+
+const fromQueryStringSafe = (serializedPrefs: Partial<QueryStringSafePrefs>): Partial<JobsTablePreferences> => {
+  const stripNullArrays = <T>(arr: T[] | [null]): T[] => (arr.length === 1 && arr[0] === null ? [] : (arr as T[]))
+
+  const { aCols, vCols, g, e, page, pS, sort, f, sb } = serializedPrefs
+  const allColumns = JOB_COLUMNS.concat((aCols ?? []).map((annotationKey) => createAnnotationColumn(annotationKey)))
+
+  return {
+    ...(aCols && { allColumnsInfo: allColumns }),
+
+    ...(vCols && {
+      visibleColumns: Object.fromEntries(allColumns.map(({ id }) => [id, vCols.includes(id as string)])),
+    }),
+
+    ...(g && { groupedColumns: stripNullArrays(g) as ColumnId[] }),
+
+    ...(e && { expandedState: Object.fromEntries(e.map((rowId) => [rowId, true])) }),
+
+    ...(page !== undefined && { pageIndex: Number(page) }),
+
+    ...(pS !== undefined && { pageSize: Number(pS) }),
+
+    ...(sort && { sortingState: sort.map((field) => ({ id: field.id, desc: field.desc === "true" })) }),
+
+    ...(f && { filterState: f }),
+
+    ...(sb && { sidebarJobId: sb }),
+  }
+}
+
+export class JobsTablePreferencesService {
+  constructor(private historyService: History) {}
+
+  getInitialUserPrefs(): JobsTablePreferences {
+    return {
+      // TODO: Retrieve local storage prefs and merge
+      ...DEFAULT_PREFERENCES,
+      ...this.getPrefsFromQueryParams(),
+    }
+  }
+
+  saveNewPrefs(newPrefs: JobsTablePreferences) {
+    this.savePrefsToQueryParams(newPrefs)
+    // TODO: Store user-preference settings to local storage (e.g. column widths)
+  }
+
+  private savePrefsToQueryParams(newPrefs: JobsTablePreferences) {
+    try {
+      // Avoids overwriting existing unrelated query params
+      const existingQueryParams = qs.parse(this.historyService.location.search, {ignoreQueryPrefix: true,})
+      const prefsQueryParams = toQueryStringSafe(newPrefs)
+      const mergedQueryParams = {
+        ...existingQueryParams,
+        ...prefsQueryParams
+      }
+
+      console.log({mergedQueryParams})
+
+      this.historyService.push({
+        search: qs.stringify(mergedQueryParams, {
+          encodeValuesOnly: true,
+          strictNullHandling: true,
+        }),
+      })
+    } catch (e) {
+      console.warn("Unable to update URL query params with table state:", e)
+    }
+  }
+
+  private getPrefsFromQueryParams(): Partial<JobsTablePreferences> {
+    try {
+      const queryParamPrefs = qs.parse(this.historyService.location.search, {
+        ignoreQueryPrefix: true,
+        strictNullHandling: true,
+      })
+      return fromQueryStringSafe(queryParamPrefs)
+    } catch (e) {
+      console.warn("Unable to parse URL query params:", e)
+      return {}
+    }
+  }
+}
+
+/**
+ * page=0&
+ * g[0]=queue&
+ * sort[0][id]=jobId&sort[0][desc]=true&
+ * vCols[0]=selectorCol&vCols[1]=queue&vCols[2]=jobSet&vCols[3]=jobId&vCols[4]=state&vCols[5]=timeInState&vCols[6]=timeSubmittedUtc&
+ * pS=50&
+ * page=NaN&
+ * f[0][id]=queue&f[0][value]=hello%20test
+ */

--- a/internal/lookout/ui/src/services/lookoutV2/JobsTablePreferencesService.ts
+++ b/internal/lookout/ui/src/services/lookoutV2/JobsTablePreferencesService.ts
@@ -80,39 +80,29 @@ const toQueryStringSafe = (prefs: JobsTablePreferences): QueryStringSafePrefs =>
 
   // The order of these keys are the order they'll show in the URL bar (in modern browsers)
   return {
-    // Current page number
     page: prefs.pageIndex.toString(),
 
-    // Grouped columns
     g: padEmptyArrayWithNull(prefs.groupedColumns),
 
-    // Column filters
     f: prefs.filterState.map(({ id, value }) => ({ id, value: value as string })),
 
-    // Sorting order
     sort: prefs.sortingState.map(({ id, desc }) => ({ id, desc: desc.toString() })),
 
-    // Visible columns
     vCols: Object.entries(prefs.visibleColumns)
       .filter(([_, visible]) => visible)
       .map(([columnId]) => columnId),
 
-    // Annotation columns
-    // TODO: Re-use constant, or add a helper
     aCols: prefs.allColumnsInfo
       .filter((col) => col.id?.startsWith(ANNOTATION_COLUMN_PREFIX))
       .map((col) => col.id?.slice(ANNOTATION_COLUMN_PREFIX.length))
       .filter((annotationKey): annotationKey is string => annotationKey !== undefined),
 
-    // Expanded rows
     e: Object.entries(prefs.expandedState)
       .filter(([_, expanded]) => expanded)
       .map(([rowId, _]) => rowId),
 
-    // Page size
     pS: prefs.pageSize.toString(),
 
-    // Sidebar job
     sb: prefs.sidebarJobId,
   }
 }
@@ -198,13 +188,3 @@ export class JobsTablePreferencesService {
     }
   }
 }
-
-/**
- * page=0&
- * g[0]=queue&
- * sort[0][id]=jobId&sort[0][desc]=true&
- * vCols[0]=selectorCol&vCols[1]=queue&vCols[2]=jobSet&vCols[3]=jobId&vCols[4]=state&vCols[5]=timeInState&vCols[6]=timeSubmittedUtc&
- * pS=50&
- * page=NaN&
- * f[0][id]=queue&f[0][value]=hello%20test
- */

--- a/internal/lookout/ui/src/services/lookoutV2/JobsTablePreferencesService.ts
+++ b/internal/lookout/ui/src/services/lookoutV2/JobsTablePreferencesService.ts
@@ -2,6 +2,7 @@ import { ExpandedStateList, ColumnFiltersState, SortingState, VisibilityState } 
 import { History } from "history"
 import { JobId } from "models/lookoutV2Models"
 import qs from "qs"
+
 import {
   ANNOTATION_COLUMN_PREFIX,
   ColumnId,
@@ -155,14 +156,14 @@ export class JobsTablePreferencesService {
   private savePrefsToQueryParams(newPrefs: JobsTablePreferences) {
     try {
       // Avoids overwriting existing unrelated query params
-      const existingQueryParams = qs.parse(this.historyService.location.search, {ignoreQueryPrefix: true,})
+      const existingQueryParams = qs.parse(this.historyService.location.search, { ignoreQueryPrefix: true })
       const prefsQueryParams = toQueryStringSafe(newPrefs)
       const mergedQueryParams = {
         ...existingQueryParams,
-        ...prefsQueryParams
+        ...prefsQueryParams,
       }
 
-      console.log({mergedQueryParams})
+      console.log({ mergedQueryParams })
 
       this.historyService.push({
         search: qs.stringify(mergedQueryParams, {

--- a/internal/lookout/ui/src/utils/jobsTableColumns.tsx
+++ b/internal/lookout/ui/src/utils/jobsTableColumns.tsx
@@ -256,9 +256,10 @@ export const DEFAULT_COLUMN_VISIBILITY: VisibilityState = Object.values(Standard
 
 export const DEFAULT_GROUPING: ColumnId[] = [StandardColumnId.Queue, StandardColumnId.JobSet]
 
+export const ANNOTATION_COLUMN_PREFIX = "annotation_"
 export const createAnnotationColumn = (annotationKey: string): JobTableColumn => {
   return accessorColumn({
-    id: `annotation_${annotationKey}`,
+    id: `${ANNOTATION_COLUMN_PREFIX}${annotationKey}`,
     accessor: (jobTableRow) => jobTableRow.annotations?.[annotationKey],
     displayName: annotationKey,
     additionalOptions: {

--- a/internal/lookout/ui/yarn.lock
+++ b/internal/lookout/ui/yarn.lock
@@ -9052,7 +9052,7 @@ q@^1.1.2:
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==
 
-qs@6.11.0:
+qs@6.11.0, qs@^6.11.0:
   version "6.11.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
   integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==


### PR DESCRIPTION
#### What type of PR is this?

This is a UI PR for Lookout V2.

#### What this PR does / why we need it:

- Saves important table state to the URL query parameters
- On-load reads the URL query parameters to populate initial settings
- Adds tests

#### Which issue(s) this PR fixes:

Part of https://github.com/G-Research/armada/issues/1869

#### Special notes for your reviewer:

**Initial state is saved to query params**
![image](https://user-images.githubusercontent.com/3807889/209320940-453b923e-9fcb-4050-9f9e-e0cc9915f078.png)

**Changing table state will update query params**
![image](https://user-images.githubusercontent.com/3807889/209321405-7a703e0b-ee46-4160-94b3-d5fb29fcddcf.png)

**After refreshing - Exact table state is maintained**
![image](https://user-images.githubusercontent.com/3807889/209321442-7fcaa000-3939-45fa-b803-1552b72ef118.png)

