### PR TITLE
Add Lookout V2 to Lookout navbar

### DIFF
--- a/internal/lookout/ui/src/components/NavBar.tsx
+++ b/internal/lookout/ui/src/components/NavBar.tsx
@@ -23,6 +23,10 @@ const PAGES: Page[] = [
     title: "Jobs",
     location: "/jobs",
   },
+  {
+    title: "V2",
+    location: "/v2",
+  },
 ]
 
 // Creates mapping from location to index of element in ordered navbar


### PR DESCRIPTION
#### What type of PR is this?

This is a UI PR for Lookout V2.

#### What this PR does / why we need it:

- Adds a "V2" entry to the Lookout navbar, making Lookout V2 more discoverable for people to try out.

#### Which issue(s) this PR fixes:

Part of https://github.com/G-Research/armada/issues/1869

#### Special notes for your reviewer:

**V2 visible in navbar**
![image](https://user-images.githubusercontent.com/3807889/209324611-0b612f4f-5b97-4169-bf72-e0717b8e6735.png)

**Clicking it takes the user to Lookout V2**
![image](https://user-images.githubusercontent.com/3807889/209324651-0695b5c1-d37e-4bba-b5f8-9f43544a5944.png)

