### PR TITLE
E2e Tests Use Event Ingester

### DIFF
--- a/config/armada/config.yaml
+++ b/config/armada/config.yaml
@@ -33,7 +33,8 @@ eventsApiRedis:
   password: ""
   db: 1
   poolSize: 1000
-defaultToLegacyEvents: true
+defaultToLegacyEvents: false
+forceNewEvents: true
 scheduling:
   preemption:
     # if enabled, Armada will accept submitted jobs which have a priorityClassName field

--- a/config/eventingester/config.yaml
+++ b/config/eventingester/config.yaml
@@ -2,7 +2,7 @@ redis:
   addrs:
     - "localhost:6379"
   password: ""
-  db: 0
+  db: 1
   poolSize: 1000
 
 pulsar:

--- a/e2e/setup/event-ingester-config.yaml
+++ b/e2e/setup/event-ingester-config.yaml
@@ -1,0 +1,13 @@
+redis:
+  addrs:
+    - "redis:6379"
+  password: ""
+  db: 1
+  poolSize: 1000
+
+pulsar:
+  enabled: true
+  URL: "pulsar://pulsar:6650"
+  jobsetEventsTopic: "events"
+
+batchDuration: 100ms

--- a/magefile.go
+++ b/magefile.go
@@ -36,7 +36,7 @@ const KIND_NAME = "armada-test"
 var kubectl func(...string) (string, error) = sh.OutCmd(
 	"kubectl",
 	"--kubeconfig", KIND_CONFIG_EXTERNAL,
-	"--context", "kind-" + KIND_NAME,
+	"--context", "kind-"+KIND_NAME,
 )
 
 // Build images, spin up a test environment, and run the integration tests against it.
@@ -53,7 +53,7 @@ func CiIntegrationTests() error {
 
 	// TODO: Necessary to avoid connection error on Armada server startup.
 	time.Sleep(10 * time.Second)
-	err = sh.Run("docker-compose", "up", "-d", "server", "executor")
+	err = sh.Run("docker-compose", "up", "-d", "server", "executor", "eventingester")
 	if err != nil {
 		return err
 	}
@@ -64,6 +64,7 @@ func CiIntegrationTests() error {
 	}
 	sh.Run("docker", "logs", "server")
 	sh.Run("docker", "logs", "executor")
+	sh.Run("docker", "logs", "eventingester")
 
 	err = sh.Run("go", "run", "cmd/armadactl/main.go", "create", "queue", "e2e-test-queue")
 	if err != nil {

--- a/makefile
+++ b/makefile
@@ -453,6 +453,8 @@ tests-e2e-setup: setup-cluster
 		armada-lookout-ingester --config /e2e/setup/lookout-ingester-config.yaml --migrateDatabase
 	docker run -d --name lookout-ingester  --network=kind -v ${PWD}/e2e:/e2e \
 		armada-lookout-ingester --config /e2e/setup/lookout-ingester-config.yaml
+	docker run -d --name event-ingester  --network=kind -v ${PWD}/e2e:/e2e \
+    		armada-event-ingester --config /e2e/setup/event-ingester-config.yaml
 	docker run -d --name jobservice --network=kind -v ${PWD}/e2e:/e2e \
 	    armada-jobservice run --config /e2e/setup/jobservice.yaml
 


### PR DESCRIPTION
* Armada default config now forces the new event api path (via the event ingester)
* Update e2e tests to have the event ingester up and running

