### PR TITLE
Default preemption Created time to now if not set

### DIFF
--- a/internal/executor/reporter/event.go
+++ b/internal/executor/reporter/event.go
@@ -139,8 +139,12 @@ func CreateJobIngressInfoEvent(pod *v1.Pod, clusterId string, associatedServices
 }
 
 func CreateJobPreemptedEvent(clusterEvent *v1.Event, clusterId string) (event *api.JobPreemptedEvent, err error) {
+	eventTime := clusterEvent.LastTimestamp.Time
+	if eventTime.IsZero() {
+		eventTime = time.Now()
+	}
 	event = &api.JobPreemptedEvent{
-		Created:   clusterEvent.LastTimestamp.Time,
+		Created:   eventTime,
 		ClusterId: clusterId,
 	}
 


### PR DESCRIPTION
This is sometimes not set by kubernetes and it is confusing the timestamp defaults to 1st Jan 00:00:00 on the event

If no timestamp is set, lets just set it to now which will be approximately correct in most cases