### PR TITLE
[Lookout Ingester] Only update jobs that are in non-terminal states

### DIFF
--- a/internal/lookoutingester/lookoutdb/insertion.go
+++ b/internal/lookoutingester/lookoutdb/insertion.go
@@ -699,7 +699,7 @@ func conflateJobUpdates(updates []*model.UpdateJobInstruction) []*model.UpdateJo
 	for _, update := range updates {
 		existing, ok := updatesById[update.JobId]
 
-		// Unfortunately once a job has reached a terminal we still get state updates for it e.g. we can get an event to
+		// Unfortunately once a job has reached a terminal state we still get state updates for it e.g. we can get an event to
 		// say it's now "running".  We have to throw these away else we'll end up with a zombie job.
 		if !ok {
 			updatesById[update.JobId] = update

--- a/internal/lookoutingester/lookoutdb/insertion.go
+++ b/internal/lookoutingester/lookoutdb/insertion.go
@@ -788,7 +788,7 @@ func filterEventsForTerminalJobs(
 
 	rowsRaw, err := withDatabaseRetryQuery(func() (interface{}, error) {
 		terminalStates := []int{repository.JobFailedOrdinal, repository.JobFailedOrdinal, repository.JobCancelledOrdinal}
-		return db.Query(ctx, "SELECT DISTINCT job_id FROM JOB where state = ANY($1) AND job_id = any($2)", terminalStates, jobIds)
+		return db.Query(ctx, "SELECT DISTINCT job_id FROM JOB where state = any($1) AND job_id = any($2)", terminalStates, jobIds)
 	})
 	if err != nil {
 		m.RecordDBError(metrics.DBOperationRead)

--- a/internal/lookoutingester/lookoutdb/insertion.go
+++ b/internal/lookoutingester/lookoutdb/insertion.go
@@ -787,7 +787,7 @@ func filterEventsForTerminalJobs(
 	}
 
 	rowsRaw, err := withDatabaseRetryQuery(func() (interface{}, error) {
-		terminalStates := []int{repository.JobFailedOrdinal, repository.JobFailedOrdinal, repository.JobCancelledOrdinal}
+		terminalStates := []int{repository.JobSucceededOrdinal, repository.JobFailedOrdinal, repository.JobCancelledOrdinal}
 		return db.Query(ctx, "SELECT DISTINCT job_id FROM JOB where state = any($1) AND job_id = any($2)", terminalStates, jobIds)
 	})
 	if err != nil {

--- a/internal/lookoutingester/lookoutdb/insertion.go
+++ b/internal/lookoutingester/lookoutdb/insertion.go
@@ -113,7 +113,7 @@ func (l *LookoutDb) UpdateJobs(ctx context.Context, instructions []*model.Update
 	if len(instructions) == 0 {
 		return
 	}
-	instructions = filterEventsForCancelledJobs(ctx, l.db, instructions, l.metrics)
+	instructions = filterEventsForTerminalJobs(ctx, l.db, instructions, l.metrics)
 
 	if l.config.Debug.DisableConflateDBUpdates {
 		l.UpdateJobsScalar(ctx, instructions)
@@ -687,11 +687,11 @@ func batchInsert(ctx context.Context, db *pgxpool.Pool, createTmp func(pgx.Tx) e
 }
 
 func conflateJobUpdates(updates []*model.UpdateJobInstruction) []*model.UpdateJobInstruction {
-	deref := func(p *int32) int32 {
+	isTerminal := func(p *int32) bool {
 		if p == nil {
-			return -1
+			return false
 		} else {
-			return *p
+			return *p == repository.JobFailedOrdinal || *p == repository.JobSucceededOrdinal || *p == repository.JobCancelledOrdinal
 		}
 	}
 
@@ -699,11 +699,11 @@ func conflateJobUpdates(updates []*model.UpdateJobInstruction) []*model.UpdateJo
 	for _, update := range updates {
 		existing, ok := updatesById[update.JobId]
 
-		// Unfortunately once a job has been cancelled we still get state updates for it e.g. we can get an event to
-		// say it's now "running".  We have to throw these away as cancelled is a terminal state.
+		// Unfortunately once a job has reached a terminal we still get state updates for it e.g. we can get an event to
+		// say it's now "running".  We have to throw these away else we'll end up with a zombie job.
 		if !ok {
 			updatesById[update.JobId] = update
-		} else if deref(existing.State) != int32(repository.JobCancelledOrdinal) {
+		} else if !isTerminal(existing.State) {
 			if update.State != nil {
 				existing.State = update.State
 			}
@@ -768,14 +768,14 @@ func conflateJobRunUpdates(updates []*model.UpdateJobRunInstruction) []*model.Up
 	return conflated
 }
 
-// filterEventsForCancelledJobs queries the database for any jobs that are in the cancelled state and removes them from the list of
-// instructions.  This is necessary because Armada will generate event stauses even for jobs that have been cancelled
-// The proper solution here is to make it so once a job is cancelled, no more events are generated for it, but until
+// filterEventsForTerminalJobs queries the database for any jobs that are in a terminal state and removes them from the list of
+// instructions.  This is necessary because Armada will generate event statuses even for jobs that have reached a terminal state
+// The proper solution here is to make it so once a job is terminal, no more events are generated for it, but until
 // that day we have to manually filter them out here.
 // NOTE: this function will retry querying the database for as long as possible in order to determine which jobs are
-// in the cancelling state.  If, however, the database returns a non-retryable error it will give up and simply not
+// in the terminal state.  If, however, the database returns a non-retryable error it will give up and simply not
 // filter out any events as the job state is undetermined.
-func filterEventsForCancelledJobs(
+func filterEventsForTerminalJobs(
 	ctx context.Context,
 	db *pgxpool.Pool,
 	instructions []*model.UpdateJobInstruction,
@@ -787,11 +787,12 @@ func filterEventsForCancelledJobs(
 	}
 
 	rowsRaw, err := withDatabaseRetryQuery(func() (interface{}, error) {
-		return db.Query(ctx, "SELECT DISTINCT job_id FROM JOB where state = $1 AND job_id = any($2)", repository.JobCancelledOrdinal, jobIds)
+		terminalStates := []int{repository.JobFailedOrdinal, repository.JobFailedOrdinal, repository.JobCancelledOrdinal}
+		return db.Query(ctx, "SELECT DISTINCT job_id FROM JOB where state = ANY($1) AND job_id = any($2)", terminalStates, jobIds)
 	})
 	if err != nil {
 		m.RecordDBError(metrics.DBOperationRead)
-		log.WithError(err).Warnf("Cannot retrieve job state from the database- Cancelled jobs may not be filtered out")
+		log.WithError(err).Warnf("Cannot retrieve job state from the database- Terminal jobs may not be filtered out")
 		return instructions
 	}
 	rows := rowsRaw.(pgx.Rows)
@@ -801,7 +802,7 @@ func filterEventsForCancelledJobs(
 		jobId := ""
 		err := rows.Scan(&jobId)
 		if err != nil {
-			log.WithError(err).Warnf("Cannot retrieve jobId from row. Cancelled job will not be filtered out")
+			log.WithError(err).Warnf("Cannot retrieve jobId from row. Terminal job will not be filtered out")
 		} else {
 			cancelledJobs[jobId] = true
 		}

--- a/internal/lookoutingester/lookoutdb/insertion_test.go
+++ b/internal/lookoutingester/lookoutdb/insertion_test.go
@@ -311,16 +311,17 @@ func TestUpdateJobsScalar(t *testing.T) {
 
 func TestUpdateJobsWithTerminal(t *testing.T) {
 	err := testutil.WithDatabasePgx(func(db *pgxpool.Pool) error {
-		initial := []*model.CreateJobInstruction{{
-			JobId:     jobIdString,
-			Queue:     queue,
-			Owner:     userId,
-			JobSet:    jobSetName,
-			Priority:  priority,
-			Submitted: baseTime,
-			State:     repository.JobQueuedOrdinal,
-			JobProto:  []byte(jobProto),
-		},
+		initial := []*model.CreateJobInstruction{
+			{
+				JobId:     jobIdString,
+				Queue:     queue,
+				Owner:     userId,
+				JobSet:    jobSetName,
+				Priority:  priority,
+				Submitted: baseTime,
+				State:     repository.JobQueuedOrdinal,
+				JobProto:  []byte(jobProto),
+			},
 			{
 				JobId:     "job2",
 				Queue:     queue,
@@ -340,13 +341,15 @@ func TestUpdateJobsWithTerminal(t *testing.T) {
 				Submitted: baseTime,
 				State:     repository.JobQueuedOrdinal,
 				JobProto:  []byte(jobProto),
-			}}
+			},
+		}
 
-		update1 := []*model.UpdateJobInstruction{{
-			JobId:     jobIdString,
-			State:     pointer.Int32(repository.JobCancelledOrdinal),
-			Cancelled: &baseTime,
-		},
+		update1 := []*model.UpdateJobInstruction{
+			{
+				JobId:     jobIdString,
+				State:     pointer.Int32(repository.JobCancelledOrdinal),
+				Cancelled: &baseTime,
+			},
 			{
 				JobId:     "job2",
 				State:     pointer.Int32(repository.JobSucceededOrdinal),

--- a/internal/lookoutingester/lookoutdb/insertion_test.go
+++ b/internal/lookoutingester/lookoutdb/insertion_test.go
@@ -307,7 +307,7 @@ func TestUpdateJobsScalar(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestUpdateJobsWithCancelled(t *testing.T) {
+func TestUpdateJobsWithTerminal(t *testing.T) {
 	err := testutil.WithDatabasePgx(func(db *pgxpool.Pool) error {
 		initial := []*model.CreateJobInstruction{{
 			JobId:     jobIdString,
@@ -645,7 +645,7 @@ func TestConflateJobUpdates(T *testing.T) {
 	assert.Equal(T, expected, updates)
 }
 
-func TestConflateJobUpdatesWithCancelled(T *testing.T) {
+func TestConflateJobUpdatesWithTerminal(T *testing.T) {
 	// Updates after the cancelled shouldn't be processed
 	updates := conflateJobUpdates([]*model.UpdateJobInstruction{
 		{JobId: jobIdString, State: pointer.Int32(repository.JobCancelledOrdinal)},

--- a/internal/lookoutingesterv2/lookoutdb/insertion.go
+++ b/internal/lookoutingesterv2/lookoutdb/insertion.go
@@ -714,8 +714,8 @@ func conflateJobUpdates(updates []*model.UpdateJobInstruction) []*model.UpdateJo
 	for _, update := range updates {
 		existing, ok := updatesById[update.JobId]
 
-		// Unfortunately once a job has been cancelled we still get state updates for it e.g. we can get an event to
-		// say it's now "running".  We have to throw these away as cancelled is a terminal state.
+		// Unfortunately once a job has reached a terminal state we still get state updates for it e.g. we can get an event to
+		// say it's now "running".  We have to throw these away else we'll end up with a zombie job.
 		if !ok {
 			updatesById[update.JobId] = update
 		} else if !isTerminal(existing.State) {

--- a/internal/lookoutingesterv2/lookoutdb/insertion.go
+++ b/internal/lookoutingesterv2/lookoutdb/insertion.go
@@ -701,7 +701,6 @@ func batchInsert(ctx context.Context, db *pgxpool.Pool, createTmp func(pgx.Tx) e
 }
 
 func conflateJobUpdates(updates []*model.UpdateJobInstruction) []*model.UpdateJobInstruction {
-
 	isTerminal := func(p *int32) bool {
 		if p == nil {
 			return false

--- a/internal/lookoutingesterv2/lookoutdb/insertion.go
+++ b/internal/lookoutingesterv2/lookoutdb/insertion.go
@@ -807,7 +807,7 @@ func (l *LookoutDb) filterEventsForTerminalJobs(
 	}
 
 	rowsRaw, err := l.withDatabaseRetryQuery(func() (interface{}, error) {
-		terminalStates := []int{repository.JobFailedOrdinal, repository.JobFailedOrdinal, repository.JobCancelledOrdinal}
+		terminalStates := []int{repository.JobSucceededOrdinal, repository.JobFailedOrdinal, repository.JobCancelledOrdinal}
 		return db.Query(ctx, "SELECT DISTINCT job_id FROM JOB where state = any($1) AND job_id = any($2)", terminalStates, jobIds)
 	})
 	if err != nil {

--- a/internal/lookoutingesterv2/lookoutdb/insertion.go
+++ b/internal/lookoutingesterv2/lookoutdb/insertion.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/G-Research/armada/internal/lookout/repository"
+
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/pkg/errors"
@@ -13,7 +15,6 @@ import (
 
 	"github.com/G-Research/armada/internal/common/armadaerrors"
 	"github.com/G-Research/armada/internal/common/database"
-	"github.com/G-Research/armada/internal/common/database/lookout"
 	"github.com/G-Research/armada/internal/common/ingest/metrics"
 	"github.com/G-Research/armada/internal/lookoutingesterv2/model"
 )
@@ -83,7 +84,7 @@ func (l *LookoutDb) UpdateJobs(ctx context.Context, instructions []*model.Update
 	if len(instructions) == 0 {
 		return
 	}
-	instructions = l.filterEventsForCancelledJobs(ctx, l.db, instructions, l.metrics)
+	instructions = l.filterEventsForTerminalJobs(ctx, l.db, instructions, l.metrics)
 	err := l.UpdateJobsBatch(ctx, instructions)
 	if err != nil {
 		log.WithError(err).Warn("Updating jobs via batch failed, will attempt to insert serially (this might be slow).")
@@ -700,11 +701,12 @@ func batchInsert(ctx context.Context, db *pgxpool.Pool, createTmp func(pgx.Tx) e
 }
 
 func conflateJobUpdates(updates []*model.UpdateJobInstruction) []*model.UpdateJobInstruction {
-	deref := func(p *int32) int32 {
+
+	isTerminal := func(p *int32) bool {
 		if p == nil {
-			return -1
+			return false
 		} else {
-			return *p
+			return *p == repository.JobFailedOrdinal || *p == repository.JobSucceededOrdinal || *p == repository.JobCancelledOrdinal
 		}
 	}
 
@@ -716,7 +718,7 @@ func conflateJobUpdates(updates []*model.UpdateJobInstruction) []*model.UpdateJo
 		// say it's now "running".  We have to throw these away as cancelled is a terminal state.
 		if !ok {
 			updatesById[update.JobId] = update
-		} else if deref(existing.State) != int32(lookout.JobCancelledOrdinal) {
+		} else if !isTerminal(existing.State) {
 			if update.Priority != nil {
 				existing.Priority = update.Priority
 			}
@@ -786,14 +788,14 @@ func conflateJobRunUpdates(updates []*model.UpdateJobRunInstruction) []*model.Up
 	return conflated
 }
 
-// filterEventsForCancelledJobs queries the database for any jobs that are in the cancelled state and removes them from the list of
-// instructions. This is necessary because Armada will generate event stauses even for jobs that have been cancelled
-// The proper solution here is to make it so once a job is cancelled, no more events are generated for it, but until
+// filterEventsForTerminalJobs queries the database for any jobs that are in a terminal state and removes them from the list of
+// instructions.  This is necessary because Armada will generate event statuses even for jobs that have reached a terminal state
+// The proper solution here is to make it so once a job is terminal, no more events are generated for it, but until
 // that day we have to manually filter them out here.
 // NOTE: this function will retry querying the database for as long as possible in order to determine which jobs are
-// in the cancelling state. If, however, the database returns a non-retryable error it will give up and simply not
+// in the terminal state.  If, however, the database returns a non-retryable error it will give up and simply not
 // filter out any events as the job state is undetermined.
-func (l *LookoutDb) filterEventsForCancelledJobs(
+func (l *LookoutDb) filterEventsForTerminalJobs(
 	ctx context.Context,
 	db *pgxpool.Pool,
 	instructions []*model.UpdateJobInstruction,
@@ -805,7 +807,8 @@ func (l *LookoutDb) filterEventsForCancelledJobs(
 	}
 
 	rowsRaw, err := l.withDatabaseRetryQuery(func() (interface{}, error) {
-		return db.Query(ctx, "SELECT DISTINCT job_id FROM JOB where state = $1 AND job_id = any($2)", lookout.JobCancelledOrdinal, jobIds)
+		terminalStates := []int{repository.JobFailedOrdinal, repository.JobFailedOrdinal, repository.JobCancelledOrdinal}
+		return db.Query(ctx, "SELECT DISTINCT job_id FROM JOB where state = any($1) AND job_id = any($2)", terminalStates, jobIds)
 	})
 	if err != nil {
 		m.RecordDBError(metrics.DBOperationRead)

--- a/internal/lookoutingesterv2/lookoutdb/insertion_test.go
+++ b/internal/lookoutingesterv2/lookoutdb/insertion_test.go
@@ -309,7 +309,7 @@ func TestUpdateJobsScalar(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestUpdateJobsWithCancelled(t *testing.T) {
+func TestUpdateJobsWithTerminal(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
 		initial := []*model.CreateJobInstruction{{
 			JobId:                     jobIdString,
@@ -655,7 +655,7 @@ func TestConflateJobUpdates(t *testing.T) {
 	assert.Equal(t, expected, updates)
 }
 
-func TestConflateJobUpdatesWithCancelled(t *testing.T) {
+func TestConflateJobUpdatesWithTerminal(t *testing.T) {
 	// Updates after the cancelled shouldn't be processed
 	updates := conflateJobUpdates([]*model.UpdateJobInstruction{
 		{JobId: jobIdString, State: pointer.Int32(lookout.JobCancelledOrdinal)},

--- a/internal/lookoutingesterv2/lookoutdb/insertion_test.go
+++ b/internal/lookoutingesterv2/lookoutdb/insertion_test.go
@@ -311,34 +311,97 @@ func TestUpdateJobsScalar(t *testing.T) {
 
 func TestUpdateJobsWithTerminal(t *testing.T) {
 	err := lookout.WithLookoutDb(func(db *pgxpool.Pool) error {
-		initial := []*model.CreateJobInstruction{{
-			JobId:                     jobIdString,
-			Queue:                     queue,
-			Owner:                     userId,
-			JobSet:                    jobSetName,
-			Cpu:                       cpu,
-			Memory:                    memory,
-			EphemeralStorage:          ephemeralStorage,
-			Gpu:                       gpu,
-			Priority:                  priority,
-			Submitted:                 baseTime,
-			State:                     lookout.JobQueuedOrdinal,
-			LastTransitionTime:        baseTime,
-			LastTransitionTimeSeconds: baseTime.Unix(),
-			JobProto:                  []byte(jobProto),
-			PriorityClass:             pointer.String(priorityClass),
-		}}
+		initial := []*model.CreateJobInstruction{
+			{
+				JobId:                     jobIdString,
+				Queue:                     queue,
+				Owner:                     userId,
+				JobSet:                    jobSetName,
+				Cpu:                       cpu,
+				Memory:                    memory,
+				EphemeralStorage:          ephemeralStorage,
+				Gpu:                       gpu,
+				Priority:                  priority,
+				Submitted:                 baseTime,
+				State:                     lookout.JobQueuedOrdinal,
+				LastTransitionTime:        baseTime,
+				LastTransitionTimeSeconds: baseTime.Unix(),
+				JobProto:                  []byte(jobProto),
+				PriorityClass:             pointer.String(priorityClass),
+			},
+			{
+				JobId:                     "job2",
+				Queue:                     queue,
+				Owner:                     userId,
+				JobSet:                    jobSetName,
+				Cpu:                       cpu,
+				Memory:                    memory,
+				EphemeralStorage:          ephemeralStorage,
+				Gpu:                       gpu,
+				Priority:                  priority,
+				Submitted:                 baseTime,
+				State:                     lookout.JobQueuedOrdinal,
+				LastTransitionTime:        baseTime,
+				LastTransitionTimeSeconds: baseTime.Unix(),
+				JobProto:                  []byte(jobProto),
+				PriorityClass:             pointer.String(priorityClass),
+			},
+			{
+				JobId:                     "job3",
+				Queue:                     queue,
+				Owner:                     userId,
+				JobSet:                    jobSetName,
+				Cpu:                       cpu,
+				Memory:                    memory,
+				EphemeralStorage:          ephemeralStorage,
+				Gpu:                       gpu,
+				Priority:                  priority,
+				Submitted:                 baseTime,
+				State:                     lookout.JobQueuedOrdinal,
+				LastTransitionTime:        baseTime,
+				LastTransitionTimeSeconds: baseTime.Unix(),
+				JobProto:                  []byte(jobProto),
+				PriorityClass:             pointer.String(priorityClass),
+			}}
 
-		update1 := []*model.UpdateJobInstruction{{
-			JobId:                     jobIdString,
-			State:                     pointer.Int32(lookout.JobCancelledOrdinal),
-			Cancelled:                 &baseTime,
-			LastTransitionTime:        &baseTime,
-			LastTransitionTimeSeconds: pointer.Int64(baseTime.Unix()),
-		}}
+		update1 := []*model.UpdateJobInstruction{
+			{
+				JobId:                     jobIdString,
+				State:                     pointer.Int32(lookout.JobCancelledOrdinal),
+				Cancelled:                 &baseTime,
+				LastTransitionTime:        &baseTime,
+				LastTransitionTimeSeconds: pointer.Int64(baseTime.Unix()),
+			},
+			{
+				JobId:                     "job2",
+				State:                     pointer.Int32(lookout.JobSucceededOrdinal),
+				Cancelled:                 &baseTime,
+				LastTransitionTime:        &baseTime,
+				LastTransitionTimeSeconds: pointer.Int64(baseTime.Unix()),
+			},
+			{
+				JobId:                     "job3",
+				State:                     pointer.Int32(lookout.JobFailedOrdinal),
+				Cancelled:                 &baseTime,
+				LastTransitionTime:        &baseTime,
+				LastTransitionTimeSeconds: pointer.Int64(baseTime.Unix()),
+			},
+		}
 
 		update2 := []*model.UpdateJobInstruction{{
 			JobId:                     jobIdString,
+			State:                     pointer.Int32(lookout.JobRunningOrdinal),
+			LastTransitionTime:        &baseTime,
+			LastTransitionTimeSeconds: pointer.Int64(baseTime.Unix()),
+			LatestRunId:               pointer.String(runIdString),
+		}, {
+			JobId:                     "job2",
+			State:                     pointer.Int32(lookout.JobRunningOrdinal),
+			LastTransitionTime:        &baseTime,
+			LastTransitionTimeSeconds: pointer.Int64(baseTime.Unix()),
+			LatestRunId:               pointer.String(runIdString),
+		}, {
+			JobId:                     "job3",
 			State:                     pointer.Int32(lookout.JobRunningOrdinal),
 			LastTransitionTime:        &baseTime,
 			LastTransitionTimeSeconds: pointer.Int64(baseTime.Unix()),
@@ -350,15 +413,21 @@ func TestUpdateJobsWithTerminal(t *testing.T) {
 		// Insert
 		ldb.CreateJobs(ctx.Background(), initial)
 
-		// Cancel the job
+		// Mark the jobs terminal
 		ldb.UpdateJobs(ctx.Background(), update1)
 
-		// Update the job - this should be discarded
+		// Update the jobs - these should be discarded
 		ldb.UpdateJobs(ctx.Background(), update2)
 
-		// Assert the state is still cancelled
+		// Assert the states are still terminal
 		job := getJob(t, db, jobIdString)
 		assert.Equal(t, lookout.JobCancelledOrdinal, int(job.State))
+
+		job2 := getJob(t, db, "job2")
+		assert.Equal(t, lookout.JobSucceededOrdinal, int(job2.State))
+
+		job3 := getJob(t, db, "job3")
+		assert.Equal(t, lookout.JobFailedOrdinal, int(job3.State))
 
 		return nil
 	})
@@ -660,11 +729,25 @@ func TestConflateJobUpdatesWithTerminal(t *testing.T) {
 	updates := conflateJobUpdates([]*model.UpdateJobInstruction{
 		{JobId: jobIdString, State: pointer.Int32(lookout.JobCancelledOrdinal)},
 		{JobId: jobIdString, State: pointer.Int32(lookout.JobRunningOrdinal)},
+		{JobId: "someSucceededJob", State: pointer.Int32(lookout.JobSucceededOrdinal)},
+		{JobId: "someSucceededJob", State: pointer.Int32(lookout.JobRunningOrdinal)},
+		{JobId: "someFailedJob", State: pointer.Int32(lookout.JobFailedOrdinal)},
+		{JobId: "someFailedJob", State: pointer.Int32(lookout.JobRunningOrdinal)},
 	})
 
 	expected := []*model.UpdateJobInstruction{
 		{JobId: jobIdString, State: pointer.Int32(lookout.JobCancelledOrdinal)},
+		{JobId: "someSucceededJob", State: pointer.Int32(lookout.JobSucceededOrdinal)},
+		{JobId: "someFailedJob", State: pointer.Int32(lookout.JobFailedOrdinal)},
 	}
+
+	sort.Slice(updates, func(i, j int) bool {
+		return updates[i].JobId < updates[j].JobId
+	})
+
+	sort.Slice(expected, func(i, j int) bool {
+		return expected[i].JobId < expected[j].JobId
+	})
 	assert.Equal(t, expected, updates)
 }
 

--- a/internal/lookoutingesterv2/lookoutdb/insertion_test.go
+++ b/internal/lookoutingesterv2/lookoutdb/insertion_test.go
@@ -362,7 +362,8 @@ func TestUpdateJobsWithTerminal(t *testing.T) {
 				LastTransitionTimeSeconds: baseTime.Unix(),
 				JobProto:                  []byte(jobProto),
 				PriorityClass:             pointer.String(priorityClass),
-			}}
+			},
+		}
 
 		update1 := []*model.UpdateJobInstruction{
 			{


### PR DESCRIPTION
Previously in both LookoutIngester and LookoutIngesterV2 we used to discard events if the job was in a `Cancelled` state because the executor could continue to send updates in this case.

This PR extends this so to all terminal states (i.e. `Cancelled`, `Failed`, `Succeeded`). This is because it appears that there are further edge cases that can cause the executors to send updates in these cases.  Hopefully we can fix the executor at some point, but for now this should prevent lookout[V2] getting zombie jobs.