### PR TITLE
Lookout V2 add debug logging to queries and optimise queries with COUNT

### DIFF
--- a/internal/lookoutv2/repository/common.go
+++ b/internal/lookoutv2/repository/common.go
@@ -112,11 +112,16 @@ func (qb *QueryBuilder) JobCount(filters []*model.Filter) (*Query, error) {
 		return nil, err
 	}
 
+	countExpr := fmt.Sprintf("COUNT(DISTINCT %s.job_id)", abbrev)
+	// If we are only fetching from jobs, no need to count distinct, as it is a big performance hit
+	if _, ok := queryTables[jobTable]; ok && len(queryTables) == 1 && len(annotationFilters) == 0 {
+		countExpr = "COUNT(*)"
+	}
 	template := fmt.Sprintf(`
-		SELECT COUNT(DISTINCT %s.job_id)
+		SELECT %s
 		%s
 		%s`,
-		abbrev, fromSql, whereSql)
+		countExpr, fromSql, whereSql)
 	templated, args := templateSql(template, qb.queryValues)
 	return &Query{
 		Sql:  templated,
@@ -289,13 +294,13 @@ func (qb *QueryBuilder) GroupBy(
 		orderSql = fmt.Sprintf("ORDER BY %s %s", order.Field, order.Direction)
 	}
 	template := fmt.Sprintf(`
-		SELECT %[1]s.%[2]s, COUNT(DISTINCT %[1]s.%[3]s) AS %[4]s
+		SELECT %[1]s.%[2]s, COUNT(*) AS %[3]s
+		%[4]s
 		%[5]s
 		%[6]s
 		%[7]s
-		%[8]s
-		%[9]s`,
-		groupCol.abbrev, groupCol.name, jobIdCol, countCol, fromSql, whereSql, groupBySql, orderSql, limitOffsetSql(skip, take))
+		%[8]s`,
+		groupCol.abbrev, groupCol.name, countCol, fromSql, whereSql, groupBySql, orderSql, limitOffsetSql(skip, take))
 	templated, args := templateSql(template, qb.queryValues)
 	return &Query{
 		Sql:  templated,

--- a/internal/lookoutv2/repository/common_test.go
+++ b/internal/lookoutv2/repository/common_test.go
@@ -132,7 +132,7 @@ func TestQueryBuilder_CreateTempTable(t *testing.T) {
 func TestQueryBuilder_JobCountEmpty(t *testing.T) {
 	query, err := NewQueryBuilder(NewTables()).JobCount([]*model.Filter{})
 	assert.NoError(t, err)
-	assert.Equal(t, splitByWhitespace("SELECT COUNT(DISTINCT j.job_id) FROM job AS j"),
+	assert.Equal(t, splitByWhitespace("SELECT COUNT(*) FROM job AS j"),
 		splitByWhitespace(query.Sql))
 	assert.Equal(t, []interface{}(nil), query.Args)
 }
@@ -258,7 +258,7 @@ func TestQueryBuilder_GroupByEmpty(t *testing.T) {
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, splitByWhitespace(`
-			SELECT j.jobset, COUNT(DISTINCT j.job_id) AS count
+			SELECT j.jobset, COUNT(*) AS count
 			FROM job AS j
 			GROUP BY j.jobset
 			LIMIT 10 OFFSET 0
@@ -280,7 +280,7 @@ func TestQueryBuilder_GroupBy(t *testing.T) {
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, splitByWhitespace(`
-			SELECT j.jobset, COUNT(DISTINCT j.job_id) AS count
+			SELECT j.jobset, COUNT(*) AS count
 			FROM job AS j
 			INNER JOIN (
 				SELECT job_id

--- a/internal/lookoutv2/repository/getjobs.go
+++ b/internal/lookoutv2/repository/getjobs.go
@@ -90,6 +90,7 @@ func (r *SqlGetJobsRepository) GetJobs(ctx context.Context, filters []*model.Fil
 		if err != nil {
 			return err
 		}
+		logQuery(countQuery)
 		rows, err := tx.Query(ctx, countQuery.Sql, countQuery.Args...)
 		if err != nil {
 			return err
@@ -100,6 +101,7 @@ func (r *SqlGetJobsRepository) GetJobs(ctx context.Context, filters []*model.Fil
 		}
 
 		createTempTableQuery, tempTableName := NewQueryBuilder(r.lookoutTables).CreateTempTable()
+		logQuery(createTempTableQuery)
 		_, err = tx.Exec(ctx, createTempTableQuery.Sql, createTempTableQuery.Args...)
 		if err != nil {
 			return err
@@ -109,6 +111,7 @@ func (r *SqlGetJobsRepository) GetJobs(ctx context.Context, filters []*model.Fil
 		if err != nil {
 			return err
 		}
+		logQuery(createTempTableQuery)
 		_, err = tx.Exec(ctx, insertQuery.Sql, insertQuery.Args...)
 		if err != nil {
 			return err

--- a/internal/lookoutv2/repository/groupjobs.go
+++ b/internal/lookoutv2/repository/groupjobs.go
@@ -63,6 +63,7 @@ func (r *SqlGroupJobsRepository) GroupBy(
 		if err != nil {
 			return err
 		}
+		logQuery(countQuery)
 		rows, err := tx.Query(ctx, countQuery.Sql, countQuery.Args...)
 		if err != nil {
 			return err
@@ -75,6 +76,7 @@ func (r *SqlGroupJobsRepository) GroupBy(
 		if err != nil {
 			return err
 		}
+		logQuery(groupByQuery)
 		groupRows, err := tx.Query(ctx, groupByQuery.Sql, groupByQuery.Args...)
 		if err != nil {
 			return err

--- a/internal/lookoutv2/repository/util.go
+++ b/internal/lookoutv2/repository/util.go
@@ -618,5 +618,5 @@ func prefixAnnotations(prefix string, annotations map[string]string) map[string]
 
 func logQuery(query *Query) {
 	log.Debug(query.Sql)
-	log.Debug("%v", query.Args)
+	log.Debugf("%v", query.Args)
 }

--- a/internal/lookoutv2/repository/util.go
+++ b/internal/lookoutv2/repository/util.go
@@ -615,3 +615,8 @@ func prefixAnnotations(prefix string, annotations map[string]string) map[string]
 	}
 	return prefixed
 }
+
+func logQuery(query *Query) {
+	log.Debug(query.Sql)
+	log.Debug("%v", query.Args)
+}


### PR DESCRIPTION
* Add logging to help debug slow queries
* Identified that using `COUNT(DISTINCT ...)` is very slow, substituting where possible with `COUNT(*)` which is much faster

