### PR TITLE
Remove Yarn from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,14 +11,6 @@ updates:
     schedule:
       interval: "monthly"
 
-  # Enable version updates for yarn
-  - package-ecosystem: "yarn"
-    # Look for `package.json` and `lock` files in the `internal/lookout` directory
-    directory: "./internal/lookout"
-    # Check the yarn registry for updates monthly
-    schedule:
-      interval: "monthly"
-
   # Maintain dependencies for Golang
   - package-ecosystem: "gomod"
     directory: "/"


### PR DESCRIPTION
This is causing the depandabot check to fail with:

```
The property '#/updates/1/package-ecosystem' value "yarn" did not match one of the following values: npm, bundler, composer, maven, mix, cargo, gradle, nuget, gomod, docker, elm, gitsubmodule, github-actions, pip, terraform, pub
```
